### PR TITLE
Fix BlueZ version typo.

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -486,7 +486,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """Perform a write operation on the specified GATT characteristic.
 
         NB: the version check below is for the "type" option to the
-        "Characteristic.WriteValue" method that was added to Bluez in 5.50
+        "Characteristic.WriteValue" method that was added to Bluez in 5.51
         https://git.kernel.org/pub/scm/bluetooth/bluez.git/commit?id=fa9473bcc48417d69cc9ef81d41a72b18e34a55a
         Before that commit, "Characteristic.WriteValue" was only "Write with
         response". "Characteristic.AcquireWrite" was added in Bluez 5.46


### PR DESCRIPTION
Support for the "type" option was actually added in v5.51, not v5.50.

See https://github.com/hbldh/bleak/pull/260#issuecomment-666717033