### PR TITLE
Added disconnected callback feature for CoreBluetooth

### DIFF
--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -61,6 +61,8 @@ class CentralManagerDelegate(NSObject):
         self.ready = False
         self.devices = {}
 
+        self.disconnected_callback = None
+
         if not self.compliant():
             logger.warning("CentralManagerDelegate is not compliant")
 
@@ -175,7 +177,7 @@ class CentralManagerDelegate(NSObject):
         #
         # i.e it is best not to trust advertisementData for later use and data
         # from it should be copied.
-        # 
+        #
         # This behaviour could be affected by the
         # CBCentralManagerScanOptionAllowDuplicatesKey global setting.
 
@@ -183,8 +185,8 @@ class CentralManagerDelegate(NSObject):
 
         if uuid_string in self.devices:
             device = self.devices[uuid_string]
-        else:        
-            address = uuid_string 
+        else:
+            address = uuid_string
             name = peripheral.name() or None
             details = peripheral
             device = BLEDeviceCoreBluetooth(address, name, details)
@@ -221,6 +223,9 @@ class CentralManagerDelegate(NSObject):
     ):
         logger.debug("Peripheral Device disconnected!")
         self._connection_state = CMDConnectionState.DISCONNECTED
+
+        if self.disconnected_callback is not None:
+            self.disconnected_callback()
 
 
 def string2uuid(uuid_str: str) -> CBUUID:


### PR DESCRIPTION
Added disconnected callback variable in `CentralManagerDelegate` class, which being set by the `set_disconencted_callback` function.

CentralManagerDelegate calls the callback function without argument, so I added wrapper function `disconnected_callback_client` in `client` that pads the `client` as argument and calls actual disconnection callback. 

Issue #184 