### PR TITLE
Change uuid to handle in data sent to notification callbacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,15 +13,21 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 ~~~~~
 
-* Added ``find_device_by_address`` method to the ``BleakScanner`` interface, for stopping scanning when a desired address is found.
-* Implemented ``find_device_by_address`` in the .NET backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
-* Implemented ``find_device_by_address`` in the BlueZ backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
-* Implemented ``find_device_by_address`` in the Core Bluetooth backend ``BleakScanner`` implementation and switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Added ``find_device_by_address`` method to the ``BleakScanner`` interface, for stopping scanning
+  when a desired address is found.
+* Implemented ``find_device_by_address`` in the .NET backend ``BleakScanner`` implementation and
+  switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Implemented ``find_device_by_address`` in the BlueZ backend ``BleakScanner`` implementation and
+  switched its ``BleakClient`` implementation to use that method in ``connect``.
+* Implemented ``find_device_by_address`` in the Core Bluetooth backend ``BleakScanner`` implementation
+  and switched its ``BleakClient`` implementation to use that method in ``connect``.
 * Added text representations of Protocol Errors that are visible in the .NET backend. Added these texts to errors raised.
 
 Changed
 ~~~~~~~
-
+* **BREAKING CHANGE** All notifications now have the characteristic's integer **handle** instead of its UUID as a
+  string as the first argument ``sender`` sent to notification callbacks. This provides the uniqueness of
+  sender in notifications as well.
 * Version 0.5.0 of BleakUWPBridge, with some modified methods and implementing ``IDisposable``.
 * Merged #224. All storing and passing of event loops in bleak is removed.
 * Removed Objective C delegate compliance checks. Merged #253.

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.7.2a10"
+__version__ = "0.8.0a1"

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -56,6 +56,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         self._disconnected_callback = None
 
+        # This maps DBus paths of GATT Characteristics to their BLE handles.
         self._char_path_to_handle = {}
 
         # We need to know BlueZ version since battery level characteristic
@@ -611,7 +612,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """Activate notifications/indications on a characteristic.
 
         Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
-        data and the second will be a ``bytearray``.
+        data and the second will be a ``bytearray`` containing the data sent from the connected server.
 
         .. code-block:: python
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -56,7 +56,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         self._disconnected_callback = None
 
-        self._char_path_to_uuid = {}
+        self._char_path_to_handle = {}
 
         # We need to know BlueZ version since battery level characteristic
         # are stored in a separate DBus interface in the BlueZ >= 5.48.
@@ -229,6 +229,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         Free all the allocated resource in DBus and Twisted. Use this method to
         eventually cleanup all otherwise leaked resources.
         """
+        self._char_path_to_handle.clear()
         await self._cleanup_notifications()
         await self._cleanup_dbus_resources()
 
@@ -299,7 +300,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             raise
         return is_connected
 
-
     # GATT services methods
 
     async def get_services(self) -> BleakGATTServiceCollection:
@@ -355,7 +355,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             self.services.add_characteristic(
                 BleakGATTCharacteristicBlueZDBus(char, object_path, _service[0].uuid)
             )
-            self._char_path_to_uuid[object_path] = char.get("UUID")
+            self._char_path_to_handle[object_path] = char.get("Handle")
 
         for desc, object_path in _descs:
             _characteristic = list(
@@ -605,17 +605,17 @@ class BleakClientBlueZDBus(BaseBleakClient):
     async def start_notify(
         self,
         char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, uuid.UUID],
-        callback: Callable[[str, Any], Any],
+        callback: Callable[[int, bytearray], None],
         **kwargs
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
-        Callbacks must accept two inputs. The first will be a uuid string
-        object and the second will be a bytearray.
+        Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
+        data and the second will be a ``bytearray``.
 
         .. code-block:: python
 
-            def callback(sender, data):
+            def callback(sender: int, data: bytearray):
                 print(f"{sender}: {data}")
             client.start_notify(char_uuid, callback)
 
@@ -670,13 +670,13 @@ class BleakClientBlueZDBus(BaseBleakClient):
             self._notification_callbacks[
                 characteristic.path
             ] = _data_notification_wrapper(
-                callback, self._char_path_to_uuid
+                callback, self._char_path_to_handle
             )  # noqa | E123 error in flake8...
         else:
             self._notification_callbacks[
                 characteristic.path
             ] = _regular_notification_wrapper(
-                callback, self._char_path_to_uuid
+                callback, self._char_path_to_handle
             )  # noqa | E123 error in flake8...
 
         self._subscriptions.append(characteristic.handle)

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -185,17 +185,17 @@ class BaseBleakClient(abc.ABC):
     async def start_notify(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        callback: Callable[[str, Any], Any],
+        callback: Callable[[int, bytearray], None],
         **kwargs
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
-        Callbacks must accept two inputs. The first will be a uuid string
-        object and the second will be a bytearray.
+        Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
+        data and the second will be a ``bytearray``.
 
         .. code-block:: python
 
-            def callback(sender, data):
+            def callback(sender: int, data: bytearray):
                 print(f"{sender}: {data}")
             client.start_notify(char_uuid, callback)
 

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -294,7 +294,7 @@ class PeripheralDelegate(NSObject):
 
         notify_callback = self._characteristic_notify_callbacks.get(c_handle)
         if notify_callback:
-            notify_callback(c_handle, value, cUUID)
+            notify_callback(c_handle, value)
 
         logger.debug("Read characteristic value")
         event = self._characteristic_read_events.get(cUUID)

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -319,7 +319,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         """Activate notifications/indications on a characteristic.
 
         Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
-        data and the second will be a ``bytearray``.
+        data and the second will be a ``bytearray`` containing the data sent from the connected server.
 
         .. code-block:: python
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -313,17 +313,17 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     async def start_notify(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        callback: Callable[[str, Any], Any],
+        callback: Callable[[int, bytearray], None],
         **kwargs
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
-        Callbacks must accept two inputs. The first will be a uuid string
-        object and the second will be a bytearray.
+        Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
+        data and the second will be a ``bytearray``.
 
         .. code-block:: python
 
-            def callback(sender, data):
+            def callback(sender: int, data: bytearray):
                 print(f"{sender}: {data}")
             client.start_notify(char_uuid, callback)
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -586,7 +586,7 @@ class BleakClientDotNet(BaseBleakClient):
         """Activate notifications/indications on a characteristic.
 
         Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
-        data and the second will be a ``bytearray``.
+        data and the second will be a ``bytearray`` containing the data sent from the connected server.
 
         .. code-block:: python
 
@@ -739,7 +739,7 @@ def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):
         reader.Dispose()
 
         return loop.call_soon_threadsafe(
-            func, int(sender.AttributeHandle), bytearray(output)
+            func, sender.AttributeHandle, bytearray(output)
         )
 
     return dotnet_notification_parser

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -580,17 +580,17 @@ class BleakClientDotNet(BaseBleakClient):
     async def start_notify(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        callback: Callable[[str, Any], Any],
+        callback: Callable[[int, bytearray], None],
         **kwargs
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
-        Callbacks must accept two inputs. The first will be a uuid string
-        object and the second will be a bytearray.
+        Callbacks must accept two inputs. The first will be a integer handle of the characteristic generating the
+        data and the second will be a ``bytearray``.
 
         .. code-block:: python
 
-            def callback(sender, data):
+            def callback(sender: int, data: bytearray):
                 print(f"{sender}: {data}")
             client.start_notify(char_uuid, callback)
 
@@ -739,7 +739,7 @@ def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):
         reader.Dispose()
 
         return loop.call_soon_threadsafe(
-            func, sender.Uuid.ToString(), bytearray(output)
+            func, int(sender.AttributeHandle), bytearray(output)
         )
 
     return dotnet_notification_parser


### PR DESCRIPTION
**POTENTIAL BREAKING CHANGE**: All notifications now have the characteristic's integer **handle** instead of its UUID as a string as the first argument ``sender`` sent to notification callbacks. This provides the uniqueness of sender in notifications as well.

This dawned on me when reviewing and merging #273. I think it is more correct this way, but it might break some existing code.