### PR TITLE
Safer `Core Bluetooth` presence check

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -51,9 +51,9 @@ if platform.system() == "Linux":
         BleakClientBlueZDBus as BleakClient,
     )  # noqa
 elif platform.system() == "Darwin":
-    from Foundation import NSClassFromString
-
-    if NSClassFromString("CBPeripheral") is None:
+    try:
+        from CoreBluetooth import CBPeripheral
+    except:
         raise BleakError("Bleak requires the CoreBluetooth Framework")
 
     from bleak.backends.corebluetooth.discovery import discover  # noqa

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -53,8 +53,8 @@ if platform.system() == "Linux":
 elif platform.system() == "Darwin":
     try:
         from CoreBluetooth import CBPeripheral
-    except:
-        raise BleakError("Bleak requires the CoreBluetooth Framework")
+    except Exception as ex:
+        raise BleakError("Bleak requires the CoreBluetooth Framework") from ex
 
     from bleak.backends.corebluetooth.discovery import discover  # noqa
     from bleak.backends.corebluetooth.scanner import (


### PR DESCRIPTION
The previous check does not working on macOS Big Sur as it presumes that Core Bluetooth was already loaded on the process.

Superseeds #278