### PR TITLE
add CHANGELOG.rst to MANIFEST.in to be able to build sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include AUTHORS.rst
+include CHANGELOG.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE


### PR DESCRIPTION
running: 
   python setup.py sdist
   pip install -t foo dist/bleak-0.7.0.tar.gz

will fail because CHANGELOG.rst is required.  This also breaks source installs from pypi, for example:
   pip install bleak --no-binary :all:

included is a trivial fixup