### PR TITLE
Adding timeout to dbus call as well to make sure it doesn't hang forever

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -86,8 +86,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """
         # A Discover must have been run before connecting to any devices.
         # Find the desired device before trying to connect.
+        timeout = kwargs.get("timeout", self._timeout)
         if self._device_path is None:
-            timeout = kwargs.get("timeout", self._timeout)
             device = await BleakScannerBlueZDBus.find_device_by_address(
                 self.address, timeout=timeout, device=self.device
             )
@@ -129,6 +129,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 "Connect",
                 interface=defs.DEVICE_INTERFACE,
                 destination=defs.BLUEZ_SERVICE,
+                timeout=timeout
             ).asFuture(loop)
         except RemoteError as e:
             await self._cleanup_all()


### PR DESCRIPTION
I have seen cases where this would get hung up.  It seems like it can be fixed by simply passing the same argument into the DBus request.  In theory the timeout could be 2x the `timeout` value.  If we care about that, we could do `timeout/2` but the intent is moreso that it does not hang forever.