### PR TITLE
Avoiding 'None' case when disconnecting

### DIFF
--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -36,7 +36,6 @@ from libdispatch import dispatch_queue_create, DISPATCH_QUEUE_SERIAL
 from bleak.backends.corebluetooth.PeripheralDelegate import PeripheralDelegate
 from bleak.backends.corebluetooth.device import BLEDeviceCoreBluetooth
 
-
 logger = logging.getLogger(__name__)
 CBCentralManagerDelegate = objc.protocolNamed("CBCentralManagerDelegate")
 
@@ -153,6 +152,10 @@ class CentralManagerDelegate(NSObject):
         return self._connection_state == CMDConnectionState.CONNECTED
 
     async def disconnect(self) -> bool:
+        # Is a peripheral even connected?
+        if self.connected_peripheral is None:
+            return True
+
         self._connection_state = CMDConnectionState.PENDING
         self.central_manager.cancelPeripheralConnection_(self.connected_peripheral)
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -110,6 +110,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     async def disconnect(self) -> bool:
         """Disconnect from the peripheral device"""
         manager = self._central_manager_delegate
+        if manager is None:
+            return False
         await manager.disconnect()
         self.services = BleakGATTServiceCollection()
         # Ensure that `get_services` retrieves services again, rather than using the cached object


### PR DESCRIPTION
If `disconnect()` is called more than once it will try to operate a _None_ object, which can cause some low-level assertion errors in CoreBluetooth and leave Bleak in a strange state.

This is related to #319 