### PR TITLE
corebluetooth: use cb_uuid_to_str() to convert kCBAdvDataServiceUUIDs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+
+`Unreleased`_
+--------------
+
+Fixed
+~~~~~
+
+* Fix well-known services not converted to UUIDs in ``BLEDevice.metadata`` in
+  CoreBluetooth backend. Fixes #342.
+
+
 `0.9.0`_ (2020-10-20)
 ---------------------
 

--- a/bleak/backends/corebluetooth/device.py
+++ b/bleak/backends/corebluetooth/device.py
@@ -3,7 +3,7 @@ from bleak.backends._manufacturers import MANUFACTURERS
 
 from Foundation import NSDictionary
 
-
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
 
 
@@ -46,8 +46,7 @@ class BLEDeviceCoreBluetooth(BLEDevice):
         cbuuids = advertisementData.get("kCBAdvDataServiceUUIDs", [])
         if not cbuuids:
             return
-        # converting to lower case to match other platforms
-        chuuids = [str(u).lower() for u in cbuuids]
+        chuuids = [cb_uuid_to_str(u) for u in cbuuids]
         if "uuids" in self.metadata:
             for uuid in chuuids:
                 if not uuid in self.metadata["uuids"]:

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Callable, Any, Union, List
 
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 from bleak.backends.scanner import BaseBleakScanner
@@ -101,8 +102,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
                 manufacturer_data = {manufacturer_id: manufacturer_value}
 
             uuids = [
-                # converting to lower case to match other platforms
-                str(u).lower()
+                cb_uuid_to_str(u)
                 for u in advertisementData.get("kCBAdvDataServiceUUIDs", [])
             ]
 


### PR DESCRIPTION
This was missed in 6a0d8c99f5c82b6b1c000316fb1c0dff49a92138.

Also, since this was just using `str()` directly on the `CBUUID` instance, it had an additional bug for well known services since `str()` would return the name of the service instead of a UUID.

Fixes #342.