### PR TITLE
backends/bluezdbus: use an a new reactor for each client

### DIFF
--- a/bleak/backends/bluezdbus/__init__.py
+++ b/bleak/backends/bluezdbus/__init__.py
@@ -5,11 +5,3 @@ __init__.py
 Created on 2017-11-19 by hbldh <henrik.blidh@nedomkull.com>
 
 """
-
-import asyncio
-from twisted.internet import asyncioreactor as _asyncioreactor
-
-loop = asyncio.new_event_loop()
-asyncio.set_event_loop(loop)
-_asyncioreactor.install(eventloop=loop)
-from twisted.internet import reactor  # noqa

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -12,14 +12,14 @@ from typing import Callable, Any, Union
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakError
 from bleak.backends.client import BaseBleakClient
-from bleak.backends.bluezdbus import reactor, defs, signals, utils
+from bleak.backends.bluezdbus import defs, signals, utils
 from bleak.backends.bluezdbus.discovery import discover
 from bleak.backends.bluezdbus.utils import get_device_object_path, get_managed_objects
 from bleak.backends.bluezdbus.service import BleakGATTServiceBlueZDBus
 from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus
 from bleak.backends.bluezdbus.descriptor import BleakGATTDescriptorBlueZDBus
 
-# txdbus MUST be imported AFTER bleak.backends.bluezdbus.reactor!
+from twisted.internet.asyncioreactor import AsyncioSelectorReactor
 from txdbus.client import connect as txdbus_connect
 from txdbus.error import RemoteError
 
@@ -107,6 +107,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # to ensure that it has been done.
         timeout = kwargs.get("timeout", self._timeout)
         await discover(timeout=timeout, device=self.device, loop=self.loop)
+
+        reactor = AsyncioSelectorReactor(self.loop)
 
         # Create system bus
         self._bus = await txdbus_connect(reactor, busAddress="system").asFuture(

--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -4,12 +4,11 @@ import asyncio
 import logging
 
 from bleak.backends.device import BLEDevice
-from bleak.backends.bluezdbus import reactor, defs
+from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.utils import validate_mac_address
 
-# txdbus.client MUST be imported AFTER bleak.backends.bluezdbus.reactor!
 from txdbus import client
-
+from twisted.internet.asyncioreactor import AsyncioSelectorReactor
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +79,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
     cached_devices = {}
     devices = {}
     rules = list()
+    reactor = AsyncioSelectorReactor(loop)
 
     # Discovery filters
     filters = kwargs.get("filters", {})


### PR DESCRIPTION
This makes things much cleaner :
- The default asyncio event loop is not modified
- No default twisted reactor is installed (a new one will be created every time)
- The reactor will use the provided event loop

Related to: #93 #125 