### PR TITLE
Connect by BLEDevice as well as string Bluetooth adress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,12 +26,15 @@ Added
 * Implemented pairing method in .NET backend.
 * Implemented pairing method in the BlueZ backend.
 * Added stumps and ``NotImplementedError`` on pairing in macOS backend.
+* Added the possibility to connect using ``BLEDevice`` instead of a string adress. This
+  allows for skipping the discovery call when connecting.
 
 Changed
 ~~~~~~~
 * **BREAKING CHANGE** All notifications now have the characteristic's integer **handle** instead of its UUID as a
   string as the first argument ``sender`` sent to notification callbacks. This provides the uniqueness of
   sender in notifications as well.
+* Renamed ``BleakClient`` argument ``address`` to ``address_or_device``.
 * Version 0.5.0 of BleakUWPBridge, with some modified methods and implementing ``IDisposable``.
 * Merged #224. All storing and passing of event loops in bleak is removed.
 * Removed Objective C delegate compliance checks. Merged #253.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,7 +34,7 @@ Changed
 * **BREAKING CHANGE** All notifications now have the characteristic's integer **handle** instead of its UUID as a
   string as the first argument ``sender`` sent to notification callbacks. This provides the uniqueness of
   sender in notifications as well.
-* Renamed ``BleakClient`` argument ``address`` to ``address_or_device``.
+* Renamed ``BleakClient`` argument ``address`` to ``address_or_ble_device``.
 * Version 0.5.0 of BleakUWPBridge, with some modified methods and implementing ``IDisposable``.
 * Merged #224. All storing and passing of event loops in bleak is removed.
 * Removed Objective C delegate compliance checks. Merged #253.

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -12,6 +12,7 @@ from typing import Callable, Any, Union
 
 from twisted.internet.error import ConnectionDone
 
+from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.exc import BleakError
@@ -36,20 +37,23 @@ class BleakClientBlueZDBus(BaseBleakClient):
     Implemented by using the `BlueZ DBUS API <https://docs.ubuntu.com/core/en/stacks/bluetooth/bluez/docs/reference/dbus-api>`_.
 
     Args:
-        address (str): The  address of the BLE peripheral to connect to.
+        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
 
     Keyword Args:
         timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
 
     """
 
-    def __init__(self, address, **kwargs):
-        super(BleakClientBlueZDBus, self).__init__(address, **kwargs)
+    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
+        super(BleakClientBlueZDBus, self).__init__(address_or_device, **kwargs)
         self.device = kwargs.get("device") if kwargs.get("device") else "hci0"
-        self.address = address
+        self.address = address_or_device
 
         # Backend specific, TXDBus objects and data
-        self._device_path = None
+        if isinstance(address_or_device, BLEDevice):
+            self._device_path = address_or_device.details["path"]
+        else:
+            self._device_path = None
         self._bus = None
         self._reactor = None
         self._rules = {}
@@ -109,16 +113,17 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """
         # A Discover must have been run before connecting to any devices.
         # Find the desired device before trying to connect.
-        timeout = kwargs.get("timeout", self._timeout)
-        device = await BleakScannerBlueZDBus.find_device_by_address(
-            self.address, timeout=timeout, device=self.device)
+        if self._device_path is None:
+            timeout = kwargs.get("timeout", self._timeout)
+            device = await BleakScannerBlueZDBus.find_device_by_address(
+                self.address, timeout=timeout, device=self.device)
 
-        if device:
-            self._device_path = device.details["path"]
-        else:
-            raise BleakError(
-                "Device with address {0} was not found.".format(self.address)
-            )
+            if device:
+                self._device_path = device.details["path"]
+            else:
+                raise BleakError(
+                    "Device with address {0} was not found.".format(self.address)
+                )
 
         loop = asyncio.get_event_loop()
         self._reactor = get_reactor(loop)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -37,21 +37,21 @@ class BleakClientBlueZDBus(BaseBleakClient):
     Implemented by using the `BlueZ DBUS API <https://docs.ubuntu.com/core/en/stacks/bluetooth/bluez/docs/reference/dbus-api>`_.
 
     Args:
-        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
+        address_or_ble_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
 
     Keyword Args:
         timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
 
     """
 
-    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
-        super(BleakClientBlueZDBus, self).__init__(address_or_device, **kwargs)
+    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs):
+        super(BleakClientBlueZDBus, self).__init__(address_or_ble_device, **kwargs)
         self.device = kwargs.get("device") if kwargs.get("device") else "hci0"
-        self.address = address_or_device
+        self.address = address_or_ble_device
 
         # Backend specific, TXDBus objects and data
-        if isinstance(address_or_device, BLEDevice):
-            self._device_path = address_or_device.details["path"]
+        if isinstance(address_or_ble_device, BLEDevice):
+            self._device_path = address_or_ble_device.details["path"]
         else:
             self._device_path = None
         self._bus = None

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -12,20 +12,26 @@ from typing import Callable, Any, Union
 
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.characteristic import BleakGATTCharacteristic
-
+from bleak.backends.device import BLEDevice
 
 class BaseBleakClient(abc.ABC):
     """The Client Interface for Bleak Backend implementations to implement.
 
     The documentation of this interface should thus be safe to use as a reference for your implementation.
 
+    Args:
+        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
+
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.
 
     """
 
-    def __init__(self, address, **kwargs):
-        self.address = address
+    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
+        if isinstance(address_or_device, BLEDevice):
+            self.address = address_or_device.address
+        else:
+            self.address = address_or_device
 
         self.services = BleakGATTServiceCollection()
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -20,18 +20,18 @@ class BaseBleakClient(abc.ABC):
     The documentation of this interface should thus be safe to use as a reference for your implementation.
 
     Args:
-        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
+        address_or_ble_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
 
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.
 
     """
 
-    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
-        if isinstance(address_or_device, BLEDevice):
-            self.address = address_or_device.address
+    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs):
+        if isinstance(address_or_ble_device, BLEDevice):
+            self.address = address_or_ble_device.address
         else:
-            self.address = address_or_device
+            self.address = address_or_ble_device
 
         self.services = BleakGATTServiceCollection()
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -20,9 +20,9 @@ from bleak.backends.corebluetooth.characteristic import (
     BleakGATTCharacteristicCoreBluetooth,
 )
 from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
-from bleak.backends.corebluetooth.discovery import discover
 from bleak.backends.corebluetooth.scanner import BleakScannerCoreBluetooth
 from bleak.backends.corebluetooth.service import BleakGATTServiceCoreBluetooth
+from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
@@ -35,14 +35,19 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     """CoreBluetooth class interface for BleakClient
 
     Args:
-        address (str): The uuid of the BLE peripheral to connect to.
+        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
 
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call during connect. Defaults to 10.0.
 
     """
-    def __init__(self, address: str, **kwargs):
-        super(BleakClientCoreBluetooth, self).__init__(address, **kwargs)
+    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
+        super(BleakClientCoreBluetooth, self).__init__(address_or_device, **kwargs)
+
+        if isinstance(address_or_device, BLEDevice):
+            self._device_info = address_or_device.details
+        else:
+            self._device_info = None
 
         self._device_info = None
         self._requester = None
@@ -64,16 +69,17 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             Boolean representing connection status.
 
         """
-        timeout = kwargs.get("timeout", self._timeout)
-        device = await BleakScannerCoreBluetooth.find_device_by_address(
-            self.address, timeout=timeout)
+        if self._device_info is None:
+            timeout = kwargs.get("timeout", self._timeout)
+            device = await BleakScannerCoreBluetooth.find_device_by_address(
+                self.address, timeout=timeout)
 
-        if device:
-            self._device_info = device.details
-        else:
-            raise BleakError(
-                "Device with address {} was not found".format(self.address)
-            )
+            if device:
+                self._device_info = device.details
+            else:
+                raise BleakError(
+                    "Device with address {} was not found".format(self.address)
+                )
 
         logger.debug("Connecting to BLE device @ {}".format(self.address))
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -35,17 +35,17 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     """CoreBluetooth class interface for BleakClient
 
     Args:
-        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
+        address_or_ble_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
 
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call during connect. Defaults to 10.0.
 
     """
-    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
-        super(BleakClientCoreBluetooth, self).__init__(address_or_device, **kwargs)
+    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs):
+        super(BleakClientCoreBluetooth, self).__init__(address_or_ble_device, **kwargs)
 
-        if isinstance(address_or_device, BLEDevice):
-            self._device_info = address_or_device.details
+        if isinstance(address_or_ble_device, BLEDevice):
+            self._device_info = address_or_ble_device.details
         else:
             self._device_info = None
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -92,19 +92,19 @@ class BleakClientDotNet(BaseBleakClient):
     Common Language Runtime (CLR). Therefore, much of the code below has a distinct C# feel.
 
     Args:
-        address_or_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
+        address_or_ble_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
 
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call. Defaults to 2.0.
 
     """
 
-    def __init__(self, address_or_device: Union[BLEDevice, str], **kwargs):
-        super(BleakClientDotNet, self).__init__(address_or_device, **kwargs)
+    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs):
+        super(BleakClientDotNet, self).__init__(address_or_ble_device, **kwargs)
 
         # Backend specific. Python.NET objects.
-        if isinstance(address_or_device, BLEDevice):
-            self._device_info = address_or_device.details.BluetoothAddress
+        if isinstance(address_or_ble_device, BLEDevice):
+            self._device_info = address_or_ble_device.details.BluetoothAddress
         else:
             self._device_info = None
         self._requester = None

--- a/examples/connect_by_bledevice.py
+++ b/examples/connect_by_bledevice.py
@@ -1,0 +1,24 @@
+"""
+Connect by BLEDevice
+"""
+
+import asyncio
+import platform
+
+from bleak import BleakClient, BleakScanner
+
+
+async def print_services(mac_addr: str):
+    device = await BleakScanner.find_device_by_address(mac_addr)
+    async with BleakClient(device) as client:
+        svcs = await client.get_services()
+        print("Services:", svcs)
+
+
+mac_addr = (
+    "24:71:89:cc:09:05"
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
+)
+loop = asyncio.get_event_loop()
+loop.run_until_complete(print_services(mac_addr))


### PR DESCRIPTION
* Added the possibility to connect using ``BLEDevice`` instead of a string adress. This allows for skipping the discovery call when connecting.
* Renamed ``BleakClient`` argument ``address`` to ``address_or_device``. 

Fixes #191 
Improves #284