### PR TITLE
Implementation of `find_specific_device` feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,13 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 -------------
 
 Added
-~~~~
+~~~~~
 
 * Added ``find_specific_device`` method to the ``BleakScanner`` interface, for stopping scanning when a desired address is found.
 * Implemented ``find_specific_device`` in the .NET backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
 * Implemented ``find_specific_device`` in the BlueZ backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Implemented ``find_specific_device`` in the Core Bluetooth backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Added text representations of Protocol Errors that are visible in the .NET backend. Added these texts to errors raised.
 
 Changed
 ~~~~~~~
@@ -34,10 +36,6 @@ Fixed
 * Fixed some type hints and docstrings.
 * Modified the ``connected_peripheral_delegate`` handling in macOS backend to fix #213 and #116.
 
-Added
-~~~~~
-
-* Added text representations of Protocol Errors that are visible in the .NET backend. Added these texts to errors raised.
 
 `0.7.1`_ (2020-07-02)
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,10 +13,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 ~~~~~
 
-* Added ``find_specific_device`` method to the ``BleakScanner`` interface, for stopping scanning when a desired address is found.
-* Implemented ``find_specific_device`` in the .NET backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
-* Implemented ``find_specific_device`` in the BlueZ backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
-* Implemented ``find_specific_device`` in the Core Bluetooth backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Added ``find_device_by_address`` method to the ``BleakScanner`` interface, for stopping scanning when a desired address is found.
+* Implemented ``find_device_by_address`` in the .NET backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Implemented ``find_device_by_address`` in the BlueZ backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Implemented ``find_device_by_address`` in the Core Bluetooth backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
 * Added text representations of Protocol Errors that are visible in the .NET backend. Added these texts to errors raised.
 
 Changed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 -------------
 
+Added
+~~~~
+
+* Added ``find_specific_device`` method to the ``BleakScanner`` interface, for stopping scanning when a desired address is found.
+* Implemented ``find_specific_device`` in the .NET backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Implemented ``find_specific_device`` in the BlueZ backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+
 Changed
 ~~~~~~~
 

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.2a9"
+__version__ = "0.7.2a10"

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.2a4"
+__version__ = "0.7.2a9"

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -32,7 +32,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
     Implemented by using the `BlueZ DBUS API <https://docs.ubuntu.com/core/en/stacks/bluetooth/bluez/docs/reference/dbus-api>`_.
 
     Args:
-        address (str): The MAC address of the BLE peripheral to connect to.
+        address (str): The  address of the BLE peripheral to connect to.
 
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -35,7 +35,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         address (str): The  address of the BLE peripheral to connect to.
 
     Keyword Args:
-        timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.
+        timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
 
     """
 
@@ -96,7 +96,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """Connect to the specified GATT server.
 
         Keyword Args:
-            timeout (float): Timeout for required ``find_specific_device`` call. Defaults to maximally 10.0 seconds.
+            timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
 
         Returns:
             Boolean representing connection status.
@@ -105,7 +105,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # A Discover must have been run before connecting to any devices.
         # Find the desired device before trying to connect.
         timeout = kwargs.get("timeout", self._timeout)
-        device = await BleakScannerBlueZDBus.find_specific_device(
+        device = await BleakScannerBlueZDBus.find_device_by_address(
             self.address, timeout=timeout, device=self.device)
 
         if device:

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -67,7 +67,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
     """
 
     def __init__(self, **kwargs):
-        super(BleakScannerBlueZDBus, self).__init__(**kwargs)
+        super(BleakScannerBlueZDBus, self).__init__()
 
         self._device = kwargs.get("device", "hci0")
         self._reactor = None
@@ -79,7 +79,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         # Discovery filters
         self._filters = kwargs.get("filters", {})
-        self._filters["Transport"] = "le"
+        if "Transport" not in self._filters:
+            self._filters["Transport"] = "le"
 
         self._adapter_path = None
         self._interface = None
@@ -178,7 +179,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         """
         self._filters = kwargs.get("filters", {})
-        self._filters["Transport"] = "le"
+        if "Transport" not in self._filters:
+            self._filters["Transport"] = "le"
 
     async def get_discovered_devices(self) -> List[BLEDevice]:
         # Reduce output.
@@ -216,13 +218,55 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         """
         self._callback = callback
 
+    @classmethod
+    async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0, **kwargs) -> BLEDevice:
+        """A convenience method for obtaining a ``BLEDevice`` object specified by MAC address.
+
+        Args:
+            device_identifier (str): The MAC address of the Bluetooth peripheral.
+            timeout (float): Optional timeout to wait for detection of specified peripheral.
+
+        Keyword Args:
+            device (str): Bluetooth device to use for discovery.
+
+        Returns:
+            The ``BLEDevice`` sought or ``None`` if not detected.
+
+        """
+        device_identifier = device_identifier.lower()
+        loop = asyncio.get_event_loop()
+        stop_scanning_event = asyncio.Event(loop=loop)
+
+        def stop_if_detected(message):
+            if any(device.get("Address", "").lower() == device_identifier for device in scanner._devices.values()):
+                loop.call_soon_threadsafe(stop_scanning_event.set)
+
+        scanner = cls(**kwargs)
+        scanner.register_detection_callback(stop_if_detected)
+
+        await scanner.start()
+        try:
+            await asyncio.wait_for(stop_scanning_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            device = None
+        else:
+            device = next(
+                d
+                for d in await scanner.get_discovered_devices()
+                if d.address.lower() == device_identifier.lower()
+            )
+        finally:
+            await scanner.stop()
+
+        return device
+
     # Helper methods
 
     def parse_msg(self, message):
         if message.member == "InterfacesAdded":
             msg_path = message.body[0]
             try:
-                device_interface = message.body[1].get("org.bluez.Device1", {})
+                device_interface = message.body[1].get(defs.DEVICE_INTERFACE, {})
             except Exception as e:
                 raise e
             self._devices[msg_path] = (

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -224,7 +224,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         Args:
             device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
+            timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
 
         Keyword Args:
             device (str): Bluetooth device to use for discovery.

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -208,18 +208,16 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         return discovered_devices
 
     def register_detection_callback(self, callback: Callable):
-        """Set a function to be called on each Scanner discovery.
-
-        Documentation for the Event Handler:
-        https://docs.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementwatcher.received
+        """Set a function to be called on each device discovery by scanner and when a discovered device has a changed property.
 
         Args:
-            callback: Function accepting one argument of type ?
+            callback: Function accepting one argument of type ``txdbus.message.SignalMessage``
+
         """
         self._callback = callback
 
     @classmethod
-    async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0, **kwargs) -> BLEDevice:
+    async def find_device_by_address(cls, device_identifier: str, timeout: float = 10.0, **kwargs) -> BLEDevice:
         """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address.
 
         Args:

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -224,7 +224,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         Args:
             device_identifier (str): The MAC address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral.
+            timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
 
         Keyword Args:
             device (str): Bluetooth device to use for discovery.
@@ -235,7 +235,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         """
         device_identifier = device_identifier.lower()
         loop = asyncio.get_event_loop()
-        stop_scanning_event = asyncio.Event(loop=loop)
+        stop_scanning_event = asyncio.Event()
 
         def stop_if_detected(message):
             if any(device.get("Address", "").lower() == device_identifier for device in scanner._devices.values()):

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -220,10 +220,10 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
     @classmethod
     async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0, **kwargs) -> BLEDevice:
-        """A convenience method for obtaining a ``BLEDevice`` object specified by MAC address.
+        """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address.
 
         Args:
-            device_identifier (str): The MAC address of the Bluetooth peripheral.
+            device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
             timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
 
         Keyword Args:

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -28,7 +28,7 @@ def get_device_object_path(hci_device, address):
 
     Args:
         hci_device (str): Which bluetooth adapter to connect with.
-        address (str): The MAC adress of the bluetooth device.
+        address (str): The Bluetooth address of the bluetooth device.
 
     Returns:
         String representation of device object path on format
@@ -36,7 +36,7 @@ def get_device_object_path(hci_device, address):
 
     """
     if not validate_mac_address(address):
-        raise BleakError("{0} is not a valid MAC adrdess.".format(address))
+        raise BleakError("{0} is not a valid Bluetooth address.".format(address))
 
     if not validate_hci_device(hci_device):
         raise BleakError("{0} is not a valid HCI device.".format(hci_device))
@@ -57,7 +57,7 @@ def get_gatt_service_path(hci_device, address, service_id):
 
         Args:
             hci_device (str): Which bluetooth adapter to connect with.
-            address (str): The MAC adress of the bluetooth device.
+            address (str): The Bluetooth address of the bluetooth device.
             service_id (int):
 
         Returns:

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -32,7 +32,7 @@ class BaseBleakClient(abc.ABC):
         self._services_resolved = False
         self._notification_callbacks = {}
 
-        self._timeout = kwargs.get("timeout", 2.0)
+        self._timeout = kwargs.get("timeout", 10.0)
 
     def __str__(self):
         return "{0}, {1}".format(self.__class__.__name__, self.address)

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -96,11 +96,8 @@ class CentralManagerDelegate(NSObject):
         """
         await asyncio.wait_for(self.powered_on_event.wait(), timeout)
 
-    async def scanForPeripherals_(self, scan_options) -> List[CBPeripheral]:
-        """
-        Scan for peripheral devices
-        scan_options = { service_uuids, timeout }
-        """
+    @objc.python_method
+    def start_scan(self, scan_options):
         # remove old
         self.devices = {}
         service_uuids = []
@@ -110,17 +107,11 @@ class CentralManagerDelegate(NSObject):
                 list(map(string2uuid, service_uuids_str))
             )
 
-        timeout = 0
-        if "timeout" in scan_options:
-            timeout = float(scan_options["timeout"])
-
         self.central_manager.scanForPeripheralsWithServices_options_(
             service_uuids, None
         )
 
-        if timeout > 0:
-            await asyncio.sleep(timeout)
-
+    async def stop_scan(self) -> List[CBPeripheral]:
         self.central_manager.stopScan()
 
         # Wait a while to allow central manager to stop scanning.
@@ -134,6 +125,16 @@ class CentralManagerDelegate(NSObject):
                 await asyncio.sleep(0.1)
 
         return []
+
+    async def scanForPeripherals_(self, scan_options) -> List[CBPeripheral]:
+        """
+        Scan for peripheral devices
+        scan_options = { service_uuids, timeout }
+        """
+
+        self.start_scan(scan_options)
+        await asyncio.sleep(float(scan_options.get("timeout", 0.0)))
+        return await self.stop_scan()
 
     async def connect_(self, peripheral: CBPeripheral) -> bool:
         self._connection_state = CMDConnectionState.PENDING

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -111,6 +111,7 @@ class CentralManagerDelegate(NSObject):
             service_uuids, None
         )
 
+    @objc.python_method
     async def stop_scan(self) -> List[CBPeripheral]:
         self.central_manager.stopScan()
 
@@ -126,6 +127,7 @@ class CentralManagerDelegate(NSObject):
 
         return []
 
+    @objc.python_method
     async def scanForPeripherals_(self, scan_options) -> List[CBPeripheral]:
         """
         Scan for peripheral devices

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -37,7 +37,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         address (str): The uuid of the BLE peripheral to connect to.
 
     Keyword Args:
-        timeout (float): Timeout for required ``discover`` call during connect. Defaults to 2.0.
+        timeout (float): Timeout for required ``discover`` call during connect. Defaults to 10.0.
 
     """
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -65,7 +65,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         """
         timeout = kwargs.get("timeout", self._timeout)
-        device = await BleakScannerCoreBluetooth.find_specific_device(
+        device = await BleakScannerCoreBluetooth.find_device_by_address(
             self.address, timeout=timeout)
 
         if device:

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -32,8 +32,8 @@ async def discover(timeout: float = 5.0, **kwargs) -> List[BLEDevice]:
 
     await manager.scanForPeripherals_(scan_options)
 
-    # CoreBluetooth doesn't explicitly use MAC addresses to identify peripheral
-    # devices because private devices may obscure their MAC addresses. To cope
+    # CoreBluetooth doesn't explicitly use Bluetooth addresses to identify peripheral
+    # devices because private devices may obscure their Bluetooth addresses. To cope
     # with this, CoreBluetooth utilizes UUIDs for each peripheral. We'll use
     # this for the BLEDevice address on macOS
 

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -118,7 +118,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
 
         Args:
             device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
+            timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
 
         Returns:
             The ``BLEDevice`` sought or ``None`` if not detected.

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -20,8 +20,8 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
     Documentation:
     https://developer.apple.com/documentation/corebluetooth/cbcentralmanager
 
-    CoreBluetooth doesn't explicitly use MAC addresses to identify peripheral
-    devices because private devices may obscure their MAC addresses. To cope
+    CoreBluetooth doesn't explicitly use Bluetooth addresses to identify peripheral
+    devices because private devices may obscure their Bluetooth addresses. To cope
     with this, CoreBluetooth utilizes UUIDs for each peripheral. Bleak uses
     this for the BLEDevice address on macOS.
 
@@ -117,7 +117,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         """A convenience method for obtaining a ``BLEDevice`` object specified by macOS UUID address.
 
         Args:
-            device_identifier (str): The MAC address of the Bluetooth peripheral.
+            device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
             timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
 
         Returns:

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -136,29 +136,13 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         loop = asyncio.get_event_loop()
         stop_scanning_event = asyncio.Event()
         device_identifier = device_identifier.lower()
+        scanner = cls(timeout=timeout)
 
         def stop_if_detected(peripheral, advertisement_data, rssi):
             if str(peripheral.identifier().UUIDString()).lower() == device_identifier:
                 loop.call_soon_threadsafe(stop_scanning_event.set)
 
-        scanner = cls(timeout=timeout)
-        scanner.register_detection_callback(stop_if_detected)
-
-        await scanner.start()
-        try:
-            await asyncio.wait_for(stop_scanning_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            device = None
-        else:
-            device = next(
-                d
-                for d in await scanner.get_discovered_devices()
-                if d.address.lower() == device_identifier.lower()
-            )
-        finally:
-            await scanner.stop()
-
-        return device
+        return await scanner._find_device_by_address(device_identifier, stop_scanning_event, stop_if_detected, timeout)
 
     # macOS specific methods
 

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -108,10 +108,19 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         return found
 
     def register_detection_callback(self, callback: Callable):
+        """Set a function to act as callback on discovered devices or devices with changed properties.
+
+        Args:
+            callback: Function accepting three arguments:
+             peripheral
+             advertisementData
+             rssi
+
+        """
         self._callback = callback
 
     @classmethod
-    async def find_specific_device(
+    async def find_device_by_address(
         cls, device_identifier: str, timeout: float = 10.0, **kwargs
     ) -> Union[BLEDevice, None]:
         """A convenience method for obtaining a ``BLEDevice`` object specified by macOS UUID address.
@@ -128,7 +137,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         stop_scanning_event = asyncio.Event()
         device_identifier = device_identifier.lower()
 
-        def stop_if_detected(peripheral, advertisementData, RSSI):
+        def stop_if_detected(peripheral, advertisement_data, rssi):
             if str(peripheral.identifier().UUIDString()).lower() == device_identifier:
                 loop.call_soon_threadsafe(stop_scanning_event.set)
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -69,7 +69,7 @@ class BleakClientDotNet(BaseBleakClient):
     Common Language Runtime (CLR). Therefore, much of the code below has a distinct C# feel.
 
     Args:
-        address (str): The MAC address of the BLE peripheral to connect to.
+        address (str): The Bluetooth address of the BLE peripheral to connect to.
 
     Keyword Args:
             timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -100,7 +100,7 @@ class BleakClientDotNet(BaseBleakClient):
         """Connect to the specified GATT server.
 
         Keyword Args:
-            timeout (float): Timeout for required ``find_specific_device`` call. Defaults to maximally 10.0 seconds.
+            timeout (float): Timeout for required ``find_device_by_address`` call. Defaults to maximally 10.0 seconds.
 
         Returns:
             Boolean representing connection status.
@@ -111,7 +111,7 @@ class BleakClientDotNet(BaseBleakClient):
 
         # Try to find the desired device.
         timeout = kwargs.get("timeout", self._timeout)
-        device = await BleakScannerDotNet.find_specific_device(
+        device = await BleakScannerDotNet.find_device_by_address(
             self.address, timeout=timeout)
 
         if device:

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -235,26 +235,10 @@ class BleakScannerDotNet(BaseBleakScanner):
         ulong_id = int(device_identifier.replace(":", ""), 16)
         loop = asyncio.get_event_loop()
         stop_scanning_event = asyncio.Event()
+        scanner = cls(timeout=timeout)
 
         def stop_if_detected(sender, event_args):
             if event_args.BluetoothAddress == ulong_id:
                 loop.call_soon_threadsafe(stop_scanning_event.set)
 
-        scanner = cls(**kwargs)
-        scanner.register_detection_callback(stop_if_detected)
-
-        await scanner.start()
-        try:
-            await asyncio.wait_for(stop_scanning_event.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            device = None
-        else:
-            device = next(
-                d
-                for d in await scanner.get_discovered_devices()
-                if d.address.lower() == device_identifier.lower()
-            )
-        finally:
-            await scanner.stop()
-
-        return device
+        return await scanner._find_device_by_address(device_identifier, stop_scanning_event, stop_if_detected, timeout)

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -56,7 +56,7 @@ class BleakScannerDotNet(BaseBleakScanner):
     """
 
     def __init__(self, **kwargs):
-        super(BleakScannerDotNet, self).__init__(**kwargs)
+        super(BleakScannerDotNet, self).__init__()
 
         self.watcher = None
         self._devices = {}
@@ -199,13 +199,22 @@ class BleakScannerDotNet(BaseBleakScanner):
 
     @classmethod
     async def find_specific_device(
-        cls, device_identifier: str, timeout: float = 20.0
+        cls, device_identifier: str, timeout: float = 10.0, **kwargs
     ) -> Union[BLEDevice, None]:
         """A convenience method for obtaining a ``BLEDevice`` object specified by MAC address.
 
         Args:
             device_identifier (str): The MAC address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to
+            timeout (float): Optional timeout to wait for detection of specified peripheral.
+
+        Keyword Args:
+            scanning mode (str): Set to "Passive" to avoid the "Active" scanning mode.
+            SignalStrengthFilter (Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter): A
+              BluetoothSignalStrengthFilter object used for configuration of Bluetooth
+              LE advertisement filtering that uses signal strength-based filtering.
+            AdvertisementFilter (Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFilter): A
+              BluetoothLEAdvertisementFilter object used for configuration of Bluetooth LE
+              advertisement filtering that uses payload section-based filtering.
 
         Returns:
             The ``BLEDevice`` sought or ``None`` if not detected.
@@ -220,7 +229,7 @@ class BleakScannerDotNet(BaseBleakScanner):
             if event_args.BluetoothAddress == ulong_id:
                 loop.call_soon_threadsafe(stop_scanning_event.set)
 
-        scanner = cls()
+        scanner = cls(**kwargs)
         scanner.register_detection_callback(stop_if_detected)
 
         await scanner.start()

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -205,7 +205,7 @@ class BleakScannerDotNet(BaseBleakScanner):
 
         Args:
             device_identifier (str): The MAC address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral.
+            timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
 
         Keyword Args:
             scanning mode (str): Set to "Passive" to avoid the "Active" scanning mode.
@@ -223,7 +223,7 @@ class BleakScannerDotNet(BaseBleakScanner):
 
         ulong_id = int(device_identifier.replace(":", ""), 16)
         loop = asyncio.get_event_loop()
-        stop_scanning_event = asyncio.Event(loop=loop)
+        stop_scanning_event = asyncio.Event()
 
         def stop_if_detected(sender, event_args):
             if event_args.BluetoothAddress == ulong_id:

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -205,7 +205,7 @@ class BleakScannerDotNet(BaseBleakScanner):
 
         Args:
             device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
+            timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
 
         Keyword Args:
             scanning mode (str): Set to "Passive" to avoid the "Active" scanning mode.

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -117,6 +117,17 @@ class BleakScannerDotNet(BaseBleakScanner):
         self.watcher = None
 
     async def set_scanning_filter(self, **kwargs):
+        """Set a scanning filter for the BleakScanner.
+
+        Keyword Args:
+            SignalStrengthFilter (Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter): A
+              BluetoothSignalStrengthFilter object used for configuration of Bluetooth
+              LE advertisement filtering that uses signal strength-based filtering.
+            AdvertisementFilter (Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFilter): A
+              BluetoothLEAdvertisementFilter object used for configuration of Bluetooth LE
+              advertisement filtering that uses payload section-based filtering.
+
+        """
         if "SignalStrengthFilter" in kwargs:
             # TODO: Handle SignalStrengthFilter parameters
             self._signal_strength_filter = kwargs["SignalStrengthFilter"]
@@ -198,7 +209,7 @@ class BleakScannerDotNet(BaseBleakScanner):
         return self.watcher.Status if self.watcher else None
 
     @classmethod
-    async def find_specific_device(
+    async def find_device_by_address(
         cls, device_identifier: str, timeout: float = 10.0, **kwargs
     ) -> Union[BLEDevice, None]:
         """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address.

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -201,10 +201,10 @@ class BleakScannerDotNet(BaseBleakScanner):
     async def find_specific_device(
         cls, device_identifier: str, timeout: float = 10.0, **kwargs
     ) -> Union[BLEDevice, None]:
-        """A convenience method for obtaining a ``BLEDevice`` object specified by MAC address.
+        """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address.
 
         Args:
-            device_identifier (str): The MAC address of the Bluetooth peripheral.
+            device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
             timeout (float): Optional timeout to wait for detection of specified peripheral. Defaults to 10.0 seconds.
 
         Keyword Args:

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -44,5 +44,5 @@ class BaseBleakScanner(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    async def find_specific_device(cls, device_identifier: str) -> BLEDevice:
+    async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0) -> BLEDevice:
         raise NotImplementedError()

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -48,10 +48,10 @@ class BaseBleakScanner(abc.ABC):
     @classmethod
     @abc.abstractmethod
     async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0) -> BLEDevice:
-        """A convenience method for obtaining a ``BLEDevice`` object specified by MAC address or (macOS) UUID address.
+        """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address or (macOS) UUID address.
 
         Args:
-            device_identifier (str): The MAC/UUID address of the Bluetooth peripheral sought.
+            device_identifier (str): The Bluetooth/UUID address of the Bluetooth peripheral sought.
             timeout (float): Optional timeout to maximally wait for detection of specified peripheral. Defaults to 10.0 seconds.
 
         Returns:

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -52,7 +52,7 @@ class BaseBleakScanner(abc.ABC):
 
         Args:
             device_identifier (str): The Bluetooth/UUID address of the Bluetooth peripheral sought.
-            timeout (float): Optional timeout to maximally wait for detection of specified peripheral. Defaults to 10.0 seconds.
+            timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
 
         Returns:
             The ``BLEDevice`` sought or ``None`` if not detected.

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -8,6 +8,9 @@ from bleak.backends.device import BLEDevice
 class BaseBleakScanner(abc.ABC):
     """Interface for Bleak Bluetooth LE Scanners"""
 
+    def __init__(self, *args, **kwargs):
+        super(BaseBleakScanner, self).__init__()
+
     async def __aenter__(self):
         await self.start()
         return self
@@ -18,7 +21,7 @@ class BaseBleakScanner(abc.ABC):
     @classmethod
     async def discover(cls, timeout=5.0, **kwargs) -> List[BLEDevice]:
         async with cls(**kwargs) as scanner:
-            await asyncio.sleep(timeout if timeout > 0.0 else 0.1)
+            await asyncio.sleep(timeout)
             devices = await scanner.get_discovered_devices()
         return devices
 
@@ -45,4 +48,14 @@ class BaseBleakScanner(abc.ABC):
     @classmethod
     @abc.abstractmethod
     async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0) -> BLEDevice:
+        """A convenience method for obtaining a ``BLEDevice`` object specified by MAC address or (macOS) UUID address.
+
+        Args:
+            device_identifier (str): The MAC/UUID address of the Bluetooth peripheral sought.
+            timeout (float): Optional timeout to maximally wait for detection of specified peripheral. Defaults to 10.0 seconds.
+
+        Returns:
+            The ``BLEDevice`` sought or ``None`` if not detected.
+
+        """
         raise NotImplementedError()

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -20,6 +20,18 @@ class BaseBleakScanner(abc.ABC):
 
     @classmethod
     async def discover(cls, timeout=5.0, **kwargs) -> List[BLEDevice]:
+        """Scan continuously for ``timeout`` seconds and return discovered devices.
+
+        Args:
+            timeout: Time to scan for.
+
+        Keyword Args:
+            **kwargs: Implementations might offer additional keyword arguments sent to the constructor of the
+                      BleakScanner class.
+
+        Returns:
+
+        """
         async with cls(**kwargs) as scanner:
             await asyncio.sleep(timeout)
             devices = await scanner.get_discovered_devices()
@@ -27,27 +39,42 @@ class BaseBleakScanner(abc.ABC):
 
     @abc.abstractmethod
     def register_detection_callback(self, callback: Callable):
+        """Register a callback that is called when a device is discovered or has a property changed."""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def start(self):
+        """Start scanning for devices"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def stop(self):
+        """Stop scanning for devices"""
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def set_scanning_filter(self, **kwargs):
+        """Set scanning filter for the BleakScanner.
+
+        Args:
+            **kwargs: The filter details. This will differ a lot between backend implementations.
+
+        """
         raise NotImplementedError()
 
     @abc.abstractmethod
     async def get_discovered_devices(self) -> List[BLEDevice]:
+        """Gets the devices registered by the BleakScanner.
+
+        Returns:
+            A list of the devices that the scanner has discovered during the scanning.
+
+        """
         raise NotImplementedError()
 
     @classmethod
     @abc.abstractmethod
-    async def find_specific_device(cls, device_identifier: str, timeout: float = 10.0) -> BLEDevice:
+    async def find_device_by_address(cls, device_identifier: str, timeout: float = 10.0) -> BLEDevice:
         """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address or (macOS) UUID address.
 
         Args:

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -86,3 +86,25 @@ class BaseBleakScanner(abc.ABC):
 
         """
         raise NotImplementedError()
+
+    async def _find_device_by_address(self, device_identifier, stop_scanning_event, stop_if_detected_callback, timeout):
+        """Internal method for performing find by address work."""
+
+        self.register_detection_callback(stop_if_detected_callback)
+
+        await self.start()
+        try:
+            await asyncio.wait_for(stop_scanning_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            device = None
+        else:
+            device = next(
+                d
+                for d in await self.get_discovered_devices()
+                if d.address.lower() == device_identifier.lower()
+            )
+        finally:
+            await self.stop()
+
+        return device
+

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -41,3 +41,8 @@ class BaseBleakScanner(abc.ABC):
     @abc.abstractmethod
     async def get_discovered_devices(self) -> List[BLEDevice]:
         raise NotImplementedError()
+
+    @classmethod
+    @abc.abstractmethod
+    async def find_specific_device(cls, device_identifier: str) -> BLEDevice:
+        raise NotImplementedError()

--- a/bleak/utils.py
+++ b/bleak/utils.py
@@ -2,26 +2,26 @@
 
 
 def mac_str_2_int(mac):
-    """Convert colon separated hex string MAC address to integer.
+    """Convert colon separated hex string Bluetooth address to integer.
 
     Args:
-        mac (str): A colon separated hex string MAC address.
+        mac (str): A colon separated hex string Bluetooth address.
 
     Returns:
-        MAC address as integer.
+        Bluetooth address as integer.
 
     """
     return int(mac.replace(":", ""), 16)
 
 
 def mac_int_2_str(mac):
-    """Convert integer MAC to colon separated hex string.
+    """Convert integer Bluetooth address to colon separated hex string.
 
     Args:
         mac (int): A positive integer.
 
     Returns:
-        MAC address as colon separated hex string.
+        Bluetooth address as colon separated hex string.
 
     """
     m = hex(mac)[2:].upper().zfill(12)

--- a/docs/backends/macos.rst
+++ b/docs/backends/macos.rst
@@ -11,7 +11,7 @@ Specific features for the macOS backend
 
 The most noticeable difference between the other
 backends of bleak and this backend, is that CoreBluetooth doesn't scan for
-other devices via MAC address. Instead, UUIDs are utilized that are often
+other devices via Bluetooth address. Instead, UUIDs are utilized that are often
 unique between the device that is scanning and the device that is being scanned.
 
 In the example files, this is handled in this fashion:

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -24,7 +24,7 @@ This will produce a printed list of detected devices:
     24:71:89:CC:09:05: CC2650 SensorTag
     4D:41:D5:8C:7A:0B: Apple, Inc. (b'\x10\x06\x11\x1a\xb2\x9b\x9c\xe3')
 
-The first part, a MAC address in Windows and Linux and a UUID in macOS, is what is
+The first part, a Bluetooth address in Windows and Linux and a UUID in macOS, is what is
 used for connecting to a device using Bleak. The list of objects returned by the `discover`
 method are instances of :py:class:`bleak.backends.device.BLEDevice` and has ``name``, ``address``
 and ``rssi`` attributes, as well as a ``metadata`` attribute, a dict with keys ``uuids`` and ``manufacturer_data``

--- a/examples/scanner.py
+++ b/examples/scanner.py
@@ -1,0 +1,30 @@
+"""
+Bleak Scanner
+-------------
+
+
+
+Updated on 2020-08-12 by hbldh <henrik.blidh@nedomkull.com>
+
+"""
+
+import asyncio
+import platform
+
+from bleak import BleakScanner
+
+
+address = (
+    "24:71:89:cc:09:05"  # <--- Change to your device's address here if you are using Windows or Linux
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"  # <--- Change to your device's address here if you are using macOS
+)
+
+
+async def run():
+    device = await BleakScanner.find_specific_device(address)
+    print(device)
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run())

--- a/examples/scanner.py
+++ b/examples/scanner.py
@@ -22,7 +22,7 @@ address = (
 
 
 async def run():
-    device = await BleakScanner.find_specific_device(address)
+    device = await BleakScanner.find_device_by_address(address)
     print(device)
 
 


### PR DESCRIPTION
A new method in the `BleakScanner` interface. Using the scanner soution, one can remove the hard wait time in `connect` calls with a much faster, variable time scanning which exits when the sought device has been detected by the scanner. This will result in generally faster connections and hopefully more stable connects as well.