### PR TITLE
Fix macOS BLEDevice.metatadata values

### DIFF
--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -161,7 +161,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             (bytearray) The read data.
 
         """
-        _uuid = await self.get_appropriate_uuid(_uuid)
+        _uuid = await self.get_appropriate_uuid(str(_uuid))
         characteristic = self.services.get_characteristic(_uuid)
         if not characteristic:
             raise BleakError("Characteristic {} was not found!".format(_uuid))
@@ -213,7 +213,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             response (bool): If write-with-response operation should be done. Defaults to `False`.
 
         """
-        _uuid = await self.get_appropriate_uuid(_uuid)
+        _uuid = await self.get_appropriate_uuid(str(_uuid))
         characteristic = self.services.get_characteristic(_uuid)
         if not characteristic:
             raise BleakError("Characteristic {} was not found!".format(_uuid))
@@ -275,7 +275,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             callback (function): The function to be called on notification.
 
         """
-        _uuid = await self.get_appropriate_uuid(_uuid)
+        _uuid = await self.get_appropriate_uuid(str(_uuid))
         characteristic = self.services.get_characteristic(_uuid)
         if not characteristic:
             raise BleakError("Characteristic {} not found!".format(_uuid))

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -62,16 +62,7 @@ async def discover(
             manufacturer_id = int.from_bytes(
                 manufacturer_binary_data[0:2], byteorder="little"
             )
-            manufacturer_value = "".join(
-                list(
-                    map(
-                        lambda x: format(x, "x")
-                        if len(format(x, "x")) == 2
-                        else "0{}".format(format(x, "x")),
-                        list(manufacturer_binary_data)[2:],
-                    )
-                )
-            )
+            manufacturer_value = bytes(manufacturer_binary_data[2:])
             manufacturer_data = {manufacturer_id: manufacturer_value}
 
         uuids = [

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -1,4 +1,3 @@
-
 """
 Perform Bluetooth LE Scan.
 
@@ -75,8 +74,16 @@ async def discover(
             )
             manufacturer_data = {manufacturer_id: manufacturer_value}
 
+        uuids = [
+            # converting to lower case to match other platforms
+            str(u).lower()
+            for u in advertisementData.get("kCBAdvDataServiceUUIDs", [])
+        ]
+
         found.append(
-            BLEDevice(address, name, details, manufacturer_data=manufacturer_data)
+            BLEDevice(
+                address, name, details, uuids=uuids, manufacturer_data=manufacturer_data
+            )
         )
 
     return found

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -52,11 +52,7 @@ async def discover(
         details = peripheral
 
         advertisementData = cbapp.central_manager_delegate.advertisement_data_list[i]
-        manufacturer_binary_data = (
-            advertisementData["kCBAdvDataManufacturerData"]
-            if "kCBAdvDataManufacturerData" in advertisementData.keys()
-            else None
-        )
+        manufacturer_binary_data = advertisementData.get("kCBAdvDataManufacturerData")
         manufacturer_data = {}
         if manufacturer_binary_data:
             manufacturer_id = int.from_bytes(


### PR DESCRIPTION
This contains some fixes for the corebluetooth backend so that the format of the `BLEDevice.metatadata` values are the same on all platforms.

See commit messages for details.