### PR TITLE
Asynchronous discovery of devices

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -106,7 +106,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # A Discover must have been run before connecting to any devices. Do a quick one here
         # to ensure that it has been done.
         timeout = kwargs.get("timeout", self._timeout)
-        await discover(timeout=timeout, device=self.device, loop=self.loop)
+        if timeout > 0:
+            await discover(timeout=timeout, device=self.device, loop=self.loop)
 
         # Create system bus
         self._bus = await txdbus_connect(reactor, busAddress="system").asFuture(

--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from typing import Callable
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.bluezdbus import reactor, defs
@@ -53,6 +54,255 @@ def _device_info(path, props):
         return None, None, None, None
 
 
+def _parse_device(path, props):
+    if not props:
+        logger.debug(
+            "Disregarding %s since no properties could be obtained." % path
+        )
+        return None
+
+    name, address, _, path = _device_info(path, props)
+    if address is None:
+        return None
+
+    uuids = props.get("UUIDs", [])
+    manufacturer_data = props.get("ManufacturerData", {})
+    return BLEDevice(
+            address,
+            name,
+            {"path": path, "props": props},
+            uuids=uuids,
+            manufacturer_data=manufacturer_data,
+        )
+
+
+class AsyncDiscovery():
+
+    def __init__(self, callback: Callable[[BLEDevice], None]=None,
+                 loop=None, device="hci0"):
+        """State keeper to discover nearby Bluetooth Low Energy devices and get
+        a call for each discovered device in an asynchronous way.
+
+        Args:
+            callback (Callable[[bleak.BLEDevice], None]): called for each discovered device.
+            loop (asyncio.AbstractEventLoop): Optional event loop to use.
+            device (str): Bluetooth device to use for discovery.
+
+        """
+        self.callback = callback
+        self.device = device
+        self.loop = loop if loop else asyncio.get_event_loop()
+        self.rules = list()
+        self.cached_devices = {}
+        self.bus = None
+        self.devices = {}
+        self.adapter_path = ""
+
+    async def _start_discovery(self, filters=None):
+        """Start discovering of nearby BLE devices.
+
+        For possible values for `filters`, see the parameters to the
+        ``SetDiscoveryFilter`` method in the `BlueZ docs
+        <https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt?h=5.48&id=0d1e3b9c5754022c779da129025d493a198d49cf>`_
+
+        The ``Transport`` parameter is always set to ``le`` by default in Bleak.
+
+        The filters are applied and the callback registered with the object is
+        called every time a new device appears or the properties of an already
+        discovered device changes. This might happen frequently, since a change
+        in the RSSI value is considered a property change.
+
+        Args:
+            filters (dict): A dict of filters to be applied on discovery.
+
+        """
+        if self.rules:
+            # List is not empty, scanning is already in progress.
+            return
+
+        if not filters:
+            filters = dict()
+
+        filters["Transport"] = "le"
+
+        self.bus = await client.connect(reactor, "system").asFuture(self.loop)
+
+        # Add signal listeners
+        self.rules.append(
+            await self.bus.addMatch(
+                self._parse_msg,
+                interface="org.freedesktop.DBus.ObjectManager",
+                member="InterfacesAdded",
+            ).asFuture(self.loop)
+        )
+        self.rules.append(
+            await self.bus.addMatch(
+                self._parse_msg,
+                interface="org.freedesktop.DBus.ObjectManager",
+                member="InterfacesRemoved",
+            ).asFuture(self.loop)
+        )
+        self.rules.append(
+            await self.bus.addMatch(
+                self._parse_msg,
+                interface="org.freedesktop.DBus.Properties",
+                member="PropertiesChanged",
+            ).asFuture(self.loop)
+        )
+
+        # Find the HCI device to use for scanning and get cached device properties
+        objects = await self.bus.callRemote(
+            "/",
+            "GetManagedObjects",
+            interface=defs.OBJECT_MANAGER_INTERFACE,
+            destination=defs.BLUEZ_SERVICE,
+        ).asFuture(self.loop)
+        self.adapter_path, interface = _filter_on_adapter(objects, self.device)
+        self.cached_devices = dict(_filter_on_device(objects))
+
+        await self.bus.callRemote(
+            self.adapter_path,
+            "SetDiscoveryFilter",
+            interface="org.bluez.Adapter1",
+            destination="org.bluez",
+            signature="a{sv}",
+            body=[filters],
+        ).asFuture(self.loop)
+        await self.bus.callRemote(
+            self.adapter_path,
+            "StartDiscovery",
+            interface="org.bluez.Adapter1",
+            destination="org.bluez",
+        ).asFuture(self.loop)
+
+    async def stop_discovery(self):
+        """
+        Stop looking for nearby devices and provide a list of all devices
+        discovered in the discovery session. If a device has been advertising
+        but became unavailable before the discovery session ended, it will still
+        show up in the returned list.
+
+        Returns:
+            List of BLEDevices that have been discovered.
+
+        """
+        if not self.rules:
+            # Discovery is currently not active.
+            return None
+
+        await self.bus.callRemote(
+            self.adapter_path,
+            "StopDiscovery",
+            interface="org.bluez.Adapter1",
+            destination="org.bluez",
+        ).asFuture(self.loop)
+
+        for rule in self.rules:
+            await self.bus.delMatch(rule).asFuture(self.loop)
+            self.rules.remove(rule)
+
+        self.bus.disconnect()
+        discovered_devices = []
+
+        for path, props in self.devices.items():
+            discovered = _parse_device(path, props)
+            if discovered:
+                discovered_devices.append(discovered)
+
+        return discovered_devices
+
+    def _parse_msg(self, message):
+        if message.member == "InterfacesAdded":
+            msg_path = message.body[0]
+            try:
+                device_interface = message.body[1].get("org.bluez.Device1", {})
+            except Exception as e:
+                raise e
+            self.devices[msg_path] = (
+                {**self.devices[msg_path], **device_interface}
+                if msg_path in self.devices
+                else device_interface
+            )
+
+            dev = _parse_device(msg_path, self.devices[msg_path])
+            if dev and self.callback:
+                self.callback(dev)
+
+        elif message.member == "PropertiesChanged":
+            iface, changed, invalidated = message.body
+            if iface != defs.DEVICE_INTERFACE:
+                return
+
+            msg_path = message.path
+            # the PropertiesChanged signal only sends changed properties, so we
+            # need to get remaining properties from cached_devices. However, we
+            # don't want to add all cached_devices to the devices dict since
+            # they may not actually be nearby or powered on.
+            if msg_path not in self.devices and msg_path in self.cached_devices:
+                self.devices[msg_path] = self.cached_devices[msg_path]
+            self.devices[msg_path] = (
+                {**self.devices[msg_path], **changed} if msg_path in self.devices else changed
+            )
+
+            dev = _parse_device(msg_path, self.devices[msg_path])
+            if dev and self.callback:
+                self.callback(dev)
+
+        elif (
+            message.member == "InterfacesRemoved"
+            and message.body[1][0] == defs.BATTERY_INTERFACE
+        ):
+            logger.info(
+                "{0}, {1} ({2}): {3}".format(
+                    message.member, message.interface, message.path, message.body
+                )
+            )
+            return
+        else:
+            msg_path = message.path
+            logger.info(
+                "{0}, {1} ({2}): {3}".format(
+                    message.member, message.interface, message.path, message.body
+                )
+            )
+
+        logger.info(
+            "{0}, {1} ({2} dBm), Object Path: {3}".format(
+                *_device_info(msg_path, self.devices.get(msg_path))
+            )
+        )
+
+async def discover_async(callback: Callable[[BLEDevice], None]=None,
+                         loop=None, **kwargs):
+    """Start discovering asynchronously nearby Bluetooth Low Energy devices.
+    The filters are applied and the callback registered with the object is
+    called every time a new device appears or the properties of an already
+    discovered device changes. This might happen frequently, since a change in
+    the RSSI value is considered a property change.
+
+    Args:
+        callback (Callable[[bleak.BLEDevice], None]): called for each discovered device.
+        loop (asyncio.AbstractEventLoop): Optional event loop to use.
+
+    Keyword Args:
+        device (str): Bluetooth device to use for discovery.
+        filters (dict): A dict of filters to be applied on discovery.
+
+    Returns:
+        A discovery state object that can be used to stop the discovery again.
+
+    """
+    device = kwargs.get("device", "hci0")
+
+    # Discovery filters
+    filters = kwargs.get("filters", {})
+
+    disco = AsyncDiscovery(callback, loop, device)
+    await disco._start_discovery(filters)
+
+    return disco
+
+
 async def discover(timeout=5.0, loop=None, **kwargs):
     """Discover nearby Bluetooth Low Energy devices.
 
@@ -75,156 +325,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
         of nearby devices.
 
     """
-    device = kwargs.get("device", "hci0")
-    loop = loop if loop else asyncio.get_event_loop()
-    cached_devices = {}
-    devices = {}
-    rules = list()
 
-    # Discovery filters
-    filters = kwargs.get("filters", {})
-    filters["Transport"] = "le"
-
-    def parse_msg(message):
-        if message.member == "InterfacesAdded":
-            msg_path = message.body[0]
-            try:
-                device_interface = message.body[1].get("org.bluez.Device1", {})
-            except Exception as e:
-                raise e
-            devices[msg_path] = (
-                {**devices[msg_path], **device_interface}
-                if msg_path in devices
-                else device_interface
-            )
-        elif message.member == "PropertiesChanged":
-            iface, changed, invalidated = message.body
-            if iface != defs.DEVICE_INTERFACE:
-                return
-
-            msg_path = message.path
-            # the PropertiesChanged signal only sends changed properties, so we
-            # need to get remaining properties from cached_devices. However, we
-            # don't want to add all cached_devices to the devices dict since
-            # they may not actually be nearby or powered on.
-            if msg_path not in devices and msg_path in cached_devices:
-                devices[msg_path] = cached_devices[msg_path]
-            devices[msg_path] = (
-                {**devices[msg_path], **changed} if msg_path in devices else changed
-            )
-        elif (
-            message.member == "InterfacesRemoved"
-            and message.body[1][0] == defs.BATTERY_INTERFACE
-        ):
-            logger.info(
-                "{0}, {1} ({2}): {3}".format(
-                    message.member, message.interface, message.path, message.body
-                )
-            )
-            return
-        else:
-            msg_path = message.path
-            logger.info(
-                "{0}, {1} ({2}): {3}".format(
-                    message.member, message.interface, message.path, message.body
-                )
-            )
-
-        logger.info(
-            "{0}, {1} ({2} dBm), Object Path: {3}".format(
-                *_device_info(msg_path, devices.get(msg_path))
-            )
-        )
-
-    bus = await client.connect(reactor, "system").asFuture(loop)
-
-    # Add signal listeners
-    rules.append(
-        await bus.addMatch(
-            parse_msg,
-            interface="org.freedesktop.DBus.ObjectManager",
-            member="InterfacesAdded",
-        ).asFuture(loop)
-    )
-
-    rules.append(
-        await bus.addMatch(
-            parse_msg,
-            interface="org.freedesktop.DBus.ObjectManager",
-            member="InterfacesRemoved",
-        ).asFuture(loop)
-    )
-
-    rules.append(
-        await bus.addMatch(
-            parse_msg,
-            interface="org.freedesktop.DBus.Properties",
-            member="PropertiesChanged",
-        ).asFuture(loop)
-    )
-
-    # Find the HCI device to use for scanning and get cached device properties
-    objects = await bus.callRemote(
-        "/",
-        "GetManagedObjects",
-        interface=defs.OBJECT_MANAGER_INTERFACE,
-        destination=defs.BLUEZ_SERVICE,
-    ).asFuture(loop)
-    adapter_path, interface = _filter_on_adapter(objects, device)
-    cached_devices = dict(_filter_on_device(objects))
-
-    # Running Discovery loop.
-    await bus.callRemote(
-        adapter_path,
-        "SetDiscoveryFilter",
-        interface="org.bluez.Adapter1",
-        destination="org.bluez",
-        signature="a{sv}",
-        body=[filters],
-    ).asFuture(loop)
-
-    await bus.callRemote(
-        adapter_path,
-        "StartDiscovery",
-        interface="org.bluez.Adapter1",
-        destination="org.bluez",
-    ).asFuture(loop)
-
+    disco = await discover_async(None, loop, **kwargs)
     await asyncio.sleep(timeout)
-
-    await bus.callRemote(
-        adapter_path,
-        "StopDiscovery",
-        interface="org.bluez.Adapter1",
-        destination="org.bluez",
-    ).asFuture(loop)
-
-    # Reduce output.
-    discovered_devices = []
-    for path, props in devices.items():
-        if not props:
-            logger.debug(
-                "Disregarding %s since no properties could be obtained." % path
-            )
-            continue
-        name, address, _, path = _device_info(path, props)
-        if address is None:
-            continue
-        uuids = props.get("UUIDs", [])
-        manufacturer_data = props.get("ManufacturerData", {})
-        discovered_devices.append(
-            BLEDevice(
-                address,
-                name,
-                {"path": path, "props": props},
-                uuids=uuids,
-                manufacturer_data=manufacturer_data,
-            )
-        )
-
-    for rule in rules:
-        await bus.delMatch(rule).asFuture(loop)
-
-    bus.disconnect()
-
-    return discovered_devices
+    return await disco.stop_discovery()

--- a/examples/discover_async.py
+++ b/examples/discover_async.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from bleak.backends.bluezdbus.discovery import discover_async
+
+def device_found(bleak_dev):
+    print("Address: ", bleak_dev.address)
+    print("Name: ", bleak_dev.name)
+    print("Details: ", bleak_dev.details)
+    print("Metadata: ", bleak_dev.metadata)
+    print("RSSI: ", bleak_dev.rssi)
+
+
+loop = asyncio.get_event_loop()
+
+disco = loop.run_until_complete(discover_async(device_found, loop))
+
+try:
+    loop.run_forever()
+except KeyboardInterrupt:
+    loop.run_until_complete(disco.stop_discovery())
+    print("Goodbye")


### PR DESCRIPTION
This patch includes two changes:
* Prevent overhead of process change for discovery if timeout = 0 is passed
* asynchronous discovery of nearby BLE devices. While
the blocking discover() function with a timeout is still available, an
additional class provides support for starting and stopping the
discovery session individually with a callback on each device change.

@hbldh I don't know whether you are interested in something like this or how you would want this to be integrated in the library. Just let me know if I should close the PR or change it to be merged upstream