### PR TITLE
Macos type error

### DIFF
--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -196,7 +196,7 @@ class PeripheralDelegate(NSObject):
         while not self._characteristic_notify_log[cUUID]:
             await asyncio.sleep(0.01)
 
-        self._characteristic_notify_status = False
+        self._characteristic_notify_status[cUUID] = False
         return True
 
     # Protocol Functions


### PR DESCRIPTION
Fixes the following error:
```
2020-01-03 00:33:47.366 Python[3151:275686] PyObjC: Converting exception to Objective-C:
Traceback (most recent call last):
  File "bleak/backends/corebluetooth/PeripheralDelegate.py", line 250, in peripheral_didUpdateValueForCharacteristic_error_
    cUUID in self._characteristic_notify_status
TypeError: argument of type 'bool' is not iterable
2020-01-03 00:33:47.374 Python[3151:275686] *** Terminating app due to uncaught exception 'OC_PythonException', reason: '<class 'TypeError'>: argument of type 'bool' is not iterable'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff2cb4db79 __exceptionPreprocess + 256
	1   libobjc.A.dylib                     0x00007fff572c13c6 objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff2cb679cd -[NSException raise] + 9
	3   _objc.cpython-37m-darwin.so         0x0000000110d28a4e PyObjCErr_ToObjCWithGILState + 46
	4   _objc.cpython-37m-darwin.so         0x0000000110cfde63 method_stub + 5283
	5   _objc.cpython-37m-darwin.so         0x0000000110d283e0 ffi_closure_unix64_inner + 720
	6   _objc.cpython-37m-darwin.so         0x0000000110d278f6 ffi_closure_unix64 + 70
	7   CoreBluetooth                       0x00007fff2c5be00e -[CBPeripheral handleCharacteristicEvent:characteristicSelector:delegateSelector:delegateFlag:] + 115
	8   CoreBluetooth                       0x00007fff2c5b9a7e -[CBPeripheral handleMsg:args:] + 297
	9   CoreBluetooth                       0x00007fff2c5b4368 -[CBCentralManager handleMsg:args:] + 198
	10  CoreBluetooth                       0x00007fff2c5af7db __30-[CBXpcConnection _handleMsg:]_block_invoke + 53
	11  libdispatch.dylib                   0x00007fff58a385f8 _dispatch_call_block_and_release + 12
	12  libdispatch.dylib                   0x00007fff58a3963d _dispatch_client_callout + 8
	13  libdispatch.dylib                   0x00007fff58a3f8e0 _dispatch_lane_serial_drain + 602
	14  libdispatch.dylib                   0x00007fff58a403c6 _dispatch_lane_invoke + 433
	15  libdispatch.dylib                   0x00007fff58a4454b _dispatch_main_queue_callback_4CF + 813
	16  CoreFoundation                      0x00007fff2ca97c76 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
	17  CoreFoundation                      0x00007fff2ca973a3 __CFRunLoopRun + 2300
	18  CoreFoundation                      0x00007fff2ca96855 CFRunLoopRunSpecific + 459
	19  Foundation                          0x00007fff2ed1932f -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 280
	20  _objc.cpython-37m-darwin.so         0x0000000110d27777 ffi_call_unix64 + 79
	21  ???                                 0x00000001133b58f0 0x0 + 4617623792
)
libc++abi.dylib: terminating with uncaught exception of type NSException
Abort trap: 6
```

`_characteristic_notify_status` is expected to be a dict. 