### PR TITLE
macOS: Adapt characteristic write log to account for WriteWithoutResponse.

### DIFF
--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -150,7 +150,7 @@ class PeripheralDelegate(NSObject):
     ) -> bool:
 
         cUUID = characteristic.UUID().UUIDString()
-        self._characteristic_write_log[cUUID] = False
+        self._characteristic_write_log[cUUID] = False if not response else True
 
         self.peripheral.writeValue_forCharacteristic_type_(value, characteristic, response)
 


### PR DESCRIPTION
f2aa8d9 fails to account for an edge case the issues found in #114, which results in the while loop in `writeCharacteristic_value_type` never resolving because the peripheral never calls the `didWriteValueForCharacteristic` method.

> On the other hand, if you specify the write type as CBCharacteristicWriteWithoutResponse, Core Bluetooth attempts to write the value but doesn’t guarantee success. If the write doesn’t succeed in this case, you aren’t notified and you don’t receive an error indicating the cause of the failure.

[Apple docs for writeCharacteristic_value_type](https://developer.apple.com/documentation/corebluetooth/cbperipheral/1518747-writevalue?language=objc#discussion)

> **Core Bluetooth invokes this method only when your app calls the writeValue:forCharacteristic:type: method with the CBCharacteristicWriteWithResponse constant specified as the write type.** If successful, the error parameter is nil. If unsuccessful, the error parameter returns the cause of the failure.

[Apple docs for didWriteValueForCharacteristic](https://developer.apple.com/documentation/corebluetooth/cbperipheraldelegate/1518823-peripheral?language=objc#discussion)