### PR TITLE
Remove passing of asyncio event loop as argument.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,13 +78,13 @@ Connect to a Bluetooth device and read its model number:
     address = "24:71:89:cc:09:05"
     MODEL_NBR_UUID = "00002a24-0000-1000-8000-00805f9b34fb"
 
-    async def run(address, loop):
-        async with BleakClient(address, loop=loop) as client:
+    async def run(address):
+        async with BleakClient(address) as client:
             model_number = await client.read_gatt_char(MODEL_NBR_UUID)
             print("Model Number: {0}".format("".join(map(chr, model_number))))
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(address, loop))
+    loop.run_until_complete(run(address))
 
 
 See examples folder for more code, for instance example code for connecting to a

--- a/bleak/backends/bluezdbus/discovery.py
+++ b/bleak/backends/bluezdbus/discovery.py
@@ -51,7 +51,7 @@ def _device_info(path, props):
         return None, None, None, None
 
 
-async def discover(timeout=5.0, loop=None, **kwargs):
+async def discover(timeout=5.0, **kwargs):
     """Discover nearby Bluetooth Low Energy devices.
 
     For possible values for `filter`, see the parameters to the
@@ -62,7 +62,6 @@ async def discover(timeout=5.0, loop=None, **kwargs):
 
     Args:
         timeout (float): Duration to scan for.
-        loop (asyncio.AbstractEventLoop): Optional event loop to use.
 
     Keyword Args:
         device (str): Bluetooth device to use for discovery.
@@ -74,7 +73,7 @@ async def discover(timeout=5.0, loop=None, **kwargs):
 
     """
     device = kwargs.get("device", "hci0")
-    loop = loop if loop else asyncio.get_event_loop()
+    loop = asyncio.get_event_loop()
     cached_devices = {}
     devices = {}
     rules = list()

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -2,7 +2,6 @@ import logging
 import asyncio
 import pathlib
 import uuid
-from asyncio.events import AbstractEventLoop
 from functools import wraps
 from typing import Callable, Any, Union, List
 
@@ -57,17 +56,10 @@ def _device_info(path, props):
 
 
 class BleakScannerBlueZDBus(BaseBleakScanner):
-    """The native Linux Bleak BLE Scanner.
+    """The native Linux Bleak BLE Scanner."""
 
-    Args:
-        loop (asyncio.events.AbstractEventLoop): The event loop to use.
-
-    Keyword Args:
-
-    """
-
-    def __init__(self, loop: AbstractEventLoop = None, **kwargs):
-        super(BleakScannerBlueZDBus, self).__init__(loop, **kwargs)
+    def __init__(self, **kwargs):
+        super(BleakScannerBlueZDBus, self).__init__(**kwargs)
 
         self._device = kwargs.get("device", "hci0")
         self._reactor = None
@@ -87,8 +79,9 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         self._callback = None
 
     async def start(self):
-        self._reactor = get_reactor(self.loop)
-        self._bus = await client.connect(self._reactor, "system").asFuture(self.loop)
+        loop = asyncio.get_event_loop()
+        self._reactor = get_reactor(loop)
+        self._bus = await client.connect(self._reactor, "system").asFuture(loop)
 
         # Add signal listeners
         self._rules.append(
@@ -96,7 +89,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
                 self.parse_msg,
                 interface="org.freedesktop.DBus.ObjectManager",
                 member="InterfacesAdded",
-            ).asFuture(self.loop)
+            ).asFuture(loop)
         )
 
         self._rules.append(
@@ -104,7 +97,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
                 self.parse_msg,
                 interface="org.freedesktop.DBus.ObjectManager",
                 member="InterfacesRemoved",
-            ).asFuture(self.loop)
+            ).asFuture(loop)
         )
 
         self._rules.append(
@@ -112,7 +105,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
                 self.parse_msg,
                 interface="org.freedesktop.DBus.Properties",
                 member="PropertiesChanged",
-            ).asFuture(self.loop)
+            ).asFuture(loop)
         )
 
         # Find the HCI device to use for scanning and get cached device properties
@@ -121,7 +114,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             "GetManagedObjects",
             interface=defs.OBJECT_MANAGER_INTERFACE,
             destination=defs.BLUEZ_SERVICE,
-        ).asFuture(self.loop)
+        ).asFuture(loop)
         self._adapter_path, self._interface = _filter_on_adapter(objects, self._device)
         self._cached_devices = dict(_filter_on_device(objects))
 
@@ -133,7 +126,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             destination="org.bluez",
             signature="a{sv}",
             body=[self._filters],
-        ).asFuture(self.loop)
+        ).asFuture(loop)
 
         # Start scanning
         await self._bus.callRemote(
@@ -141,18 +134,19 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             "StartDiscovery",
             interface="org.bluez.Adapter1",
             destination="org.bluez",
-        ).asFuture(self.loop)
+        ).asFuture(loop)
 
     async def stop(self):
+        loop = asyncio.get_event_loop()
         await self._bus.callRemote(
             self._adapter_path,
             "StopDiscovery",
             interface="org.bluez.Adapter1",
             destination="org.bluez",
-        ).asFuture(self.loop)
+        ).asFuture(loop)
 
         for rule in self._rules:
-            await self._bus.delMatch(rule).asFuture(self.loop)
+            await self._bus.delMatch(rule).asFuture(loop)
         self._rules.clear()
 
         # Try to disconnect the System Bus.

--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 
+import asyncio
+
 from bleak.backends.bluezdbus.defs import PROPERTIES_INTERFACE, OBJECT_MANAGER_INTERFACE
 
 
-def listen_properties_changed(bus, loop, callback):
+def listen_properties_changed(bus, callback):
     """Create a future for a PropertiesChanged signal listener.
 
     Args:
         bus: The system bus object to use.
-        loop: The asyncio loop to use for adding the future to.
         callback: The callback function to run when signal is received.
 
     Returns:
@@ -20,15 +21,14 @@ def listen_properties_changed(bus, loop, callback):
         interface=PROPERTIES_INTERFACE,
         member="PropertiesChanged",
         path_namespace="/org/bluez",
-    ).asFuture(loop)
+    ).asFuture(asyncio.get_event_loop())
 
 
-def listen_interfaces_added(bus, loop, callback):
+def listen_interfaces_added(bus, callback):
     """Create a future for a InterfacesAdded signal listener.
 
     Args:
         bus: The system bus object to use.
-        loop: The asyncio loop to use for adding the future to.
         callback: The callback function to run when signal is received.
 
     Returns:
@@ -40,15 +40,14 @@ def listen_interfaces_added(bus, loop, callback):
         interface=OBJECT_MANAGER_INTERFACE,
         member="InterfacesAdded",
         path_namespace="/org/bluez",
-    ).asFuture(loop)
+    ).asFuture(asyncio.get_event_loop())
 
 
-def listen_interfaces_removed(bus, loop, callback):
+def listen_interfaces_removed(bus, callback):
     """Create a future for a InterfacesAdded signal listener.
 
     Args:
         bus: The system bus object to use.
-        loop: The asyncio loop to use for adding the future to.
         callback: The callback function to run when signal is received.
 
     Returns:
@@ -60,4 +59,4 @@ def listen_interfaces_removed(bus, loop, callback):
         interface=OBJECT_MANAGER_INTERFACE,
         member="InterfacesRemoved",
         path_namespace="/org/bluez",
-    ).asFuture(loop)
+    ).asFuture(asyncio.get_event_loop())

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import asyncio
 import re
 
 from bleak.uuids import uuidstr_to_str
@@ -68,13 +69,13 @@ def get_gatt_service_path(hci_device, address, service_id):
     return base + "{0}/service{1:02d}".format(base, service_id)
 
 
-async def get_managed_objects(bus, loop, object_path_filter=None):
+async def get_managed_objects(bus, object_path_filter=None):
     objects = await bus.callRemote(
         "/",
         "GetManagedObjects",
         interface="org.freedesktop.DBus.ObjectManager",
         destination="org.bluez",
-    ).asFuture(loop)
+    ).asFuture(asyncio.get_event_loop())
     if object_path_filter:
         return dict(
             filter(lambda i: i[0].startswith(object_path_filter), objects.items())

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -23,9 +23,8 @@ class BaseBleakClient(abc.ABC):
 
     """
 
-    def __init__(self, address, loop=None, **kwargs):
+    def __init__(self, address, **kwargs):
         self.address = address
-        self.loop = loop if loop else asyncio.get_event_loop()
 
         self.services = BleakGATTServiceCollection()
 
@@ -39,7 +38,7 @@ class BaseBleakClient(abc.ABC):
 
     def __repr__(self):
         return "<{0}, {1}, {2}>".format(
-            self.__class__.__name__, self.address, self.loop
+            self.__class__.__name__, self.address
         )
 
     # Async Context managers

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -6,7 +6,6 @@ Created on 2019-6-26 by kevincar <kevincarrolldavis@gmail.com>
 
 import logging
 import uuid
-from asyncio.events import AbstractEventLoop
 from typing import Callable, Any, Union
 
 from Foundation import NSData, CBUUID
@@ -31,15 +30,14 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
     Args:
         address (str): The uuid of the BLE peripheral to connect to.
-        loop (asyncio.events.AbstractEventLoop): The event loop to use.
 
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call during connect. Defaults to 2.0.
 
     """
 
-    def __init__(self, address: str, loop: AbstractEventLoop = None, **kwargs):
-        super(BleakClientCoreBluetooth, self).__init__(address, loop, **kwargs)
+    def __init__(self, address: str, **kwargs):
+        super(BleakClientCoreBluetooth, self).__init__(address, **kwargs)
 
         self._device_info = None
         self._requester = None
@@ -62,7 +60,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         """
         timeout = kwargs.get("timeout", self._timeout)
-        devices = await discover(timeout=timeout, loop=self.loop)
+        devices = await discover(timeout=timeout)
         sought_device = list(
             filter(lambda x: x.address.upper() == self.address.upper(), devices)
         )
@@ -101,7 +99,9 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         """
         self._disconnected_callback = callback
-        cbapp.central_manager_delegate.disconnected_callback = self._disconnect_callback_client
+        cbapp.central_manager_delegate.disconnected_callback = (
+            self._disconnect_callback_client
+        )
 
     def _disconnect_callback_client(self):
         """
@@ -161,7 +161,9 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self._services = services
         return self.services
 
-    async def read_gatt_char(self, _uuid: Union[str, uuid.UUID], use_cached=False, **kwargs) -> bytearray:
+    async def read_gatt_char(
+        self, _uuid: Union[str, uuid.UUID], use_cached=False, **kwargs
+    ) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
         Args:

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -8,25 +8,20 @@ Created on 2019-06-24 by kevincar <kevincarrolldavis@gmail.com>
 """
 
 import asyncio
-from asyncio.events import AbstractEventLoop
 from typing import List
 
 from bleak.backends.corebluetooth import CBAPP as cbapp
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
-async def discover(
-    timeout: float = 5.0, loop: AbstractEventLoop = None, **kwargs
-) -> List[BLEDevice]:
+
+async def discover(timeout: float = 5.0, **kwargs) -> List[BLEDevice]:
     """Perform a Bluetooth LE Scan.
 
     Args:
         timeout (float): duration of scanning period
-        loop (Event Loop): Event Loop to use
 
     """
-    loop = loop if loop else asyncio.get_event_loop()
-
     if not cbapp.central_manager_delegate.enabled:
         raise BleakError("Bluetooth device is turned off")
 
@@ -39,7 +34,5 @@ async def discover(
     # with this, CoreBluetooth utilizes UUIDs for each peripheral. We'll use
     # this for the BLEDevice address on macOS
 
-
     devices = cbapp.central_manager_delegate.devices
     return list(devices.values())
-

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -2,7 +2,6 @@ import logging
 import asyncio
 import pathlib
 import uuid
-from asyncio.events import AbstractEventLoop
 from typing import Callable, Any, Union, List
 
 from bleak.backends.corebluetooth import CBAPP as cbapp
@@ -26,16 +25,14 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
     with this, CoreBluetooth utilizes UUIDs for each peripheral. Bleak uses
     this for the BLEDevice address on macOS.
 
-    Args:
-        loop (asyncio.events.AbstractEventLoop): The event loop to use.
-
     Keyword Args:
         timeout (double): The scanning timeout to be used, in case of missing
           ``stopScan_`` metod.
 
     """
-    def __init__(self, loop: AbstractEventLoop = None, **kwargs):
-        super(BleakScannerCoreBluetooth, self).__init__(loop, **kwargs)
+
+    def __init__(self, **kwargs):
+        super(BleakScannerCoreBluetooth, self).__init__(**kwargs)
 
         if not cbapp.central_manager_delegate.enabled:
             raise BleakError("Bluetooth device is turned off")
@@ -103,5 +100,4 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             return cbapp.central_manager_delegate.isScanning_
         except:
             return None
-
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -8,7 +8,6 @@ Created on 2017-12-05 by hbldh <henrik.blidh@nedomkull.com>
 import logging
 import asyncio
 import uuid
-from asyncio.events import AbstractEventLoop
 from functools import wraps
 from typing import Callable, Any, Union
 
@@ -72,15 +71,14 @@ class BleakClientDotNet(BaseBleakClient):
 
     Args:
         address (str): The MAC address of the BLE peripheral to connect to.
-        loop (asyncio.events.AbstractEventLoop): The event loop to use.
 
     Keyword Args:
             timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.
 
     """
 
-    def __init__(self, address: str, loop: AbstractEventLoop = None, **kwargs):
-        super(BleakClientDotNet, self).__init__(address, loop, **kwargs)
+    def __init__(self, address: str, **kwargs):
+        super(BleakClientDotNet, self).__init__(address, **kwargs)
 
         # Backend specific. Python.NET objects.
         self._device_info = None
@@ -112,7 +110,7 @@ class BleakClientDotNet(BaseBleakClient):
         """
         # Try to find the desired device.
         timeout = kwargs.get("timeout", self._timeout)
-        devices = await discover(timeout=timeout, loop=self.loop)
+        devices = await discover(timeout=timeout)
         sought_device = list(
             filter(lambda x: x.address.upper() == self.address.upper(), devices)
         )
@@ -138,7 +136,6 @@ class BleakClientDotNet(BaseBleakClient):
                 BluetoothLEDevice.FromBluetoothAddressAsync(*args)
             ),
             return_type=BluetoothLEDevice,
-            loop=self.loop,
         )
 
         def _ConnectionStatusChanged_Handler(sender, args):
@@ -155,7 +152,7 @@ class BleakClientDotNet(BaseBleakClient):
             connected = True
         else:
             for _ in range(5):
-                await asyncio.sleep(0.2, loop=self.loop)
+                await asyncio.sleep(0.2)
                 connected = await self.is_connected()
                 if connected:
                     break
@@ -234,7 +231,6 @@ class BleakClientDotNet(BaseBleakClient):
                     self._requester.GetGattServicesAsync()
                 ),
                 return_type=GattDeviceServicesResult,
-                loop=self.loop,
             )
 
             if services_result.Status != GattCommunicationStatus.Success:
@@ -259,7 +255,6 @@ class BleakClientDotNet(BaseBleakClient):
                         service.GetCharacteristicsAsync()
                     ),
                     return_type=GattCharacteristicsResult,
-                    loop=self.loop,
                 )
                 self.services.add_service(BleakGATTServiceDotNet(service))
                 if characteristics_result.Status != GattCommunicationStatus.Success:
@@ -291,7 +286,6 @@ class BleakClientDotNet(BaseBleakClient):
                             characteristic.GetDescriptorsAsync()
                         ),
                         return_type=GattDescriptorsResult,
-                        loop=self.loop,
                     )
                     self.services.add_characteristic(
                         BleakGATTCharacteristicDotNet(characteristic)
@@ -358,7 +352,6 @@ class BleakClientDotNet(BaseBleakClient):
                 )
             ),
             return_type=GattReadResult,
-            loop=self.loop,
         )
         if read_result.Status == GattCommunicationStatus.Success:
             reader = DataReader.FromBuffer(IBuffer(read_result.Value))
@@ -411,7 +404,6 @@ class BleakClientDotNet(BaseBleakClient):
                 )
             ),
             return_type=GattReadResult,
-            loop=self.loop,
         )
         if read_result.Status == GattCommunicationStatus.Success:
             reader = DataReader.FromBuffer(IBuffer(read_result.Value))
@@ -467,7 +459,6 @@ class BleakClientDotNet(BaseBleakClient):
                 )
             ),
             return_type=GattWriteResult,
-            loop=self.loop,
         )
         if write_result.Status == GattCommunicationStatus.Success:
             logger.debug("Write Characteristic {0} : {1}".format(_uuid, data))
@@ -509,7 +500,6 @@ class BleakClientDotNet(BaseBleakClient):
                 descriptor.obj.WriteValueAsync(writer.DetachBuffer())
             ),
             return_type=GattWriteResult,
-            loop=self.loop,
         )
         if write_result.Status == GattCommunicationStatus.Success:
             logger.debug("Write Descriptor {0} : {1}".format(handle, data))
@@ -605,7 +595,7 @@ class BleakClientDotNet(BaseBleakClient):
             # TODO: Enable adding multiple handlers!
             self._callbacks[characteristic_obj.Uuid.ToString()] = TypedEventHandler[
                 GattCharacteristic, GattValueChangedEventArgs
-            ](_notification_wrapper(self.loop, callback))
+            ](_notification_wrapper(callback))
             self._bridge.AddValueChangedCallback(
                 characteristic_obj, self._callbacks[characteristic_obj.Uuid.ToString()]
             )
@@ -624,7 +614,6 @@ class BleakClientDotNet(BaseBleakClient):
                 )
             ),
             return_type=GattCommunicationStatus,
-            loop=self.loop,
         )
 
         if status != GattCommunicationStatus.Success:
@@ -656,7 +645,6 @@ class BleakClientDotNet(BaseBleakClient):
                 )
             ),
             return_type=GattCommunicationStatus,
-            loop=self.loop,
         )
 
         if status != GattCommunicationStatus.Success:
@@ -670,7 +658,7 @@ class BleakClientDotNet(BaseBleakClient):
             self._bridge.RemoveValueChangedCallback(characteristic.obj, callback)
 
 
-def _notification_wrapper(loop: AbstractEventLoop, func: Callable):
+def _notification_wrapper(func: Callable):
     @wraps(func)
     def dotnet_notification_parser(sender: Any, args: Any):
         # Return only the UUID string representation as sender.
@@ -679,7 +667,7 @@ def _notification_wrapper(loop: AbstractEventLoop, func: Callable):
         output = Array.CreateInstance(Byte, reader.UnconsumedBufferLength)
         reader.ReadBytes(output)
 
-        return loop.call_soon_threadsafe(
+        return asyncio.get_event_loop().call_soon_threadsafe(
             func, sender.Uuid.ToString(), bytearray(output)
         )
 

--- a/bleak/backends/dotnet/discovery.py
+++ b/bleak/backends/dotnet/discovery.py
@@ -9,7 +9,7 @@ import pathlib
 import logging
 import asyncio
 from typing import List
-from asyncio.events import AbstractEventLoop
+
 
 from bleak.backends.device import BLEDevice
 
@@ -26,14 +26,11 @@ logger = logging.getLogger(__name__)
 _here = pathlib.Path(__file__).parent
 
 
-async def discover(
-    timeout: float = 5.0, loop: AbstractEventLoop = None, **kwargs
-) -> List[BLEDevice]:
+async def discover(timeout: float = 5.0, **kwargs) -> List[BLEDevice]:
     """Perform a Bluetooth LE Scan using Windows.Devices.Bluetooth.Advertisement
 
     Args:
         timeout (float): Time to scan for.
-        loop (Event Loop): The event loop to use.
 
     Keyword Args:
         string_output (bool): If set to false, ``discover`` returns .NET
@@ -43,8 +40,6 @@ async def discover(
         List of strings or objects found.
 
     """
-    loop = loop if loop else asyncio.get_event_loop()
-
     watcher = BluetoothLEAdvertisementWatcher()
 
     devices = {}
@@ -87,7 +82,7 @@ async def discover(
 
     # Watcher works outside of the Python process.
     watcher.Start()
-    await asyncio.sleep(timeout, loop=loop)
+    await asyncio.sleep(timeout)
     watcher.Stop()
 
     try:
@@ -125,14 +120,11 @@ async def discover(
     return found
 
 
-async def discover_by_enumeration(
-    timeout: float = 5.0, loop: AbstractEventLoop = None, **kwargs
-) -> List[BLEDevice]:
+async def discover_by_enumeration(timeout: float = 5.0, **kwargs) -> List[BLEDevice]:
     """Perform a Bluetooth LE Scan using Windows.Devices.Enumeration
 
     Args:
         timeout (float): Time to scan for.
-        loop (Event Loop): The event loop to use.
 
     Keyword Args:
         string_output (bool): If set to false, ``discover`` returns .NET
@@ -142,8 +134,6 @@ async def discover_by_enumeration(
         List of strings or objects found.
 
     """
-    loop = loop if loop else asyncio.get_event_loop()
-
     requested_properties = Array[str](
         [
             "System.Devices.Aep.DeviceAddress",
@@ -221,7 +211,7 @@ async def discover_by_enumeration(
 
     # Watcher works outside of the Python process.
     watcher.Start()
-    await asyncio.sleep(timeout, loop=loop)
+    await asyncio.sleep(timeout)
     watcher.Stop()
 
     try:

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -2,7 +2,6 @@ import logging
 import asyncio
 import pathlib
 import uuid
-from asyncio.events import AbstractEventLoop
 from functools import wraps
 from typing import Callable, Any, Union, List
 
@@ -45,9 +44,6 @@ class BleakScannerDotNet(BaseBleakScanner):
     Implemented using `pythonnet <https://pythonnet.github.io/>`_, a package that provides an integration to the .NET
     Common Language Runtime (CLR). Therefore, much of the code below has a distinct C# feel.
 
-    Args:
-        loop (asyncio.events.AbstractEventLoop): The event loop to use.
-
     Keyword Args:
         scanning mode (str): Set to "Passive" to avoid the "Active" scanning mode.
         SignalStrengthFilter (Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter): A
@@ -59,8 +55,8 @@ class BleakScannerDotNet(BaseBleakScanner):
 
     """
 
-    def __init__(self, loop: AbstractEventLoop = None, **kwargs):
-        super(BleakScannerDotNet, self).__init__(loop, **kwargs)
+    def __init__(self, **kwargs):
+        super(BleakScannerDotNet, self).__init__(**kwargs)
 
         self.watcher = None
         self._devices = {}

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -1,21 +1,12 @@
 import abc
 import asyncio
-from asyncio import AbstractEventLoop
 from typing import Callable, List
 
 from bleak.backends.device import BLEDevice
 
 
 class BaseBleakScanner(abc.ABC):
-    """Interface for Bleak Bluetooth LE Scanners
-
-    Args:
-        loop (Event Loop): The event loop to use.
-
-    """
-
-    def __init__(self, loop: AbstractEventLoop = None, **kwargs):
-        self.loop = loop if loop else asyncio.get_event_loop()
+    """Interface for Bleak Bluetooth LE Scanners"""
 
     async def __aenter__(self):
         await self.start()
@@ -25,11 +16,9 @@ class BaseBleakScanner(abc.ABC):
         await self.stop()
 
     @classmethod
-    async def discover(
-        cls, timeout=5.0, loop: AbstractEventLoop = None, **kwargs
-    ) -> List[BLEDevice]:
-        async with cls(loop, **kwargs) as scanner:
-            await asyncio.sleep(timeout if timeout > 0.0 else 0.1, loop=loop)
+    async def discover(cls, timeout=5.0, **kwargs) -> List[BLEDevice]:
+        async with cls(**kwargs) as scanner:
+            await asyncio.sleep(timeout if timeout > 0.0 else 0.1)
             devices = await scanner.get_discovered_devices()
         return devices
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,13 +14,13 @@ via the asyncronous context manager like this:
     address = "24:71:89:cc:09:05"
     MODEL_NBR_UUID = "00002a24-0000-1000-8000-00805f9b34fb"
 
-    async def run(address, loop):
-        async with BleakClient(address, loop=loop) as client:
+    async def run(address):
+        async with BleakClient(address) as client:
             model_number = await client.read_gatt_char(MODEL_NBR_UUID)
             print("Model Number: {0}".format("".join(map(chr, model_number))))
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(address, loop))
+    loop.run_until_complete(run(address))
 
 or one can do it without the context manager like this:
 
@@ -32,8 +32,8 @@ or one can do it without the context manager like this:
     address = "24:71:89:cc:09:05"
     MODEL_NBR_UUID = "00002a24-0000-1000-8000-00805f9b34fb"
 
-    async def run(address, loop):
-        client = BleakClient(address, loop=loop)
+    async def run(address):
+        client = BleakClient(address)
         try:
             await client.connect()
             model_number = await client.read_gatt_char(MODEL_NBR_UUID)
@@ -44,7 +44,7 @@ or one can do it without the context manager like this:
             await client.disconnect()
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(address, loop))
+    loop.run_until_complete(run(address))
 
 Try to make sure you always get to call the disconnect method for a client before discarding it;
 the Bluetooth stack on the OS might need to be cleared of residual data which is cached in the

--- a/examples/disconnect_callback.py
+++ b/examples/disconnect_callback.py
@@ -13,13 +13,13 @@ import asyncio
 from bleak import BleakClient
 
 
-async def show_disconnect_handling(mac_addr: str, loop: asyncio.AbstractEventLoop):
-    async with BleakClient(mac_addr, loop=loop) as client:
+async def show_disconnect_handling(mac_addr: str):
+    async with BleakClient(mac_addr) as client:
         disconnected_event = asyncio.Event()
 
         def disconnect_callback(client, future):
             print("Disconnected callback called!")
-            loop.call_soon_threadsafe(disconnected_event.set)
+            asyncio.get_event_loop().call_soon_threadsafe(disconnected_event.set)
 
         client.set_disconnected_callback(disconnect_callback)
         print("Sleeping until device disconnects according to BlueZ...")
@@ -30,4 +30,4 @@ async def show_disconnect_handling(mac_addr: str, loop: asyncio.AbstractEventLoo
 
 mac_addr = "24:71:89:cc:09:05"
 loop = asyncio.get_event_loop()
-loop.run_until_complete(show_disconnect_handling(mac_addr, loop))
+loop.run_until_complete(show_disconnect_handling(mac_addr))

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -27,11 +27,10 @@ def notification_handler(sender, data):
     print("{0}: {1}".format(sender, data))
 
 
-async def run(address, loop, debug=False):
+async def run(address, debug=False):
     if debug:
         import sys
 
-        # loop.set_debug(True)
         l = logging.getLogger("asyncio")
         l.setLevel(logging.DEBUG)
         h = logging.StreamHandler(sys.stdout)
@@ -39,12 +38,12 @@ async def run(address, loop, debug=False):
         l.addHandler(h)
         logger.addHandler(h)
 
-    async with BleakClient(address, loop=loop) as client:
+    async with BleakClient(address) as client:
         x = await client.is_connected()
         logger.info("Connected: {0}".format(x))
 
         await client.start_notify(CHARACTERISTIC_UUID, notification_handler)
-        await asyncio.sleep(5.0, loop=loop)
+        await asyncio.sleep(5.0)
         await client.stop_notify(CHARACTERISTIC_UUID)
 
 
@@ -58,4 +57,5 @@ if __name__ == "__main__":
         else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"  # <--- Change to your device's address here if you are using macOS
     )
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(address, loop, True))
+    # loop.set_debug(True)
+    loop.run_until_complete(run(address, True))

--- a/examples/get_services.py
+++ b/examples/get_services.py
@@ -14,8 +14,8 @@ import platform
 from bleak import BleakClient
 
 
-async def print_services(mac_addr: str, loop: asyncio.AbstractEventLoop):
-    async with BleakClient(mac_addr, loop=loop) as client:
+async def print_services(mac_addr: str):
+    async with BleakClient(mac_addr) as client:
         svcs = await client.get_services()
         print("Services:", svcs)
 
@@ -26,4 +26,4 @@ mac_addr = (
     else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"
 )
 loop = asyncio.get_event_loop()
-loop.run_until_complete(print_services(mac_addr, loop))
+loop.run_until_complete(print_services(mac_addr))

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -93,18 +93,17 @@ IO_DATA_CHAR_UUID = "f000aa65-0451-4000-b000-000000000000"
 IO_CONFIG_CHAR_UUID = "f000aa66-0451-4000-b000-000000000000"
 
 
-async def run(address, loop, debug=False):
+async def run(address, debug=False):
     if debug:
         import sys
 
-        # loop.set_debug(True)
         # l = logging.getLogger("asyncio")
         # l.setLevel(logging.DEBUG)
         # h = logging.StreamHandler(sys.stdout)
         # h.setLevel(logging.DEBUG)
         # l.addHandler(h)
 
-    async with BleakClient(address, loop=loop) as client:
+    async with BleakClient(address) as client:
         x = await client.is_connected()
         logger.info("Connected: {0}".format(x))
 
@@ -153,7 +152,7 @@ async def run(address, loop, debug=False):
         assert value == write_value
 
         await client.start_notify(KEY_PRESS_UUID, keypress_handler)
-        await asyncio.sleep(5.0, loop=loop)
+        await asyncio.sleep(5.0)
         await client.stop_notify(KEY_PRESS_UUID)
 
 
@@ -167,4 +166,5 @@ if __name__ == "__main__":
         else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"
     )
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(address, loop, True))
+    # loop.set_debug(True)
+    loop.run_until_complete(run(address, True))

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -15,18 +15,17 @@ import logging
 from bleak import BleakClient
 
 
-async def run(address, loop, debug=False):
+async def run(address, debug=False):
     log = logging.getLogger(__name__)
     if debug:
         import sys
 
-        loop.set_debug(True)
         log.setLevel(logging.DEBUG)
         h = logging.StreamHandler(sys.stdout)
         h.setLevel(logging.DEBUG)
         log.addHandler(h)
 
-    async with BleakClient(address, loop=loop) as client:
+    async with BleakClient(address) as client:
         x = await client.is_connected()
         log.info("Connected: {0}".format(x))
 
@@ -61,4 +60,5 @@ if __name__ == "__main__":
         else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"
     )
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(run(address, loop, True))
+    loop.set_debug(True)
+    loop.run_until_complete(run(address, True))


### PR DESCRIPTION
This removes most cases of passing the asyncio event loop as an argument (some cases are kept in the Linux backend for interop with txdbus/twisted).

Passing the loop as an argument has been deprecated in Python 3.8 and will be removed in 3.10.

Explanation: https://stackoverflow.com/a/60315290/1976323

This is a breaking change, but it seems better to do it now rather than wait for it to break in Python itself in a few years.