### PR TITLE
Fix get_services function of corebluetooth client

### DIFF
--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -130,7 +130,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         """
         if self._services is not None:
-            return self._services
+            return self.services
 
         logger.debug("Retrieving services...")
         manager = self._device_info.manager().delegate()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -93,6 +93,9 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         manager = self._device_info.manager().delegate()
         await manager.disconnect()
         self.services = BleakGATTServiceCollection()
+        # Ensure that `get_services` retrieves services again, rather than using the cached object
+        self._services_resolved = False
+        self._services = None 
         return True
 
     async def is_connected(self) -> bool:


### PR DESCRIPTION
The get_services function incorrectly returns the underlying `_service` array rather than the services object when reading it from the cache.