### PR TITLE
Fixed issue #374 by moving the dbus 'StartNotify' call in start_notif…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 -----
 
 * Fixed use of bare exceptions.
+* Fixed #374 "BleakClientBlueZDBus.start_notify() misses initial notifications with fast Bluetooth devices"
 
 Removed
 ~~~~~~~

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -716,15 +716,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     char_specifier
                 )
             )
-        await self._bus.callRemote(
-            characteristic.path,
-            "StartNotify",
-            interface=defs.GATT_CHARACTERISTIC_INTERFACE,
-            destination=defs.BLUEZ_SERVICE,
-            signature="",
-            body=[],
-            returnSignature="",
-        ).asFuture(asyncio.get_event_loop())
 
         if _wrap:
             self._notification_callbacks[
@@ -740,6 +731,16 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )  # noqa | E123 error in flake8...
 
         self._subscriptions.append(characteristic.handle)
+
+        await self._bus.callRemote(
+            characteristic.path,
+            "StartNotify",
+            interface=defs.GATT_CHARACTERISTIC_INTERFACE,
+            destination=defs.BLUEZ_SERVICE,
+            signature="",
+            body=[],
+            returnSignature="",
+        ).asFuture(asyncio.get_event_loop())
 
     async def stop_notify(
         self,


### PR DESCRIPTION
…y() after the callback has been stored in the _notification_callbacks dict

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.6+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
