### PR TITLE
Add macOS specific dependencies to requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,3 +11,6 @@ PyYAML>=3.13
 pytest>=3.9.2
 pytest-runner>=4.2
 pytest-cov>=2.5.1
+# macos reqs
+pyobjc>=5.2; sys_platform == 'darwin'
+pyobjc-framework-CoreBluetooth>=5.2; sys_platform == 'darwin'


### PR DESCRIPTION
Using latest versions of libraries, presume this is OK.

See https://stackoverflow.com/a/35614580 for how this is done. Could do the same for Linux or Windows as well.

Tested this change on Linux, has no effect as expected:
```
$ pip install -r requirements_dev.txt
Ignoring pyobjc: markers 'sys_platform == "darwin"' don't match your environment
Ignoring pyobjc-framework-CoreBluetooth: markers 'sys_platform == "darwin"' don't match your environment
[snipped]
```