### PR TITLE
Handle 2-stage discovery on MacOS better

### DIFF
--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -201,6 +201,8 @@ class CentralManagerDelegate(NSObject):
         RSSI: NSNumber,
     ):
         # Note: this function might be called several times for same device.
+        # This can happen for instance when an active scan is done, and the
+        # second call with contain the data from the BLE scan response.
         # Example a first time with the following keys in advertisementData:
         # ['kCBAdvDataLocalName', 'kCBAdvDataIsConnectable', 'kCBAdvDataChannel']
         # ... and later a second time with other keys (and values) such as:
@@ -216,6 +218,9 @@ class CentralManagerDelegate(NSObject):
 
         if uuid_string in self.devices:
             device = self.devices[uuid_string]
+            # It could be the device did not have a name previously but now it does.
+            if peripheral.name():
+                device.name = peripheral.name()
         else:
             address = uuid_string
             name = peripheral.name() or None

--- a/bleak/backends/corebluetooth/device.py
+++ b/bleak/backends/corebluetooth/device.py
@@ -47,7 +47,13 @@ class BLEDeviceCoreBluetooth(BLEDevice):
         if not cbuuids:
             return
         # converting to lower case to match other platforms
-        self.metadata["uuids"] = [str(u).lower() for u in cbuuids]
+        chuuids = [str(u).lower() for u in cbuuids]
+        if 'uuids' in self.metadata:
+            for uuid in chuuids:
+                if not uuid in self.metadata['uuids']:
+                    self.metadata['uuids'].append(uuid)
+        else:
+            self.metadata["uuids"] = chuuids
 
     def _update_manufacturer(self, advertisementData: NSDictionary):
         mfg_bytes = advertisementData.get("kCBAdvDataManufacturerData")


### PR DESCRIPTION
On MacOS you may get two callbacks when running a discovery: one when the `ADV_IND` packet arrives and a second one (in case of an active scan) when the SCAN_RSP packet arrives.

Bleak always picks up the device name only from the first packet (if it is in there). Bleak also overwrites any service UUIDs from the first packet if there are service UUIDs in the second packet.

This PR fixes both issues. It also addresses my main reason for #281