### PR TITLE
Fix app crash on Windows when receiving approx 300 bytes

### DIFF
--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -307,8 +307,7 @@ class BleakClientDotNet(BaseBleakClient):
         )
         if read_result.Status == GattCommunicationStatus.Success:
             reader = DataReader.FromBuffer(IBuffer(read_result.Value))
-            output = Array.CreateInstance(Byte, reader.UnconsumedBufferLength)
-            reader.ReadBytes(output)
+            output = [reader.ReadByte() for _ in range(reader.UnconsumedBufferLength)]
             value = bytearray(output)
             logger.debug("Read Characteristic {0} : {1}".format(_uuid, value))
         else:
@@ -350,8 +349,7 @@ class BleakClientDotNet(BaseBleakClient):
         )
         if read_result.Status == GattCommunicationStatus.Success:
             reader = DataReader.FromBuffer(IBuffer(read_result.Value))
-            output = Array.CreateInstance(Byte, reader.UnconsumedBufferLength)
-            reader.ReadBytes(output)
+            output = [reader.ReadByte() for _ in range(reader.UnconsumedBufferLength)]
             value = bytearray(output)
             logger.debug("Read Descriptor {0} : {1}".format(handle, value))
         else:
@@ -568,8 +566,7 @@ def _notification_wrapper(loop: AbstractEventLoop, func: Callable):
         # Return only the UUID string representation as sender.
         # Also do a conversion from System.Bytes[] to bytearray.
         reader = DataReader.FromBuffer(args.CharacteristicValue)
-        output = Array.CreateInstance(Byte, reader.UnconsumedBufferLength)
-        reader.ReadBytes(output)
+        output = [reader.ReadByte() for _ in range(reader.UnconsumedBufferLength)]
 
         return loop.call_soon_threadsafe(func, sender.Uuid.ToString(), bytearray(output))
 


### PR DESCRIPTION
OS: Win10, Python: 3.7, 3.8
For unknown for me reason after receiving approx 300 bytes (in 26 bytes messages) with 'client.start_notify(...)' my app crashes. After some investigating I found that removing line `output = Array.CreateInstance(Byte, reader.UnconsumedBufferLength)` fixes my app, so I replaced it with for loop to read one byte at a time from `args.CharacteristicValue`. I applied this scheme in 2 other places but don't know if it's necessary.