### PR TITLE
bluez: only subscribe to BlueZ messages on DBus

### DIFF
--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -145,6 +145,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
             parse_msg,
             interface="org.freedesktop.DBus.ObjectManager",
             member="InterfacesAdded",
+            path_namespace="/org/bluez",
         ).asFuture(loop)
     )
 
@@ -153,6 +154,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
             parse_msg,
             interface="org.freedesktop.DBus.ObjectManager",
             member="InterfacesRemoved",
+            path_namespace="/org/bluez",
         ).asFuture(loop)
     )
 
@@ -161,6 +163,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
             parse_msg,
             interface="org.freedesktop.DBus.Properties",
             member="PropertiesChanged",
+            path_namespace="/org/bluez",
         ).asFuture(loop)
     )
 

--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -16,7 +16,10 @@ def listen_properties_changed(bus, loop, callback):
 
     """
     return bus.addMatch(
-        callback, interface=PROPERTIES_INTERFACE, member="PropertiesChanged"
+        callback,
+        interface=PROPERTIES_INTERFACE,
+        member="PropertiesChanged",
+        path_namespace="/org/bluez"
     ).asFuture(loop)
 
 
@@ -33,7 +36,10 @@ def listen_interfaces_added(bus, loop, callback):
 
     """
     return bus.addMatch(
-        callback, interface=OBJECT_MANAGER_INTERFACE, member="InterfacesAdded"
+        callback,
+        interface=OBJECT_MANAGER_INTERFACE,
+        member="InterfacesAdded",
+        path_namespace="/org/bluez"
     ).asFuture(loop)
 
 
@@ -50,5 +56,8 @@ def listen_interfaces_removed(bus, loop, callback):
 
     """
     return bus.addMatch(
-        callback, interface=OBJECT_MANAGER_INTERFACE, member="InterfacesRemoved"
+        callback,
+        interface=OBJECT_MANAGER_INTERFACE,
+        member="InterfacesRemoved",
+        path_namespace="/org/bluez"
     ).asFuture(loop)


### PR DESCRIPTION
The management of the discovery and clients on Linux is primarly done
through subscribing and listening to DBus messages. The subscriptions
have been identified only through the Interface names and their members.
However, those interfaces are generic and can be implemented by all kind
of applications that expose their API through DBus. This led to the
situation where for example NetworkManager events are forwarded to the
bleak application and handled in the callback.

Although those messages have been ignored, they shouldn't even reach the
application. This patch limits the subscriptions to messages with the
"/org/bluez" path prefix and therefore to relevant BlueZ messages.

Fixes #151