### PR TITLE
Advertisement data

### DIFF
--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -24,7 +24,7 @@ from Foundation import (
 )
 
 from bleak.backends.corebluetooth.PeripheralDelegate import PeripheralDelegate
-from bleak.backends.device import BLEDevice
+from bleak.backends.corebluetooth.device import BLEDeviceCoreBluetooth
 
 
 logger = logging.getLogger(__name__)
@@ -37,50 +37,6 @@ class CMDConnectionState(Enum):
     PENDING = 1
     CONNECTED = 2
 
-
-class BLEDeviceCoreBluetooth(BLEDevice):
-    """
-        
-    """
-    def __init__(self, *args, **kwargs):
-        super(BLEDeviceCoreBluetooth, self).__init__(*args, **kwargs)
-        # The metadata keys are more or less part of the crossplattform interface.
-        self.metadata = {}
-        self._rssi = kwargs.get("rssi")
-
-    def _update(self, advertisementData):
-        # other fields that might be of interest:
-        #   kCBAdvDataAppleMfgData
-        #   kCBAdvDataChannel
-        #   kCBAdvDataManufacturerData
-        #   kCBAdvDataIsConnectable
-        #   kCBAdvDataChannel
-        #   kCBAdvDataAppleMfgData
-        #   kCBAdvDataTxPowerLevel
-        #   kCBAdvDataLocalName
-
-        self._update_uuids(advertisementData)
-        self._update_manufacturer(advertisementData)
-
-    def _update_uuids(self, advertisementData):
-        cbuuids = advertisementData.get("kCBAdvDataServiceUUIDs", [])
-        if not cbuuids:
-            return 
-        # converting to lower case to match other platforms
-        self.metadata["uuids"] = [str(u).lower() for u in cbuuids]
-
-    def _update_manufacturer(self, advertisementData):
-        mfg_bytes = advertisementData.get("kCBAdvDataManufacturerData")
-        if not mfg_bytes:
-            return
-
-        mfg_id = int.from_bytes(mfg_bytes[0:2], byteorder="little")
-        mfg_val = bytes(mfg_bytes[2:])
-        self.metadata["manufacturer_data"] = {mfg_id: mfg_val}
-
-    @property 
-    def rssi(self):
-        return self._rssi
 
 class CentralManagerDelegate(NSObject):
     """macOS conforming python class for managing the CentralManger for BLE"""

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -288,3 +288,4 @@ class CentralManagerDelegate(NSObject):
 def string2uuid(uuid_str: str) -> CBUUID:
     """Convert a string to a uuid"""
     return CBUUID.UUIDWithString_(uuid_str)
+

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -37,7 +37,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
     """
 
-    def __init__(self, address: str, loop: AbstractEventLoop, **kwargs):
+    def __init__(self, address: str, loop: AbstractEventLoop = None, **kwargs):
         super(BleakClientCoreBluetooth, self).__init__(address, loop, **kwargs)
 
         self._device_info = None

--- a/bleak/backends/corebluetooth/device.py
+++ b/bleak/backends/corebluetooth/device.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from bleak.backends._manufacturers import MANUFACTURERS
+
+from Foundation import NSDictionary
+
+
+from bleak.backends.device import BLEDevice
+
+
+class BLEDeviceCoreBluetooth(BLEDevice):
+    """
+    A CoreBlutooth class representing a BLE server detected during
+    a `discover` call.
+
+    - The `details` attribute will be a CBPeripheral object.
+
+    - The `metadata` keys are more or less part of the crossplattform interface.
+
+    - Note: Take care not to rely on any reference to `advertisementData` and
+      it's data as lower layers of the corebluetooth stack can change it. i.e.
+      only valid/trusted in callback(s) or if copied.
+
+    - AdvertisementData fields/keys that might be of interest:
+      - kCBAdvDataAppleMfgData
+      - kCBAdvDataChannel
+      - kCBAdvDataManufacturerData
+      - kCBAdvDataIsConnectable
+      - kCBAdvDataChannel
+      - kCBAdvDataAppleMfgData
+      - kCBAdvDataTxPowerLevel
+      - kCBAdvDataLocalName
+      - kCBAdvDataServiceUUIDs
+      - kCBAdvDataManufacturerData
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(BLEDeviceCoreBluetooth, self).__init__(*args, **kwargs)
+        self.metadata = {}
+        self._rssi = kwargs.get("rssi")
+
+    def _update(self, advertisementData: NSDictionary):
+        self._update_uuids(advertisementData)
+        self._update_manufacturer(advertisementData)
+
+    def _update_uuids(self, advertisementData: NSDictionary):
+        cbuuids = advertisementData.get("kCBAdvDataServiceUUIDs", [])
+        if not cbuuids:
+            return
+        # converting to lower case to match other platforms
+        self.metadata["uuids"] = [str(u).lower() for u in cbuuids]
+
+    def _update_manufacturer(self, advertisementData: NSDictionary):
+        mfg_bytes = advertisementData.get("kCBAdvDataManufacturerData")
+        if not mfg_bytes:
+            return
+
+        mfg_id = int.from_bytes(mfg_bytes[0:2], byteorder="little")
+        mfg_val = bytes(mfg_bytes[2:])
+        self.metadata["manufacturer_data"] = {mfg_id: mfg_val}
+
+    @property
+    def rssi(self):
+        return self._rssi
+
+
+class BLEDevice(object):
+    """A simple wrapper class representing a BLE server detected during
+    a `discover` call.
+
+    - When using Windows backend, `details` attribute is a
+      `Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement` object, unless
+      it is created with the Windows.Devices.Enumeration discovery method, then is is a
+      `Windows.Devices.Enumeration.DeviceInformation`
+    - When using Linux backend, `details` attribute is a
+      dict with keys `path` which has the string path to the DBus device object and `props`
+      which houses the properties dictionary of the D-Bus Device.
+    - When using macOS backend, `details` attribute will be a CBPeripheral object
+    """
+
+    def __init__(self, address, name, details=None, **kwargs):
+        self.address = address
+        self.name = name if name else "Unknown"
+        self.details = details
+        self.metadata = kwargs
+
+    @property
+    def rssi(self):
+        """Get the signal strength in dBm"""
+        if isinstance(self.details, dict) and "props" in self.details:
+            rssi = self.details["props"].get("RSSI", 0)  # Should not be set to 0...
+        elif hasattr(self.details, "RawSignalStrengthInDBm"):
+            rssi = self.details.RawSignalStrengthInDBm
+        elif hasattr(self.details, "Properties"):
+            rssi = {p.Key: p.Value for p in self.details.Properties}[
+                "System.Devices.Aep.SignalStrength"
+            ]
+        else:
+            rssi = None
+        return int(rssi) if rssi is not None else None
+
+    def __str__(self):
+        if self.name == "Unknown":
+            if "manufacturer_data" in self.metadata:
+                ks = list(self.metadata["manufacturer_data"].keys())
+                if len(ks):
+                    mf = MANUFACTURERS.get(ks[0], MANUFACTURERS.get(0xFFFF))
+                    value = self.metadata["manufacturer_data"].get(
+                        ks[0], MANUFACTURERS.get(0xFFFF)
+                    )
+                    # TODO: Evaluate how to interpret the value of the company identifier...
+                    return "{0}: {1} ({2})".format(self.address, mf, value)
+        return "{0}: {1}".format(self.address, self.name)
+

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -15,7 +15,6 @@ from bleak.backends.corebluetooth import CBAPP as cbapp
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
-
 async def discover(
     timeout: float = 5.0, loop: AbstractEventLoop = None, **kwargs
 ) -> List[BLEDevice]:
@@ -27,8 +26,6 @@ async def discover(
 
     """
     loop = loop if loop else asyncio.get_event_loop()
-
-    devices = {}
 
     if not cbapp.central_manager_delegate.enabled:
         raise BleakError("Bluetooth device is turned off")
@@ -42,35 +39,7 @@ async def discover(
     # with this, CoreBluetooth utilizes UUIDs for each peripheral. We'll use
     # this for the BLEDevice address on macOS
 
-    found = []
 
-    peripherals = cbapp.central_manager_delegate.peripheral_list
+    devices = cbapp.central_manager_delegate.devices
+    return list(devices.values())
 
-    for i, peripheral in enumerate(peripherals):
-        address = peripheral.identifier().UUIDString()
-        name = peripheral.name() or "Unknown"
-        details = peripheral
-
-        advertisementData = cbapp.central_manager_delegate.advertisement_data_list[i]
-        manufacturer_binary_data = advertisementData.get("kCBAdvDataManufacturerData")
-        manufacturer_data = {}
-        if manufacturer_binary_data:
-            manufacturer_id = int.from_bytes(
-                manufacturer_binary_data[0:2], byteorder="little"
-            )
-            manufacturer_value = bytes(manufacturer_binary_data[2:])
-            manufacturer_data = {manufacturer_id: manufacturer_value}
-
-        uuids = [
-            # converting to lower case to match other platforms
-            str(u).lower()
-            for u in advertisementData.get("kCBAdvDataServiceUUIDs", [])
-        ]
-
-        found.append(
-            BLEDevice(
-                address, name, details, uuids=uuids, manufacturer_data=manufacturer_data
-            )
-        )
-
-    return found


### PR DESCRIPTION
Fixes the following issues on MacOS/CoreBluetooth backend:

- #142. advertisementData such as service UUIDs lost as multiple calls to
  centralManager_didDiscoverPeripheral_advertisementData_RSSI_
  for same device (but different advertisementData) was not handled.

- Devices never removed only added while scanning and long running
  applications would have get incorrect scan result.

- Scan was never stoped if timeout was 0 or None.
