### PR TITLE
Add a disconnect callback for BlueZ

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -537,6 +537,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 the new data on the GATT Characteristic.
 
         """
+
+        logger.debug('DBUS: path: {}, domain: {}, body: {}'
+                     .format(message.path,
+                             message.body[0],
+                             message.body[1]))
+
         if message.body[0] == defs.GATT_CHARACTERISTIC_INTERFACE:
             if message.path in self._notification_callbacks:
                 logger.info(

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -40,6 +40,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
         self._bus = None
         self._rules = {}
 
+        self.disconnect_callback = None
+
         self._char_path_to_uuid = {}
 
         # We need to know BlueZ version since battery level characteristic
@@ -50,6 +52,20 @@ class BleakClientBlueZDBus(BaseBleakClient):
         self._bluez_version = tuple(map(int, s.groups()))
 
     # Connectivity methods
+
+    def set_disconnect_callback(
+            self, callback: Callable[[BaseBleakClient], None], **kwargs
+    ) -> None:
+        """Set the disconnect callback.
+        The callback will be called on DBus PropChanged event with
+        the 'Connected' key set to False.
+
+        Args:
+            callback: callback to be called on disconnection.
+
+        """
+
+        self.disconnect_callback = callback
 
     async def connect(self, **kwargs) -> bool:
         """Connect to the specified GATT server.
@@ -531,7 +547,17 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 self._notification_callbacks[message.path](
                     message.path, message.body[1]
                 )
-
+        elif message.body[0] == defs.DEVICE_INTERFACE:
+            device_path = '/org/bluez/%s/dev_%s' % (self.device,
+                                        self.address.replace(':', '_'))
+            if message.path == device_path:
+                message_body_map = message.body[1]
+                if 'Connected' in message_body_map and \
+                   not message_body_map['Connected']:
+                    logger.debug("Device {} disconnected."
+                                 .format(self.address))
+                    if self.disconnect_callback is not None:
+                        self.disconnect_callback(self)
 
 def _data_notification_wrapper(func, char_map):
     @wraps(func)

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -47,6 +47,20 @@ class BaseBleakClient(abc.ABC):
     # Connectivity methods
 
     @abc.abstractmethod
+    async def set_disconnect_callback(
+            self, callback: Callable[['BaseBleakClient'], None], **kwargs
+    ) -> None:
+        """Set the disconnect callback.
+        The callback will only be called on unsolicited disconnect event.
+
+        Args:
+            callback: callback to be called on disconnection.
+
+        """
+
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     async def connect(self, **kwargs) -> bool:
         """Connect to the specified GATT server.
 


### PR DESCRIPTION
This tries to fix issue #82 for BlueZ implementation only.
Other implementations (Core Bluetooth and .NET) will fail with a
NotImplementedError exception.

The disconnect event is found in the DBus _PropChanged_:
> path: /org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX, domain: org.bluez.Device1, body: {'ServicesResolved': False, 'Connected': False}

The callback will be called only on unsolicited disconnect event from
peer. An initiated disconnect from the host will not call it.
    

