### PR TITLE
macOS fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
   backend. Merged #343.
 * Fix CBCentralManager not properly waited for during initialization in some
   cases.
+* Fix AttributeError in CoreBluetooth when using BLEDeviceCoreBluetooth object.
 
 
 `0.9.0`_ (2020-10-20)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Fixed
   CoreBluetooth backend. Fixes #342.
 * Fix advertising data replaced instead of merged in scanner in CoreBluetooth
   backend. Merged #343.
+* Fix CBCentralManager not properly waited for during initialization in some
+  cases.
 
 
 `0.9.0`_ (2020-10-20)

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -225,7 +225,7 @@ class CentralManagerDelegate(NSObject):
             address = uuid_string
             name = peripheral.name() or None
             details = peripheral
-            device = BLEDeviceCoreBluetooth(address, name, details)
+            device = BLEDeviceCoreBluetooth(address, name, details, delegate=self)
             self.devices[uuid_string] = device
 
         device._rssi = float(RSSI)

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -48,9 +48,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         if isinstance(address_or_ble_device, BLEDevice):
             self._device_info = address_or_ble_device.details
-            self._central_manager_delegate = address_or_ble_device.metadata.get(
-                "delegate"
-            )
+            self._central_manager_delegate = address_or_ble_device.metadata["delegate"]
         else:
             self._device_info = None
             self._central_manager_delegate = None
@@ -79,7 +77,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
             if device:
                 self._device_info = device.details
-                self._central_manager_delegate = device.metadata.get("delegate")
+                self._central_manager_delegate = device.metadata["delegate"]
             else:
                 raise BleakError(
                     "Device with address {} was not found".format(self.address)

--- a/bleak/backends/corebluetooth/device.py
+++ b/bleak/backends/corebluetooth/device.py
@@ -14,7 +14,7 @@ class BLEDeviceCoreBluetooth(BLEDevice):
 
     - The `details` attribute will be a CBPeripheral object.
 
-    - The `metadata` keys are more or less part of the crossplattform interface.
+    - The `metadata` keys are more or less part of the cross-platform interface.
 
     - Note: Take care not to rely on any reference to `advertisementData` and
       it's data as lower layers of the corebluetooth stack can change it. i.e.
@@ -35,7 +35,6 @@ class BLEDeviceCoreBluetooth(BLEDevice):
 
     def __init__(self, *args, **kwargs):
         super(BLEDeviceCoreBluetooth, self).__init__(*args, **kwargs)
-        self.metadata = {}
         self._rssi = kwargs.get("rssi")
 
     def _update(self, advertisementData: NSDictionary):

--- a/bleak/backends/corebluetooth/discovery.py
+++ b/bleak/backends/corebluetooth/discovery.py
@@ -7,12 +7,10 @@ Created on 2019-06-24 by kevincar <kevincarrolldavis@gmail.com>
 
 """
 
-import asyncio
 from typing import List
 
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.device import BLEDevice
-from bleak.exc import BleakError
 
 
 async def discover(timeout: float = 5.0, **kwargs) -> List[BLEDevice]:
@@ -23,11 +21,6 @@ async def discover(timeout: float = 5.0, **kwargs) -> List[BLEDevice]:
 
     """
     manager = CentralManagerDelegate.alloc().init()
-    try:
-        await manager.wait_for_powered_on(0.1)
-    except asyncio.TimeoutError:
-        raise BleakError("Bluetooth device is turned off")
-
     scan_options = {"timeout": timeout}
 
     await manager.scanForPeripherals_(scan_options)

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -7,7 +7,6 @@ from typing import Callable, Any, Union, List
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
-from bleak.exc import BleakError
 from bleak.backends.scanner import BaseBleakScanner
 
 
@@ -40,11 +39,6 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         self._timeout = kwargs.get("timeout", 5.0)
 
     async def start(self):
-        try:
-            await self._manager.wait_for_powered_on(0.1)
-        except asyncio.TimeoutError:
-            raise BleakError("Bluetooth device is turned off")
-
         self._identifiers = {}
 
         def callback(p, a, r):


### PR DESCRIPTION
First commit fixes possible race condition when using `CBCentralManager` in rare cases. (I was also getting a `asyncio.TimeoutError` from `wait_for_powered_on()` when running using a debugger that is fixed by this.)

Second commit fixes a regression from 583c08e4bf1b.