### PR TITLE
Use raw literals for regex patterns

### DIFF
--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -7,7 +7,7 @@ from bleak.backends.bluezdbus import defs
 from bleak.exc import BleakError
 
 _mac_address_regex = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
-_hci_device_regex = re.compile("^hci(\d+)$")
+_hci_device_regex = re.compile("^hci(\\d+)$")
 
 
 def validate_mac_address(address):


### PR DESCRIPTION
Should fix this Python 3 related warning:
```
 src/bleak/bleak/backends/bluezdbus/utils.py:10: DeprecationWarning: invalid escape sequence \d
    _hci_device_regex = re.compile("^hci(\d+)$")
```