### PR TITLE
Fix device_info logic in dotnet client

### DIFF
--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -136,7 +136,7 @@ class BleakClientDotNet(BaseBleakClient):
         self._bridge = Bridge()
 
         # Try to find the desired device.
-        if self._device_info is not None:
+        if self._device_info is None:
             timeout = kwargs.get("timeout", self._timeout)
             device = await BleakScannerDotNet.find_device_by_address(
                 self.address, timeout=timeout)


### PR DESCRIPTION
The logic was inverted. If a device was given in the BleakClient constructor, then the _device_info attribute is set to the Bluetooth address, otherwise it is set to None. So we should only trying scanning for the device if _device_info is None.