### PR TITLE
Feature/handles

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Removed
 
 * Removed documentation note about not using new event loops in Linux. This was fixed by #143.
 * ``_central_manager_delegate_ready`` was removed in macOS backend.
+* Removed the ``bleak.backends.bluez.utils.get_gatt_service_path`` method. It is not used by
+  bleak and possibly generates errors.
+
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 * Better feedback of communication errors to user in .NET backend and implementing error details proposed in #174.
 * Two devices example file to use for e.g. debugging.
 * Detection/discovery callbacks in Core Bluetooth backend ```Scanner`` implemented.
+* Characteristic handle printout in ``service_explorer.py``.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,10 @@ Changed
   with the event loop where the central manager was created. Fixes #111.
 * The Central Manager is no longer global in the Core Bluetooth backend. A new one is created for each
   ``BleakClient`` and ``BleakScanner``. Fixes #206 and #105.
+* Merged #167 and reworked characteristics handling in Bleak. Implemented in all backends;
+  bleak now uses the characteristics' handle to identify and keep track of them.
+  Fixes #139 and #159 and allows connection for devices with multiple instances
+  of the same characteristic UUIDs.
 * In ``requirements.txt`` and ``Pipfile``, the requirement on ``pythonnet``
   was bumped to version 2.5.1, which seems to solve issues described in #217 and #225.
 * Renamed ``HISTORY.rst`` to ``CHANGELOG.rst`` and adopted

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.6.5a5"
+__version__ = "0.6.5a6"

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -41,6 +41,11 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         return self.__service_uuid
 
     @property
+    def handle(self) -> int:
+        """The handle of this characteristic"""
+        return int(self.obj.get("Handle"))
+
+    @property
     def uuid(self) -> str:
         """The uuid of this characteristic"""
         return self.obj.get("UUID")

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -1,3 +1,4 @@
+import re
 from uuid import UUID
 from typing import Union, List
 
@@ -25,6 +26,8 @@ _GattCharacteristicsFlagsEnum = {
     # "authorize"
 }
 
+_handle_regex = re.compile('/char([0-9a-fA-F]*)')
+
 
 class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
     """GATT Characteristic implementation for the BlueZ DBus backend"""
@@ -35,6 +38,18 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         self.__path = object_path
         self.__service_uuid = service_uuid
 
+        # The `Handle` attribute is added in BlueZ Release 5.51. Empirically,
+        # it seems to hold true that the "/charYYYY" that is at the end of the
+        # DBUS path actually is the desired handle. Using regex to extract
+        # that and using as handle, since handle is mostly used for keeping
+        # track of characteristics (internally in bleak anyway).
+        self._handle = self.obj.get("Handle")
+        if not self._handle:
+            _handle_from_path = _handle_regex.search(self.path)
+            if _handle_from_path:
+                self._handle = int(_handle_from_path.groups()[0], 16)
+        self._handle = int(self._handle)
+
     @property
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
@@ -43,7 +58,7 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
     @property
     def handle(self) -> int:
         """The handle of this characteristic"""
-        return int(self.obj.get("Handle"))
+        return self._handle
 
     @property
     def uuid(self) -> str:

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -70,11 +70,14 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         return self.__descriptors
 
     def get_descriptor(
-        self, _uuid: Union[str, UUID]
+        self, specifier: Union[int, str, UUID]
     ) -> Union[BleakGATTDescriptor, None]:
-        """Get a descriptor by UUID"""
+        """Get a descriptor by handle (int) or UUID (str or uuid.UUID)"""
         try:
-            return next(filter(lambda x: x.uuid == _uuid, self.descriptors))
+            if isinstance(specifier, int):
+                return next(filter(lambda x: x.handle == specifier, self.descriptors))
+            else:
+                return next(filter(lambda x: x.uuid == str(specifier), self.descriptors))
         except StopIteration:
             return None
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -326,7 +326,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 )
             )
             self.services.add_descriptor(
-                BleakGATTDescriptorBlueZDBus(desc, object_path, _characteristic[0].uuid)
+                BleakGATTDescriptorBlueZDBus(desc, object_path, _characteristic[0].uuid, int(_characteristic[0].handle))
             )
 
         self._services_resolved = True

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -11,6 +11,7 @@ from functools import wraps, partial
 from typing import Callable, Any, Union
 
 from bleak.backends.service import BleakGATTServiceCollection
+from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
 from bleak.backends.client import BaseBleakClient
 from bleak.backends.bluezdbus import defs, signals, utils, get_reactor
@@ -239,6 +240,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         await self._cleanup_dbus_resources()
 
+        self.services = BleakGATTServiceCollection()
+
         return is_disconnected
 
     async def is_connected(self) -> bool:
@@ -334,21 +337,27 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
     # IO methods
 
-    async def read_gatt_char(self, _uuid: Union[str, uuid.UUID], **kwargs) -> bytearray:
+    async def read_gatt_char(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], **kwargs) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to read from.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to read from,
+                specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
 
         Returns:
             (bytearray) The read data.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
+
         if not characteristic:
             # Special handling for BlueZ >= 5.48, where Battery Service (0000180f-0000-1000-8000-00805f9b34fb:)
             # has been moved to interface org.bluez.Battery1 instead of as a regular service.
-            if _uuid == "00002a19-0000-1000-8000-00805f9b34fb" and (
+            if str(char_specifier) == "00002a19-0000-1000-8000-00805f9b34fb" and (
                 self._bluez_version[0] == 5 and self._bluez_version[1] >= 48
             ):
                 props = await self._get_device_properties(
@@ -358,11 +367,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 value = bytearray([props.get("Percentage", "")])
                 logger.debug(
                     "Read Battery Level {0} | {1}: {2}".format(
-                        _uuid, self._device_path, value
+                        char_specifier, self._device_path, value
                     )
                 )
                 return value
-            if str(_uuid) == "00002a00-0000-1000-8000-00805f9b34fb" and (
+            if str(char_specifier) == "00002a00-0000-1000-8000-00805f9b34fb" and (
                 self._bluez_version[0] == 5 and self._bluez_version[1] >= 48
             ):
                 props = await self._get_device_properties(
@@ -372,13 +381,13 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 value = bytearray(props.get("Name", "").encode("ascii"))
                 logger.debug(
                     "Read Device Name {0} | {1}: {2}".format(
-                        _uuid, self._device_path, value
+                        char_specifier, self._device_path, value
                     )
                 )
                 return value
 
             raise BleakError(
-                "Characteristic with UUID {0} could not be found!".format(_uuid)
+                "Characteristic with UUID {0} could not be found!".format(char_specifier)
             )
 
         value = bytearray(
@@ -395,7 +404,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         logger.debug(
             "Read Characteristic {0} | {1}: {2}".format(
-                _uuid, characteristic.path, value
+                characteristic.uuid, characteristic.path, value
             )
         )
         return value
@@ -432,13 +441,13 @@ class BleakClientBlueZDBus(BaseBleakClient):
         return value
 
     async def write_gatt_char(
-        self, _uuid: Union[str, uuid.UUID], data: bytearray, response: bool = False
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], data: bytearray, response: bool = False
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
 
         NB: the version check below is for the "type" option to the
         "Characteristic.WriteValue" method that was added to Bluez in 5.50
-        ttps://git.kernel.org/pub/scm/bluetooth/bluez.git/commit?id=fa9473bcc48417d69cc9ef81d41a72b18e34a55a
+        https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit?id=fa9473bcc48417d69cc9ef81d41a72b18e34a55a
         Before that commit, "Characteristic.WriteValue" was only "Write with
         response". "Characteristic.AcquireWrite" was added in Bluez 5.46
         https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit/doc/gatt-api.txt?id=f59f3dedb2c79a75e51a3a0d27e2ae06fefc603e
@@ -446,21 +455,26 @@ class BleakClientBlueZDBus(BaseBleakClient):
         of Bluez, it is not possible to "Write without response".
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to write to.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to write
+                to, specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
             data (bytes or bytearray): The data to send.
             response (bool): If write-with-response operation should be done. Defaults to `False`.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
-        if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
 
+        if not characteristic:
+            raise BleakError("Characteristic {0} was not found!".format(char_specifier))
         if (
             "write" not in characteristic.properties
             and "write-without-response" not in characteristic.properties
         ):
             raise BleakError(
-                "Characteristic %s does not support write operations!" % str(_uuid)
+                "Characteristic %s does not support write operations!" % str(characteristic.uuid)
             )
         if not response and "write-without-response" not in characteristic.properties:
             response = True
@@ -473,7 +487,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             response = False
             logger.warning(
                 "Characteristic %s does not support Write with response. Trying without..."
-                % str(_uuid)
+                % str(characteristic.uuid)
             )
 
         # See docstring for details about this handling.
@@ -508,7 +522,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         logger.debug(
             "Write Characteristic {0} | {1}: {2}".format(
-                _uuid, characteristic.path, data
+                characteristic.uuid, characteristic.path, data
             )
         )
 
@@ -539,7 +553,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
     async def start_notify(
         self,
-        _uuid: Union[str, uuid.UUID],
+        char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
         callback: Callable[[str, Any], Any],
         **kwargs
     ) -> None:
@@ -555,7 +569,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
             client.start_notify(char_uuid, callback)
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to start notification on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to activate
+                notifications/indications on a characteristic, specified by either integer handle,
+                UUID or directly by the BleakGATTCharacteristic object representing it.
             callback (function): The function to be called on notification.
 
         Keyword Args:
@@ -564,22 +580,26 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         """
         _wrap = kwargs.get("notification_wrapper", True)
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
+
         if not characteristic:
             # Special handling for BlueZ >= 5.48, where Battery Service (0000180f-0000-1000-8000-00805f9b34fb:)
             # has been moved to interface org.bluez.Battery1 instead of as a regular service.
             # The org.bluez.Battery1 on the other hand does not provide a notification method, so here we cannot
             # provide this functionality...
             # See https://kernel.googlesource.com/pub/scm/bluetooth/bluez/+/refs/tags/5.48/doc/battery-api.txt
-            if str(_uuid) == "00002a19-0000-1000-8000-00805f9b34fb" and (
+            if str(char_specifier) == "00002a19-0000-1000-8000-00805f9b34fb" and (
                 self._bluez_version[0] == 5 and self._bluez_version[1] >= 48
             ):
                 raise BleakError(
                     "Notifications on Battery Level Char ({0}) is not "
-                    "possible in BlueZ >= 5.48. Use regular read instead.".format(_uuid)
+                    "possible in BlueZ >= 5.48. Use regular read instead.".format(char_specifier)
                 )
             raise BleakError(
-                "Characteristic with UUID {0} could not be found!".format(_uuid)
+                "Characteristic with UUID {0} could not be found!".format(char_specifier)
             )
         await self._bus.callRemote(
             characteristic.path,
@@ -604,18 +624,24 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 callback, self._char_path_to_uuid
             )  # noqa | E123 error in flake8...
 
-        self._subscriptions.append(str(_uuid))
+        self._subscriptions.append(characteristic.handle)
 
-    async def stop_notify(self, _uuid: Union[str, uuid.UUID]) -> None:
+    async def stop_notify(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]) -> None:
         """Deactivate notification/indication on a specified characteristic.
 
         Args:
-            _uuid: The characteristic to stop notifying/indicating on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to deactivate
+                notification/indication on, specified by either integer handle, UUID or
+                directly by the BleakGATTCharacteristic object representing it.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+            raise BleakError("Characteristic {} not found!".format(char_specifier))
+
         await self._bus.callRemote(
             characteristic.path,
             "StopNotify",
@@ -627,25 +653,31 @@ class BleakClientBlueZDBus(BaseBleakClient):
         ).asFuture(self.loop)
         self._notification_callbacks.pop(characteristic.path, None)
 
-        self._subscriptions.remove(str(_uuid))
+        self._subscriptions.remove(characteristic.handle)
 
     # DBUS introspection method for characteristics.
 
-    async def get_all_for_characteristic(self, _uuid: Union[str, uuid.UUID]) -> dict:
+    async def get_all_for_characteristic(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]) -> dict:
         """Get all properties for a characteristic.
 
         This method should generally not be needed by end user, since it is a DBus specific method.
 
         Args:
-            _uuid: The characteristic to get properties for.
+            char_specifier: The characteristic to get properties for, specified by either
+                integer handle, UUID or directly by the BleakGATTCharacteristic
+                object representing it.
 
         Returns:
             (dict) Properties dictionary
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+            raise BleakError("Characteristic {} not found!".format(char_specifier))
+
         out = await self._bus.callRemote(
             characteristic.path,
             "GetAll",

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -108,7 +108,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # A Discover must have been run before connecting to any devices. Do a quick one here
         # to ensure that it has been done.
         timeout = kwargs.get("timeout", self._timeout)
-        await discover(timeout=timeout, device=self.device, loop=self.loop)
+        discovered = await discover(timeout=timeout, device=self.device, loop=self.loop)
 
         self._reactor = get_reactor(self.loop)
 
@@ -116,7 +116,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         self._bus = await txdbus_connect(self._reactor, busAddress="system").asFuture(
             self.loop
         )
-        # TODO: Handle path errors from txdbus/dbus
+        # TODO: Build this device path differently. Need to get it from BlueZ backend for proper path...
         self._device_path = get_device_object_path(self.device, self.address)
 
         def _services_resolved_callback(message):

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 import uuid
 from asyncio import Future
-from asyncio.events import AbstractEventLoop
 from functools import wraps, partial
 from typing import Callable, Any, Union
 
@@ -104,7 +103,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             Boolean representing connection status.
 
         """
-
         # A Discover must have been run before connecting to any devices. Do a quick one here
         # to ensure that it has been done.
         timeout = kwargs.get("timeout", self._timeout)

--- a/bleak/backends/bluezdbus/descriptor.py
+++ b/bleak/backends/bluezdbus/descriptor.py
@@ -4,11 +4,17 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 class BleakGATTDescriptorBlueZDBus(BleakGATTDescriptor):
     """GATT Descriptor implementation for BlueZ DBus backend"""
 
-    def __init__(self, obj: dict, object_path: str, characteristic_uuid: str):
+    def __init__(self, obj: dict, object_path: str, characteristic_uuid: str, characteristic_handle: int):
         super(BleakGATTDescriptorBlueZDBus, self).__init__(obj)
         self.__path = object_path
         self.__characteristic_uuid = characteristic_uuid
+        self.__characteristic_handle = characteristic_handle
         self.__handle = int(self.path.split("/")[-1].replace("desc", ""), 16)
+
+    @property
+    def characteristic_handle(self) -> int:
+        """handle for the characteristic that this descriptor belongs to"""
+        return self.__characteristic_handle
 
     @property
     def characteristic_uuid(self) -> str:

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -45,9 +45,16 @@ class BleakGATTCharacteristic(abc.ABC):
 
     @property
     @abc.abstractmethod
+    def handle(self) -> int:
+        """The handle for this characteristic"""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
     def uuid(self) -> str:
         """The UUID for this characteristic"""
         raise NotImplementedError()
+
 
     @property
     @abc.abstractmethod

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -55,7 +55,6 @@ class BleakGATTCharacteristic(abc.ABC):
         """The UUID for this characteristic"""
         raise NotImplementedError()
 
-
     @property
     @abc.abstractmethod
     def description(self) -> str:
@@ -75,8 +74,8 @@ class BleakGATTCharacteristic(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_descriptor(self, _uuid: Union[str, UUID]) -> Union[BleakGATTDescriptor, None]:
-        """Get a descriptor by UUID"""
+    def get_descriptor(self, specifier: Union[int, str, UUID]) -> Union[BleakGATTDescriptor, None]:
+        """Get a descriptor by handle (int) or UUID (str or uuid.UUID)"""
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -11,6 +11,7 @@ import uuid
 from typing import Callable, Any, Union
 
 from bleak.backends.service import BleakGATTServiceCollection
+from bleak.backends.characteristic import BleakGATTCharacteristic
 
 
 class BaseBleakClient(abc.ABC):
@@ -122,11 +123,13 @@ class BaseBleakClient(abc.ABC):
     # I/O methods
 
     @abc.abstractmethod
-    async def read_gatt_char(self, _uuid: Union[str, uuid.UUID], **kwargs) -> bytearray:
+    async def read_gatt_char(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], **kwargs) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to read from.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to read from,
+                specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
 
         Returns:
             (bytearray) The read data.
@@ -149,12 +152,14 @@ class BaseBleakClient(abc.ABC):
 
     @abc.abstractmethod
     async def write_gatt_char(
-        self, _uuid: Union[str, uuid.UUID], data: bytearray, response: bool = False
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], data: bytearray, response: bool = False
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to write to.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to write
+                to, specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
             data (bytes or bytearray): The data to send.
             response (bool): If write-with-response operation should be done. Defaults to `False`.
 
@@ -174,7 +179,7 @@ class BaseBleakClient(abc.ABC):
 
     @abc.abstractmethod
     async def start_notify(
-        self, _uuid: Union[str, uuid.UUID], callback: Callable[[str, Any], Any], **kwargs
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], callback: Callable[[str, Any], Any], **kwargs
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
@@ -188,18 +193,22 @@ class BaseBleakClient(abc.ABC):
             client.start_notify(char_uuid, callback)
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to start notification/indication on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to activate
+                notifications/indications on a characteristic, specified by either integer handle,
+                UUID or directly by the BleakGATTCharacteristic object representing it.
             callback (function): The function to be called on notification.
 
         """
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def stop_notify(self, _uuid: Union[str, uuid.UUID]) -> None:
+    async def stop_notify(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]) -> None:
         """Deactivate notification/indication on a specified characteristic.
 
         Args:
-            _uuid: The characteristic to stop notifying/indicating on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to deactivate
+                notification/indication on, specified by either integer handle, UUID or
+                directly by the BleakGATTCharacteristic object representing it.
 
         """
         raise NotImplementedError()

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -76,6 +76,11 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
         return self.obj.service().UUID().UUIDString()
 
     @property
+    def handle(self) -> int:
+        """Integer handle for this characteristic"""
+        return int(self.obj.handle())
+
+    @property
     def uuid(self) -> str:
         """The uuid of this characteristic"""
         return self.obj.UUID().UUIDString()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -20,6 +20,8 @@ from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluet
 from bleak.backends.corebluetooth.discovery import discover
 from bleak.backends.corebluetooth.service import BleakGATTServiceCoreBluetooth
 from bleak.backends.service import BleakGATTServiceCollection
+from bleak.backends.characteristic import BleakGATTCharacteristic
+
 from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
@@ -87,6 +89,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         """Disconnect from the peripheral device"""
         manager = self._device_info.manager().delegate()
         await manager.disconnect()
+        self.services = BleakGATTServiceCollection()
         return True
 
     async def is_connected(self) -> bool:
@@ -165,11 +168,13 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self._services = services
         return self.services
 
-    async def read_gatt_char(self, _uuid: Union[str, uuid.UUID], use_cached=False, **kwargs) -> bytearray:
+    async def read_gatt_char(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], use_cached=False, **kwargs) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to read from.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to read from,
+                specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
             use_cached (bool): `False` forces macOS to read the value from the
                 device again and not use its own cached value. Defaults to `False`.
 
@@ -178,16 +183,19 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         """
         manager = self._device_info.manager().delegate()
-        _uuid = await self.get_appropriate_uuid(str(_uuid))
-        characteristic = self.services.get_characteristic(str(_uuid))
+
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {} was not found!".format(_uuid))
+            raise BleakError("Characteristic {} was not found!".format(char_specifier))
 
         output = await manager.connected_peripheral_delegate.readCharacteristic_(
             characteristic.obj, use_cached=use_cached
         )
         value = bytearray(output)
-        logger.debug("Read Characteristic {0} : {1}".format(_uuid, value))
+        logger.debug("Read Characteristic {0} : {1}".format(characteristic.uuid, value))
         return value
 
     async def read_gatt_descriptor(
@@ -204,6 +212,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             (bytearray) The read data.
         """
         manager = self._device_info.manager().delegate()
+
         descriptor = self.services.get_descriptor(handle)
         if not descriptor:
             raise BleakError("Descriptor {} was not found!".format(handle))
@@ -221,21 +230,26 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         return value
 
     async def write_gatt_char(
-        self, _uuid: Union[str, uuid.UUID], data: bytearray, response: bool = False
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], data: bytearray, response: bool = False
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to write to.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to write
+                to, specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
             data (bytes or bytearray): The data to send.
             response (bool): If write-with-response operation should be done. Defaults to `False`.
 
         """
         manager = self._device_info.manager().delegate()
-        _uuid = await self.get_appropriate_uuid(str(_uuid))
-        characteristic = self.services.get_characteristic(str(_uuid))
+
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {} was not found!".format(_uuid))
+            raise BleakError("Characteristic {} was not found!".format(char_specifier))
 
         value = NSData.alloc().initWithBytes_length_(data, len(data))
         success = await manager.connected_peripheral_delegate.writeCharacteristic_value_type_(
@@ -244,7 +258,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             CBCharacteristicWriteWithResponse if response else CBCharacteristicWriteWithoutResponse
         )
         if success:
-            logger.debug("Write Characteristic {0} : {1}".format(_uuid, data))
+            logger.debug("Write Characteristic {0} : {1}".format(characteristic.uuid, data))
         else:
             raise BleakError(
                 "Could not write value {0} to characteristic {1}: {2}".format(
@@ -261,6 +275,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         """
         manager = self._device_info.manager().delegate()
+
         descriptor = self.services.get_descriptor(handle)
         if not descriptor:
             raise BleakError("Descriptor {} was not found!".format(handle))
@@ -279,7 +294,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             )
 
     async def start_notify(
-        self, _uuid: Union[str, uuid.UUID], callback: Callable[[str, Any], Any], **kwargs
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], callback: Callable[[str, Any], Any], **kwargs
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
@@ -293,15 +308,20 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             client.start_notify(char_uuid, callback)
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to start notification/indication on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to activate
+                notifications/indications on a characteristic, specified by either integer handle,
+                UUID or directly by the BleakGATTCharacteristic object representing it.
             callback (function): The function to be called on notification.
 
         """
         manager = self._device_info.manager().delegate()
-        _uuid = await self.get_appropriate_uuid(str(_uuid))
-        characteristic = self.services.get_characteristic(str(_uuid))
+
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} not found!".format(_uuid))
+            raise BleakError("Characteristic {0} not found!".format(char_specifier))
 
         success = await manager.connected_peripheral_delegate.startNotify_cb_(
             characteristic.obj, callback
@@ -313,18 +333,24 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 )
             )
 
-    async def stop_notify(self, _uuid: Union[str, uuid.UUID]) -> None:
+    async def stop_notify(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]) -> None:
         """Deactivate notification/indication on a specified characteristic.
 
         Args:
-            _uuid: The characteristic to stop notifying/indicating on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to deactivate
+                notification/indication on, specified by either integer handle, UUID or
+                directly by the BleakGATTCharacteristic object representing it.
+
 
         """
         manager = self._device_info.manager().delegate()
-        _uuid = await self.get_appropriate_uuid(str(_uuid))
-        characteristic = self.services.get_characteristic(str(_uuid))
+
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {} not found!".format(_uuid))
+            raise BleakError("Characteristic {} not found!".format(char_specifier))
 
         success = await manager.connected_peripheral_delegate.stopNotify_(
             characteristic.obj
@@ -333,32 +359,3 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             raise BleakError(
                 "Could not stop notify on {0}: {1}".format(characteristic.uuid, success)
             )
-
-    async def get_appropriate_uuid(self, _uuid: str) -> str:
-        if len(_uuid) == 4:
-            return _uuid.upper()
-
-        if await self.is_uuid_16bit_compatible(_uuid):
-            return _uuid[4:8].upper()
-
-        return _uuid.upper()
-
-    async def is_uuid_16bit_compatible(self, _uuid: str) -> bool:
-        test_uuid = "0000FFFF-0000-1000-8000-00805F9B34FB"
-        test_int = await self.convert_uuid_to_int(test_uuid)
-        uuid_int = await self.convert_uuid_to_int(_uuid)
-        result_int = uuid_int & test_int
-        return uuid_int == result_int
-
-    async def convert_uuid_to_int(self, _uuid: str) -> int:
-        UUID_cb = CBUUID.alloc().initWithString_(_uuid)
-        UUID_data = UUID_cb.data()
-        UUID_bytes = UUID_data.getBytes_length_(None, len(UUID_data))
-        UUID_int = int.from_bytes(UUID_bytes, byteorder="big")
-        return UUID_int
-
-    async def convert_int_to_uuid(self, i: int) -> str:
-        UUID_bytes = i.to_bytes(length=16, byteorder="big")
-        UUID_data = NSData.alloc().initWithBytes_length_(UUID_bytes, len(UUID_bytes))
-        UUID_cb = CBUUID.alloc().initWithData_(UUID_data)
-        return UUID_cb.UUIDString()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -158,7 +158,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 for descriptor in descriptors:
                     self.services.add_descriptor(
                         BleakGATTDescriptorCoreBluetooth(
-                            descriptor, characteristic.UUID().UUIDString()
+                            descriptor, characteristic.UUID().UUIDString(), int(characteristic.handle())
                         )
                     )
         self._services_resolved = True

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -12,14 +12,19 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
     """GATT Descriptor implementation for CoreBluetooth backend"""
 
-    def __init__(self, obj: CBDescriptor, characteristic_uuid: str):
+    def __init__(self, obj: CBDescriptor, characteristic_uuid: str, characteristic_handle: int):
         super(BleakGATTDescriptorCoreBluetooth, self).__init__(obj)
-
         self.obj = obj
         self.__characteristic_uuid = characteristic_uuid
+        self.__characteristic_handle = characteristic_handle
 
     def __str__(self):
         return "{0}: (Handle: {1})".format(self.uuid, self.handle)
+
+    @property
+    def characteristic_handle(self) -> int:
+        """handle for the characteristic that this descriptor belongs to"""
+        return self.__characteristic_handle
 
     @property
     def characteristic_uuid(self) -> str:

--- a/bleak/backends/corebluetooth/utils.py
+++ b/bleak/backends/corebluetooth/utils.py
@@ -1,0 +1,34 @@
+from Foundation import NSData, CBUUID
+
+
+def cb_uuid_to_str(_uuid: str) -> str:
+    if len(_uuid) == 4:
+        return '0000{0}-0000-1000-8000-00805f9b34fb'.format(_uuid.lower())
+    # TODO: Evaluate if this is a necessary method...
+    # elif _is_uuid_16bit_compatible(_uuid):
+    #    return _uuid[4:8].lower()
+    else:
+        return _uuid.lower()
+
+
+def _is_uuid_16bit_compatible(_uuid: str) -> bool:
+    test_uuid = "0000FFFF-0000-1000-8000-00805F9B34FB"
+    test_int = _convert_uuid_to_int(test_uuid)
+    uuid_int = _convert_uuid_to_int(_uuid)
+    result_int = uuid_int & test_int
+    return uuid_int == result_int
+
+
+def _convert_uuid_to_int(_uuid: str) -> int:
+    UUID_cb = CBUUID.alloc().initWithString_(_uuid)
+    UUID_data = UUID_cb.data()
+    UUID_bytes = UUID_data.getBytes_length_(None, len(UUID_data))
+    UUID_int = int.from_bytes(UUID_bytes, byteorder="big")
+    return UUID_int
+
+
+def _convert_int_to_uuid(i: int) -> str:
+    UUID_bytes = i.to_bytes(length=16, byteorder="big")
+    UUID_data = NSData.alloc().initWithBytes_length_(UUID_bytes, len(UUID_bytes))
+    UUID_cb = CBUUID.alloc().initWithData_(UUID_data)
+    return UUID_cb.UUIDString()

--- a/bleak/backends/descriptor.py
+++ b/bleak/backends/descriptor.py
@@ -48,6 +48,12 @@ class BleakGATTDescriptor(abc.ABC):
 
     @property
     @abc.abstractmethod
+    def characteristic_handle(self) -> int:
+        """handle for the characteristic that this descriptor belongs to"""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
     def uuid(self) -> str:
         """UUID for this descriptor"""
         raise NotImplementedError()

--- a/bleak/backends/descriptor.py
+++ b/bleak/backends/descriptor.py
@@ -8,27 +8,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 import abc
 from typing import Any
 
-
-_ = """Characteristic Aggregate Format	org.bluetooth.descriptor.gatt.characteristic_aggregate_format	0x2905	GSS
-Characteristic Extended Properties	org.bluetooth.descriptor.gatt.characteristic_extended_properties	0x2900	GSS
-Characteristic Presentation Format	org.bluetooth.descriptor.gatt.characteristic_presentation_format	0x2904	GSS
-Characteristic User Description	org.bluetooth.descriptor.gatt.characteristic_user_description	0x2901	GSS
-Client Characteristic Configuration	org.bluetooth.descriptor.gatt.client_characteristic_configuration	0x2902	GSS
-Environmental Sensing Configuration	org.bluetooth.descriptor.es_configuration	0x290B	GSS
-Environmental Sensing Measurement	org.bluetooth.descriptor.es_measurement	0x290C	GSS
-Environmental Sensing Trigger Setting	org.bluetooth.descriptor.es_trigger_setting	0x290D	GSS
-External Report Reference	org.bluetooth.descriptor.external_report_reference	0x2907	GSS
-Number of Digitals	org.bluetooth.descriptor.number_of_digitals	0x2909	GSS
-Report Reference	org.bluetooth.descriptor.report_reference	0x2908	GSS
-Server Characteristic Configuration	org.bluetooth.descriptor.gatt.server_characteristic_configuration	0x2903	GSS
-Time Trigger Setting	org.bluetooth.descriptor.time_trigger_setting	0x290E	GSS
-Valid Range	org.bluetooth.descriptor.valid_range	0x2906	GSS
-Value Trigger Setting	org.bluetooth.descriptor.value_trigger_setting	0x290A	GSS
-"""
-_descriptor_descriptions = {
-    "0000{0}-0000-1000-8000-00805f9b34fb".format(v[2][2:]): v
-    for v in [x.split("\t") for x in _.splitlines()]
-}
+_descriptor_descriptions = {'00002905-0000-1000-8000-00805f9b34fb': ['Characteristic Aggregate Format', 'org.bluetooth.descriptor.gatt.characteristic_aggregate_format', '0x2905', 'GSS'], '00002900-0000-1000-8000-00805f9b34fb': ['Characteristic Extended Properties', 'org.bluetooth.descriptor.gatt.characteristic_extended_properties', '0x2900', 'GSS'], '00002904-0000-1000-8000-00805f9b34fb': ['Characteristic Presentation Format', 'org.bluetooth.descriptor.gatt.characteristic_presentation_format', '0x2904', 'GSS'], '00002901-0000-1000-8000-00805f9b34fb': ['Characteristic User Description', 'org.bluetooth.descriptor.gatt.characteristic_user_description', '0x2901', 'GSS'], '00002902-0000-1000-8000-00805f9b34fb': ['Client Characteristic Configuration', 'org.bluetooth.descriptor.gatt.client_characteristic_configuration', '0x2902', 'GSS'], '0000290B-0000-1000-8000-00805f9b34fb': ['Environmental Sensing Configuration', 'org.bluetooth.descriptor.es_configuration', '0x290B', 'GSS'], '0000290C-0000-1000-8000-00805f9b34fb': ['Environmental Sensing Measurement', 'org.bluetooth.descriptor.es_measurement', '0x290C', 'GSS'], '0000290D-0000-1000-8000-00805f9b34fb': ['Environmental Sensing Trigger Setting', 'org.bluetooth.descriptor.es_trigger_setting', '0x290D', 'GSS'], '00002907-0000-1000-8000-00805f9b34fb': ['External Report Reference', 'org.bluetooth.descriptor.external_report_reference', '0x2907', 'GSS'], '00002909-0000-1000-8000-00805f9b34fb': ['Number of Digitals', 'org.bluetooth.descriptor.number_of_digitals', '0x2909', 'GSS'], '00002908-0000-1000-8000-00805f9b34fb': ['Report Reference', 'org.bluetooth.descriptor.report_reference', '0x2908', 'GSS'], '00002903-0000-1000-8000-00805f9b34fb': ['Server Characteristic Configuration', 'org.bluetooth.descriptor.gatt.server_characteristic_configuration', '0x2903', 'GSS'], '0000290E-0000-1000-8000-00805f9b34fb': ['Time Trigger Setting', 'org.bluetooth.descriptor.time_trigger_setting', '0x290E', 'GSS'], '00002906-0000-1000-8000-00805f9b34fb': ['Valid Range', 'org.bluetooth.descriptor.valid_range', '0x2906', 'GSS'], '0000290A-0000-1000-8000-00805f9b34fb': ['Value Trigger Setting', 'org.bluetooth.descriptor.value_trigger_setting', '0x290A', 'GSS']}
 
 
 class BleakGATTDescriptor(abc.ABC):

--- a/bleak/backends/dotnet/characteristic.py
+++ b/bleak/backends/dotnet/characteristic.py
@@ -52,12 +52,17 @@ class BleakGATTCharacteristicDotNet(BleakGATTCharacteristic):
         ]
 
     def __str__(self):
-        return "{0}: {1}".format(self.uuid, self.description)
+        return "[{0}] {1}: {2}".format(self.handle, self.uuid, self.description)
 
     @property
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
         return self.obj.Service.Uuid.ToString()
+
+    @property
+    def handle(self) -> int:
+        """The handle of this characteristic"""
+        return int(self.obj.AttributeHandle)
 
     @property
     def uuid(self) -> str:

--- a/bleak/backends/dotnet/characteristic.py
+++ b/bleak/backends/dotnet/characteristic.py
@@ -84,10 +84,13 @@ class BleakGATTCharacteristicDotNet(BleakGATTCharacteristic):
         """List of descriptors for this service"""
         return self.__descriptors
 
-    def get_descriptor(self, _uuid: Union[str, UUID]) -> Union[BleakGATTDescriptorDotNet, None]:
-        """Get a descriptor by UUID"""
+    def get_descriptor(self, specifier: Union[int, str, UUID]) -> Union[BleakGATTDescriptorDotNet, None]:
+        """Get a descriptor by handle (int) or UUID (str or uuid.UUID)"""
         try:
-            return next(filter(lambda x: x.uuid == str(_uuid), self.descriptors))
+            if isinstance(specifier, int):
+                return next(filter(lambda x: x.handle == specifier, self.descriptors))
+            else:
+                return next(filter(lambda x: x.uuid == str(specifier), self.descriptors))
         except StopIteration:
             return None
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -322,7 +322,7 @@ class BleakClientDotNet(BaseBleakClient):
                     for descriptor in list(descriptors_result.Descriptors):
                         self.services.add_descriptor(
                             BleakGATTDescriptorDotNet(
-                                descriptor, characteristic.Uuid.ToString()
+                                descriptor, characteristic.Uuid.ToString(), int(characteristic.AttributeHandle)
                             )
                         )
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -20,6 +20,7 @@ from bleak.backends.dotnet.utils import (
     wrap_IAsyncOperation,
     IAsyncOperationAwaitable,
 )
+from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.dotnet.service import BleakGATTServiceDotNet
 from bleak.backends.dotnet.characteristic import BleakGATTCharacteristicDotNet
@@ -86,7 +87,6 @@ class BleakClientDotNet(BaseBleakClient):
         self._device_info = None
         self._requester = None
         self._bridge = Bridge()
-        self._callbacks = {}
 
         self._address_type = (
             kwargs["address_type"]
@@ -332,12 +332,14 @@ class BleakClientDotNet(BaseBleakClient):
     # I/O methods
 
     async def read_gatt_char(
-        self, _uuid: Union[str, uuid.UUID], use_cached=False, **kwargs
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], use_cached=False, **kwargs
     ) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to read from.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to read from,
+                specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
             use_cached (bool): `False` forces Windows to read the value from the
                 device again and not use its own cached value. Defaults to `False`.
 
@@ -345,9 +347,12 @@ class BleakClientDotNet(BaseBleakClient):
             (bytearray) The read data.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+            raise BleakError("Characteristic {0} was not found!".format(char_specifier))
 
         read_result = await wrap_IAsyncOperation(
             IAsyncOperation[GattReadResult](
@@ -365,7 +370,7 @@ class BleakClientDotNet(BaseBleakClient):
             output = Array.CreateInstance(Byte, reader.UnconsumedBufferLength)
             reader.ReadBytes(output)
             value = bytearray(output)
-            logger.debug("Read Characteristic {0} : {1}".format(_uuid, value))
+            logger.debug("Read Characteristic {0} : {1}".format(characteristic.uuid, value))
         else:
             if read_result.Status == GattCommunicationStatus.ProtocolError:
                 raise BleakDotNetTaskError(
@@ -439,19 +444,24 @@ class BleakClientDotNet(BaseBleakClient):
         return value
 
     async def write_gatt_char(
-        self, _uuid: Union[str, uuid.UUID], data: bytearray, response: bool = False
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID], data: bytearray, response: bool = False
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to write to.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to write
+                to, specified by either integer handle, UUID or directly by the
+                BleakGATTCharacteristic object representing it.
             data (bytes or bytearray): The data to send.
             response (bool): If write-with-response operation should be done. Defaults to `False`.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+            raise BleakError("Characteristic {} was not found!".format(char_specifier))
 
         writer = DataWriter()
         writer.WriteBytes(Array[Byte](data))
@@ -470,7 +480,7 @@ class BleakClientDotNet(BaseBleakClient):
             loop=self.loop,
         )
         if write_result.Status == GattCommunicationStatus.Success:
-            logger.debug("Write Characteristic {0} : {1}".format(_uuid, data))
+            logger.debug("Write Characteristic {0} : {1}".format(characteristic.uuid, data))
         else:
             if write_result.Status == GattCommunicationStatus.ProtocolError:
                 raise BleakError(
@@ -534,7 +544,7 @@ class BleakClientDotNet(BaseBleakClient):
 
     async def start_notify(
         self,
-        _uuid: Union[str, uuid.UUID],
+        char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
         callback: Callable[[str, Any], Any],
         **kwargs
     ) -> None:
@@ -550,18 +560,23 @@ class BleakClientDotNet(BaseBleakClient):
             client.start_notify(char_uuid, callback)
 
         Args:
-            _uuid (str or UUID): The uuid of the characteristics to start notification/indication on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to activate
+                notifications/indications on a characteristic, specified by either integer handle,
+                UUID or directly by the BleakGATTCharacteristic object representing it.
             callback (function): The function to be called on notification.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+            raise BleakError("Characteristic {0} not found!".format(char_specifier))
 
-        if self._notification_callbacks.get(str(_uuid)):
-            await self.stop_notify(_uuid)
+        if self._notification_callbacks.get(characteristic.handle):
+            await self.stop_notify(characteristic)
 
-        status = await self._start_notify(characteristic.obj, callback)
+        status = await self._start_notify(characteristic, callback)
 
         if status != GattCommunicationStatus.Success:
             # TODO: Find out how to get the ProtocolError code that describes a
@@ -574,20 +589,20 @@ class BleakClientDotNet(BaseBleakClient):
 
     async def _start_notify(
         self,
-        characteristic_obj: GattCharacteristic,
+        characteristic: BleakGATTCharacteristic,
         callback: Callable[[str, Any], Any],
     ):
         """Internal method performing call to BleakUWPBridge method.
 
         Args:
-            characteristic_obj: The Managed Windows.Devices.Bluetooth.GenericAttributeProfile.GattCharacteristic Object
+            characteristic: The BleakGATTCharacteristic to start notification on.
             callback: The function to be called on notification.
 
         Returns:
             (int) The GattCommunicationStatus of the operation.
 
         """
-
+        characteristic_obj = characteristic.obj
         if (
             characteristic_obj.CharacteristicProperties
             & GattCharacteristicProperties.Indicate
@@ -603,16 +618,16 @@ class BleakClientDotNet(BaseBleakClient):
 
         try:
             # TODO: Enable adding multiple handlers!
-            self._callbacks[characteristic_obj.Uuid.ToString()] = TypedEventHandler[
+            self._notification_callbacks[characteristic.handle] = TypedEventHandler[
                 GattCharacteristic, GattValueChangedEventArgs
             ](_notification_wrapper(self.loop, callback))
             self._bridge.AddValueChangedCallback(
-                characteristic_obj, self._callbacks[characteristic_obj.Uuid.ToString()]
+                characteristic_obj, self._notification_callbacks[characteristic.handle]
             )
         except Exception as e:
             logger.debug("Start Notify problem: {0}".format(e))
-            if characteristic_obj.Uuid.ToString() in self._callbacks:
-                callback = self._callbacks.pop(characteristic_obj.Uuid.ToString())
+            if characteristic_obj.Uuid.ToString() in self._notification_callbacks:
+                callback = self._notification_callbacks.pop(characteristic.handle)
                 self._bridge.RemoveValueChangedCallback(characteristic_obj, callback)
 
             return GattCommunicationStatus.AccessDenied
@@ -628,24 +643,30 @@ class BleakClientDotNet(BaseBleakClient):
         )
 
         if status != GattCommunicationStatus.Success:
-            # This usually happens when a device reports that it support indicate, but it actually doesn't.
-            if characteristic_obj.Uuid.ToString() in self._callbacks:
-                callback = self._callbacks.pop(characteristic_obj.Uuid.ToString())
+            # This usually happens when a device reports that it support indicate,
+            # but it actually doesn't.
+            if characteristic.handle in self._notification_callbacks:
+                callback = self._notification_callbacks.pop(characteristic.handle)
                 self._bridge.RemoveValueChangedCallback(characteristic_obj, callback)
 
             return GattCommunicationStatus.AccessDenied
         return status
 
-    async def stop_notify(self, _uuid: Union[str, uuid.UUID]) -> None:
+    async def stop_notify(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]) -> None:
         """Deactivate notification/indication on a specified characteristic.
 
         Args:
-            _uuid: The characteristic to stop notifying/indicating on.
+            char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to deactivate
+                notification/indication on, specified by either integer handle, UUID or
+                directly by the BleakGATTCharacteristic object representing it.
 
         """
-        characteristic = self.services.get_characteristic(str(_uuid))
+        if not isinstance(char_specifier, BleakGATTCharacteristic):
+            characteristic = self.services.get_characteristic(char_specifier)
+        else:
+            characteristic = char_specifier
         if not characteristic:
-            raise BleakError("Characteristic {0} was not found!".format(_uuid))
+            raise BleakError("Characteristic {} not found!".format(char_specifier))
 
         status = await wrap_IAsyncOperation(
             IAsyncOperation[GattCommunicationStatus](
@@ -666,7 +687,7 @@ class BleakClientDotNet(BaseBleakClient):
                 )
             )
         else:
-            callback = self._callbacks.pop(characteristic.uuid)
+            callback = self._notification_callbacks.pop(characteristic.handle)
             self._bridge.RemoveValueChangedCallback(characteristic.obj, callback)
 
 

--- a/bleak/backends/dotnet/descriptor.py
+++ b/bleak/backends/dotnet/descriptor.py
@@ -7,13 +7,19 @@ from Windows.Devices.Bluetooth.GenericAttributeProfile import GattDescriptor
 class BleakGATTDescriptorDotNet(BleakGATTDescriptor):
     """GATT Descriptor implementation for .NET backend"""
 
-    def __init__(self, obj: GattDescriptor, characteristic_uuid: str):
+    def __init__(self, obj: GattDescriptor, characteristic_uuid: str, characteristic_handle: int):
         super(BleakGATTDescriptorDotNet, self).__init__(obj)
         self.obj = obj
         self.__characteristic_uuid = characteristic_uuid
+        self.__characteristic_handle = characteristic_handle
 
     def __str__(self):
         return "{0}: (Handle: {1})".format(self.uuid, self.handle)
+
+    @property
+    def characteristic_handle(self) -> int:
+        """handle for the characteristic that this descriptor belongs to"""
+        return self.__characteristic_handle
 
     @property
     def characteristic_uuid(self) -> str:

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -82,7 +82,7 @@ class BleakGATTServiceCollection(object):
 
     @property
     def characteristics(self) -> dict:
-        """Returns dictionary of UUID strings to BleakGATTCharacteristic"""
+        """Returns dictionary of handle strings to BleakGATTCharacteristic"""
         return self.__characteristics
 
     @property
@@ -111,8 +111,8 @@ class BleakGATTServiceCollection(object):
 
         Should not be used by end user, but rather by `bleak` itself.
         """
-        if characteristic.uuid not in self.__characteristics:
-            self.__characteristics[characteristic.uuid] = characteristic
+        if characteristic.handle not in self.__characteristics:
+            self.__characteristics[characteristic.handle] = characteristic
             self.__services[characteristic.service_uuid].add_characteristic(
                 characteristic
             )
@@ -132,7 +132,7 @@ class BleakGATTServiceCollection(object):
          """
         if descriptor.handle not in self.__descriptors:
             self.__descriptors[descriptor.handle] = descriptor
-            self.__characteristics[descriptor.characteristic_uuid].add_descriptor(
+            self.__characteristics[descriptor.characteristic_handle].add_descriptor(
                 descriptor
             )
         else:

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -6,6 +6,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 
 """
 import abc
+import uuid
 from uuid import UUID
 from typing import List, Union, Iterator
 
@@ -64,11 +65,11 @@ class BleakGATTServiceCollection(object):
         self.__descriptors = {}
 
     def __getitem__(
-        self, item: Union[str, int]
+        self, item: Union[str, int, uuid.UUID]
     ) -> Union[BleakGATTService, BleakGATTCharacteristic, BleakGATTDescriptor]:
         """Get a service, characteristic or descriptor from uuid or handle"""
         return self.services.get(
-            item, self.characteristics.get(item, self.descriptors.get(item, None))
+            str(item), self.characteristics.get(item, self.descriptors.get(item, None))
         )
 
     def __iter__(self) -> Iterator[BleakGATTService]:
@@ -82,7 +83,7 @@ class BleakGATTServiceCollection(object):
 
     @property
     def characteristics(self) -> dict:
-        """Returns dictionary of handle strings to BleakGATTCharacteristic"""
+        """Returns dictionary of handles to BleakGATTCharacteristic"""
         return self.__characteristics
 
     @property
@@ -121,9 +122,17 @@ class BleakGATTServiceCollection(object):
                 "This characteristic is already present in this BleakGATTServiceCollection!"
             )
 
-    def get_characteristic(self, _uuid: Union[str, UUID]) -> BleakGATTCharacteristic:
-        """Get a characteristic by UUID string"""
-        return self.characteristics.get(str(_uuid), None)
+    def get_characteristic(self, specifier: Union[int, str, UUID]) -> BleakGATTCharacteristic:
+        """Get a characteristic by handle (int) or UUID (str or uuid.UUID)"""
+        if isinstance(specifier, int):
+            return self.characteristics.get(specifier, None)
+        else:
+            # Assume uuid usage.
+            x = list(filter(lambda x: x.uuid == str(specifier), self.characteristics.values()))
+            if len(x) > 1:
+                raise BleakError("Multiple Characteristics with this UUID, refer to your desired characteristic by the `handle` attribute instead.")
+            else:
+                return x[0] if x else None
 
     def add_descriptor(self, descriptor: BleakGATTDescriptor):
         """Add a :py:class:`~BleakGATTDescriptor` to the service collection.

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     address = (
         "24:71:89:cc:09:05"  # <--- Change to your device's address here if you are using Windows or Linux
         if platform.system() != "Darwin"
-        else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"  # <--- Change to your device's address here if you are using macOS
+        else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"  # <--- Change to your device's address here if you are using macOS
     )
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run(address, loop, True))

--- a/examples/get_services.py
+++ b/examples/get_services.py
@@ -23,7 +23,7 @@ async def print_services(mac_addr: str, loop: asyncio.AbstractEventLoop):
 mac_addr = (
     "24:71:89:cc:09:05"
     if platform.system() != "Darwin"
-    else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
 )
 loop = asyncio.get_event_loop()
 loop.run_until_complete(print_services(mac_addr, loop))

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -164,7 +164,7 @@ if __name__ == "__main__":
     address = (
         "24:71:89:cc:09:05"
         if platform.system() != "Darwin"
-        else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"
+        else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
     )
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run(address, loop, True))

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -41,8 +41,8 @@ async def run(address, loop, debug=False):
                 else:
                     value = None
                 log.info(
-                    "\t[Characteristic] {0}: ({1}) | Name: {2}, Value: {3} ".format(
-                        char.uuid, ",".join(char.properties), char.description, value
+                    "\t[Characteristic] {0}: (Handle: {1}) ({2}) | Name: {3}, Value: {4} ".format(
+                        char.uuid, char.handle, ",".join(char.properties), char.description, value
                     )
                 )
                 for descriptor in char.descriptors:

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
     address = (
         "24:71:89:cc:09:05"
         if platform.system() != "Darwin"
-        else "243E23AE-4A99-406C-B317-18F1BD7B4CBE"
+        else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
     )
     loop = asyncio.get_event_loop()
     loop.run_until_complete(run(address, loop, True))


### PR DESCRIPTION
Merges #167 by means of new branch.

Changed some details of #167 to handle characteristics a bit differently.
`read_gatt_char`, `write_gatt_char`, `start_notify` and `stop_notify` now accepts 

- `BleakGATTCharacteristics` objects
- integer handler for the characteristic to use
- string uuid
- `uuid.UUID` objects

The efficiency of using the different solutions are in that descending order as well. It is now less effective than before to use string representations of the UUIDs of a characteristic, this is an effect of keeping track of characteristics is done by integer handles instead of string uuids. This will hopefully fix #139 and #159.
