### PR TITLE
Register a disconnected callback and clean up subscriptions on disconnect

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -134,6 +134,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
         )
         return True
 
+    async def _cleanup(self) -> None:
+        for rule_name, rule_id in self._rules.items():
+            logger.debug("Removing rule {0}, ID: {1}".format(rule_name, rule_id))
+            await self._bus.delMatch(rule_id).asFuture(self.loop)
+
     async def disconnect(self) -> bool:
         """Disconnect from the specified GATT server.
 
@@ -142,9 +147,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         """
         logger.debug("Disconnecting from BLE device...")
-        for rule_name, rule_id in self._rules.items():
-            logger.debug("Removing rule {0}, ID: {1}".format(rule_name, rule_id))
-            await self._bus.delMatch(rule_id).asFuture(self.loop)
+
+        await self._cleanup()
+
         await self._bus.callRemote(
             self._device_path,
             "Disconnect",

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -537,6 +537,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 the new data on the GATT Characteristic.
 
         """
+
+        logger.debug('DBUS: path: {}, domain: {}, body: {}'
+                     .format(message.path,
+                             message.body[0],
+                             message.body[1]))
+
         if message.body[0] == defs.GATT_CHARACTERISTIC_INTERFACE:
             if message.path in self._notification_callbacks:
                 logger.info(

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -47,6 +47,30 @@ class BaseBleakClient(abc.ABC):
     # Connectivity methods
 
     @abc.abstractmethod
+    async def set_disconnected_callback(
+            self, callback: Callable[['BaseBleakClient'], None], **kwargs
+    ) -> None:
+        """Set the disconnect callback.
+        The callback will only be called on unsolicited disconnect event.
+
+        Callbacks must accept one input which is the client object itself.
+
+        .. code-block:: python
+
+            def callback(client):
+                print("Client with address {} got disconnected!".format(client.address))
+
+            client.set_disconnected_callback(callback)
+            client.connect()
+
+        Args:
+            callback: callback to be called on disconnection.
+
+        """
+
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     async def connect(self, **kwargs) -> bool:
         """Connect to the specified GATT server.
 


### PR DESCRIPTION
This patch contains two changes:
* Add API and Bluez implementation to set a callback fired when a device disconnects without active intervention from the client
* Remove all existing subscriptions to characteristic notifications when a device disconnects

Replaces #85 
Fixes #83 
Closes #82