### PR TITLE
Adding a timeout on OSX so that the connect cannot hang forever.

### DIFF
--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -77,6 +77,7 @@ class CentralManagerDelegate(NSObject):
 
         self.callbacks = {}
         self.disconnected_callback = None
+        self._connection_state_changed = asyncio.Event()
 
         self.central_manager = CBCentralManager.alloc().initWithDelegate_queue_(
             self, dispatch_queue_create(b"bleak.corebluetooth", DISPATCH_QUEUE_SERIAL)
@@ -146,11 +147,11 @@ class CentralManagerDelegate(NSObject):
         self._connection_state = CMDConnectionState.PENDING
         self.central_manager.connectPeripheral_options_(peripheral, None)
 
-        start = time.time()
-        while self._connection_state == CMDConnectionState.PENDING:
-            await asyncio.sleep(0)
-            if time.time() - start > timeout:
-                raise TimeoutError("Failed to connect in %d seconds" % timeout)
+        try:
+            await asyncio.wait_for(self._connection_state_changed.wait(), timeout=timeout)
+        except TimeoutError:
+            logger.debug(f"Connection timed out after {timeout} seconds.")
+            return False
 
         self.connected_peripheral = peripheral
 
@@ -272,6 +273,7 @@ class CentralManagerDelegate(NSObject):
             )
             self.connected_peripheral_delegate = peripheralDelegate
             self._connection_state = CMDConnectionState.CONNECTED
+            self._connection_state_changed.set()
 
     def centralManager_didConnectPeripheral_(self, central, peripheral):
         logger.debug("centralManager_didConnectPeripheral_")
@@ -291,6 +293,7 @@ class CentralManagerDelegate(NSObject):
             )
         )
         self._connection_state = CMDConnectionState.DISCONNECTED
+        self._connection_state_changed.set()
 
     def centralManager_didFailToConnectPeripheral_error_(
         self, centralManager: CBCentralManager, peripheral: CBPeripheral, error: NSError

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -9,7 +9,6 @@ Created on June, 25 2019 by kevincar <kevincarrolldavis@gmail.com>
 import asyncio
 import logging
 import platform
-import time
 from enum import Enum
 from typing import List
 

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -148,7 +148,9 @@ class CentralManagerDelegate(NSObject):
         self.central_manager.connectPeripheral_options_(peripheral, None)
 
         try:
-            await asyncio.wait_for(self._connection_state_changed.wait(), timeout=timeout)
+            await asyncio.wait_for(
+                self._connection_state_changed.wait(), timeout=timeout
+            )
         except TimeoutError:
             logger.debug(f"Connection timed out after {timeout} seconds.")
             return False

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -9,6 +9,7 @@ Created on June, 25 2019 by kevincar <kevincarrolldavis@gmail.com>
 import asyncio
 import logging
 import platform
+import time
 from enum import Enum
 from typing import List
 
@@ -141,12 +142,15 @@ class CentralManagerDelegate(NSObject):
         await asyncio.sleep(float(scan_options.get("timeout", 0.0)))
         return await self.stop_scan()
 
-    async def connect_(self, peripheral: CBPeripheral) -> bool:
+    async def connect_(self, peripheral: CBPeripheral, timeout=10.0) -> bool:
         self._connection_state = CMDConnectionState.PENDING
         self.central_manager.connectPeripheral_options_(peripheral, None)
 
+        start = time.time()
         while self._connection_state == CMDConnectionState.PENDING:
             await asyncio.sleep(0)
+            if time.time() - start > timeout:
+                raise TimeoutError("Failed to connect in %d seconds" % timeout)
 
         self.connected_peripheral = peripheral
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -71,8 +71,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             Boolean representing connection status.
 
         """
+        timeout = kwargs.get("timeout", self._timeout)
         if self._device_info is None:
-            timeout = kwargs.get("timeout", self._timeout)
             device = await BleakScannerCoreBluetooth.find_device_by_address(
                 self.address, timeout=timeout
             )
@@ -89,7 +89,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         manager = self._central_manager_delegate
         logger.debug("CentralManagerDelegate  at {}".format(manager))
         logger.debug("Connecting to BLE device @ {}".format(self.address))
-        await manager.connect_(self._device_info)
+        await manager.connect_(self._device_info, timeout=timeout)
         manager.disconnected_callback = self._disconnected_callback_client
 
         # Now get services


### PR DESCRIPTION
I have seen connect get itself in a state where will loop indefinitely.  This timeout fix seems to fix it.  `time.time()` seems like a hack, but I cannot think of a better way offhand.  Open to suggestions.