### PR TITLE
Prevent leaking of DBus connections on discovery

### DIFF
--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -199,4 +199,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
         manufacturer_data = props.get('ManufacturerData', {})
         discovered_devices.append(BLEDevice(address, name, {"path": path, "props": props}, uuids=uuids,
                                   manufacturer_data=manufacturer_data))
+
+    bus.disconnect()
+
     return discovered_devices


### PR DESCRIPTION
During a call to discover() on the Bluez backend, a DBus connection is
opened, but never closed. If discover() is called multiple times while
the application is running, DBus at some point prevents opening
additional connections.

Make sure the bus connection is closed after discovery.

Fixes #91 