### PR TITLE
UUID fixes and cleanups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,11 +16,20 @@ Added
 * Timeout for BlueZ backend connect call to avoid potential infinite hanging. Merged #306.
 * Added Interfaces API docs again.
 
+Changed
+~~~~~~~
+
+* ``BleakCharacteristic.description()`` on .NET now returns the same value as
+  other platforms.
+
 Fixed
 ~~~~~
 
 * UUID property bug fixed in BlueZ backend. Merged #307
 * Fix for broken RTD documentation.
+* Fix UUID string arguments should not be case sensitive.
+* Fix ``BleakGATTService.get_characteristic()`` method overridden with ``NotImplementedError``
+  in BlueZ backend.
 
 `0.8.0`_ (2020-09-22)
 ---------------------

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -3,7 +3,6 @@ from typing import Union, List
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.descriptor import BleakGATTDescriptor
-from bleak.uuids import uuidstr_to_str
 
 
 _GattCharacteristicsFlagsEnum = {
@@ -53,11 +52,6 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
     def uuid(self) -> str:
         """The uuid of this characteristic"""
         return self.obj.get("UUID")
-
-    @property
-    def description(self) -> str:
-        """Description for this characteristic"""
-        return uuidstr_to_str(self.uuid)
 
     @property
     def properties(self) -> List:

--- a/bleak/backends/bluezdbus/descriptor.py
+++ b/bleak/backends/bluezdbus/descriptor.py
@@ -1,5 +1,4 @@
 from bleak.backends.descriptor import BleakGATTDescriptor
-from bleak.uuids import uuidstr_to_str
 
 
 class BleakGATTDescriptorBlueZDBus(BleakGATTDescriptor):
@@ -42,8 +41,3 @@ class BleakGATTDescriptorBlueZDBus(BleakGATTDescriptor):
     def path(self) -> str:
         """The DBus path. Mostly needed by `bleak`, not by end user"""
         return self.__path
-
-    @property
-    def description(self) -> str:
-        """Description for this descriptor"""
-        return uuidstr_to_str(self.uuid)

--- a/bleak/backends/bluezdbus/service.py
+++ b/bleak/backends/bluezdbus/service.py
@@ -23,12 +23,6 @@ class BleakGATTServiceBlueZDBus(BleakGATTService):
         """List of characteristics for this service"""
         return self.__characteristics
 
-    def get_characteristic(
-        self, _uuid: Union[str, UUID]
-    ) -> Union[BleakGATTCharacteristicBlueZDBus, None]:
-        """Get a characteristic by UUID"""
-        raise NotImplementedError()
-
     def add_characteristic(self, characteristic: BleakGATTCharacteristicBlueZDBus):
         """Add a :py:class:`~BleakGATTCharacteristicBlueZDBus` to the service.
 

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from typing import List, Union, Any
 
 from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.uuids import uuidstr_to_str
 
 
 class GattCharacteristicsFlags(enum.Enum):
@@ -54,10 +55,9 @@ class BleakGATTCharacteristic(abc.ABC):
         raise NotImplementedError()
 
     @property
-    @abc.abstractmethod
     def description(self) -> str:
         """Description for this characteristic"""
-        raise NotImplementedError()
+        return uuidstr_to_str(self.uuid)
 
     @property
     @abc.abstractmethod

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -13,7 +13,6 @@ from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
 from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
-from bleak.uuids import uuidstr_to_str
 
 
 class CBChacteristicProperties(Enum):
@@ -87,12 +86,6 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     def uuid(self) -> str:
         """The uuid of this characteristic"""
         return self._uuid
-
-    @property
-    def description(self) -> str:
-        """Description for this characteristic"""
-        # No description available in Core Bluetooth backend.
-        return uuidstr_to_str(self._uuid)
 
     @property
     def properties(self) -> List:

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -77,7 +77,7 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     @property
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
-        return self.obj.service().UUID().UUIDString()
+        return cb_uuid_to_str(self.obj.service().UUID().UUIDString())
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -68,8 +68,7 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
             for v in [2 ** n for n in range(10)]
             if (self.obj.properties() & v)
         ]
-        uuid_string = self.obj.UUID().UUIDString()
-        self._uuid = cb_uuid_to_str(uuid_string)
+        self._uuid = cb_uuid_to_str(self.obj.UUID())
 
     def __str__(self):
         return "{0}: {1}".format(self.uuid, self.description)
@@ -77,7 +76,7 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     @property
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
-        return cb_uuid_to_str(self.obj.service().UUID().UUIDString())
+        return cb_uuid_to_str(self.obj.service().UUID())
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -192,7 +192,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                     self.services.add_descriptor(
                         BleakGATTDescriptorCoreBluetooth(
                             descriptor,
-                            cb_uuid_to_str(characteristic.UUID().UUIDString()),
+                            cb_uuid_to_str(characteristic.UUID()),
                             int(characteristic.handle()),
                         )
                     )

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -22,6 +22,7 @@ from bleak.backends.corebluetooth.characteristic import (
 from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
 from bleak.backends.corebluetooth.scanner import BleakScannerCoreBluetooth
 from bleak.backends.corebluetooth.service import BleakGATTServiceCoreBluetooth
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -191,7 +192,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                     self.services.add_descriptor(
                         BleakGATTDescriptorCoreBluetooth(
                             descriptor,
-                            characteristic.UUID().UUIDString(),
+                            cb_uuid_to_str(characteristic.UUID().UUIDString()),
                             int(characteristic.handle()),
                         )
                     )

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -8,7 +8,6 @@ from Foundation import CBDescriptor
 
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.descriptor import BleakGATTDescriptor
-from bleak.uuids import uuidstr_to_str
 
 
 class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
@@ -44,8 +43,3 @@ class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
     def handle(self) -> int:
         """Integer handle for this descriptor"""
         return int(self.obj.handle())
-
-    @property
-    def description(self) -> str:
-        """Description for this descriptor"""
-        return uuidstr_to_str(self.uuid)

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -38,7 +38,7 @@ class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
     @property
     def uuid(self) -> str:
         """UUID for this descriptor"""
-        return cb_uuid_to_str(self.obj.UUID().UUIDString())
+        return cb_uuid_to_str(self.obj.UUID())
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -6,6 +6,7 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 """
 from Foundation import CBDescriptor
 
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.uuids import uuidstr_to_str
 
@@ -37,7 +38,7 @@ class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
     @property
     def uuid(self) -> str:
         """UUID for this descriptor"""
-        return self.obj.UUID().UUIDString()
+        return cb_uuid_to_str(self.obj.UUID().UUIDString())
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -19,7 +19,7 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
     @property
     def uuid(self) -> str:
         """UUID for this service."""
-        return cb_uuid_to_str(self.obj.UUID().UUIDString())
+        return cb_uuid_to_str(self.obj.UUID())
 
     @property
     def characteristics(self) -> List[BleakGATTCharacteristicCoreBluetooth]:

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -1,3 +1,4 @@
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from typing import List, Union
 
 from Foundation import CBService, CBUUID
@@ -17,21 +18,13 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
 
     @property
     def uuid(self) -> str:
-        return self.obj.UUID().UUIDString()
+        """UUID for this service."""
+        return cb_uuid_to_str(self.obj.UUID().UUIDString())
 
     @property
     def characteristics(self) -> List[BleakGATTCharacteristicCoreBluetooth]:
         """List of characteristics for this service"""
         return self.__characteristics
-
-    def get_characteristic(
-        self, _uuid: CBUUID
-    ) -> Union[BleakGATTCharacteristicCoreBluetooth, None]:
-        """Get a characteristic by UUID"""
-        try:
-            return next(filter(lambda x: x.uuid == _uuid, self.characteristics))
-        except StopIteration:
-            return None
 
     def add_characteristic(self, characteristic: BleakGATTCharacteristicCoreBluetooth):
         """Add a :py:class:`~BleakGATTCharacteristicDotNet` to the service.

--- a/bleak/backends/corebluetooth/utils.py
+++ b/bleak/backends/corebluetooth/utils.py
@@ -1,7 +1,19 @@
 from Foundation import NSData, CBUUID
 
 
-def cb_uuid_to_str(_uuid: str) -> str:
+def cb_uuid_to_str(_uuid: CBUUID) -> str:
+    """Converts a CoreBluetooth UUID to a Python string.
+
+    If ``_uuid`` is a 16-bit UUID, it is assumed to be a Bluetooth GATT UUID
+    (``0000xxxx-0000-1000-8000-00805f9b34fb``).
+
+    Args
+        _uuid: The UUID.
+
+    Returns:
+        The UUID as a lower case Python string (``xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx``)
+    """
+    _uuid = _uuid.UUIDString()
     if len(_uuid) == 4:
         return "0000{0}-0000-1000-8000-00805f9b34fb".format(_uuid.lower())
     # TODO: Evaluate if this is a necessary method...

--- a/bleak/backends/corebluetooth/utils.py
+++ b/bleak/backends/corebluetooth/utils.py
@@ -12,7 +12,7 @@ def cb_uuid_to_str(_uuid: str) -> str:
 
 
 def _is_uuid_16bit_compatible(_uuid: str) -> bool:
-    test_uuid = "0000FFFF-0000-1000-8000-00805F9B34FB"
+    test_uuid = "0000ffff-0000-1000-8000-00805f9b34fb"
     test_int = _convert_uuid_to_int(test_uuid)
     uuid_int = _convert_uuid_to_int(_uuid)
     result_int = uuid_int & test_int
@@ -31,4 +31,4 @@ def _convert_int_to_uuid(i: int) -> str:
     UUID_bytes = i.to_bytes(length=16, byteorder="big")
     UUID_data = NSData.alloc().initWithBytes_length_(UUID_bytes, len(UUID_bytes))
     UUID_cb = CBUUID.alloc().initWithData_(UUID_data)
-    return UUID_cb.UUIDString()
+    return UUID_cb.UUIDString().lower()

--- a/bleak/backends/descriptor.py
+++ b/bleak/backends/descriptor.py
@@ -136,6 +136,6 @@ class BleakGATTDescriptor(abc.ABC):
         raise NotImplementedError()
 
     @property
-    def description(self):
+    def description(self) -> str:
         """A text description of what this descriptor represents"""
         return _descriptor_descriptions.get(self.uuid.lower(), ["None"])[0]

--- a/bleak/backends/dotnet/characteristic.py
+++ b/bleak/backends/dotnet/characteristic.py
@@ -70,11 +70,6 @@ class BleakGATTCharacteristicDotNet(BleakGATTCharacteristic):
         return self.obj.Uuid.ToString()
 
     @property
-    def description(self) -> str:
-        """Description for this characteristic"""
-        return self.obj.UserDescription
-
-    @property
     def properties(self) -> List:
         """Properties of this characteristic"""
         return self.__props

--- a/bleak/backends/dotnet/service.py
+++ b/bleak/backends/dotnet/service.py
@@ -17,22 +17,14 @@ class BleakGATTServiceDotNet(BleakGATTService):
         ]
 
     @property
-    def uuid(self):
+    def uuid(self) -> str:
+        """UUID for this service."""
         return self.obj.Uuid.ToString()
 
     @property
     def characteristics(self) -> List[BleakGATTCharacteristicDotNet]:
         """List of characteristics for this service"""
         return self.__characteristics
-
-    def get_characteristic(
-        self, _uuid: Union[str, UUID]
-    ) -> Union[BleakGATTCharacteristicDotNet, None]:
-        """Get a characteristic by UUID"""
-        try:
-            return next(filter(lambda x: x.uuid == str(_uuid), self.characteristics))
-        except StopIteration:
-            return None
 
     def add_characteristic(self, characteristic: BleakGATTCharacteristicDotNet):
         """Add a :py:class:`~BleakGATTCharacteristicDotNet` to the service.

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -118,7 +118,7 @@ class BleakGATTServiceCollection(object):
 
     def get_service(self, _uuid: Union[str, UUID]) -> BleakGATTService:
         """Get a service by UUID string"""
-        return self.services.get(str(_uuid), None)
+        return self.services.get(str(_uuid).lower(), None)
 
     def add_characteristic(self, characteristic: BleakGATTCharacteristic):
         """Add a :py:class:`~BleakGATTCharacteristic` to the service collection.
@@ -145,7 +145,8 @@ class BleakGATTServiceCollection(object):
             # Assume uuid usage.
             x = list(
                 filter(
-                    lambda x: x.uuid == str(specifier), self.characteristics.values()
+                    lambda x: x.uuid == str(specifier).lower(),
+                    self.characteristics.values(),
                 )
             )
             if len(x) > 1:

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -6,7 +6,6 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 
 """
 import abc
-import uuid
 from uuid import UUID
 from typing import List, Union, Iterator
 
@@ -50,12 +49,24 @@ class BleakGATTService(abc.ABC):
         """
         raise NotImplementedError()
 
-    @abc.abstractmethod
     def get_characteristic(
-        self, _uuid: Union[str, UUID]
+        self, uuid: Union[str, UUID]
     ) -> Union[BleakGATTCharacteristic, None]:
-        """Get a characteristic by UUID"""
-        raise NotImplementedError()
+        """Get a characteristic by UUID.
+
+        Args:
+            uuid: The UUID to match.
+
+        Returns:
+            The first characteristic matching ``uuid`` or ``None`` if no
+            matching characteristic was found.
+        """
+        try:
+            return next(
+                filter(lambda x: x.uuid == str(uuid).lower(), self.characteristics)
+            )
+        except StopIteration:
+            return None
 
 
 class BleakGATTServiceCollection(object):
@@ -67,7 +78,7 @@ class BleakGATTServiceCollection(object):
         self.__descriptors = {}
 
     def __getitem__(
-        self, item: Union[str, int, uuid.UUID]
+        self, item: Union[str, int, UUID]
     ) -> Union[BleakGATTService, BleakGATTCharacteristic, BleakGATTDescriptor]:
         """Get a service, characteristic or descriptor from uuid or handle"""
         return self.services.get(


### PR DESCRIPTION
I recently ran into an issue where calling methods such as` BleakGattService.get_characteristic()` with a string for the UUID that contained uppercase letters would fail even though the UUID was otherwise correct.

This fixes that issue and includes some more cleanups in related code.