### PR TITLE
fix dotnet event callbacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Fixed
 -----
 
 * Fixed use of bare exceptions.
-* Fixed #374 "BleakClientBlueZDBus.start_notify() misses initial notifications with fast Bluetooth devices"
+* Fixed #374 "BleakClientBlueZDBus.start_notify() misses initial notifications with fast Bluetooth devices".
+* Fix event callbacks on Windows not running in asyncio event loop thread.
 
 Removed
 ~~~~~~~

--- a/bleak/backends/dotnet/discovery.py
+++ b/bleak/backends/dotnet/discovery.py
@@ -17,13 +17,18 @@ from bleak.backends.device import BLEDevice
 from BleakBridge import Bridge  # noqa: F401
 
 from System import Array, Object
-from Windows.Devices import Enumeration
 from Windows.Devices.Bluetooth.Advertisement import (
     BluetoothLEAdvertisementWatcher,
     BluetoothLEScanningMode,
     BluetoothLEAdvertisementType,
     BluetoothLEAdvertisementReceivedEventArgs,
     BluetoothLEAdvertisementWatcherStoppedEventArgs,
+)
+from Windows.Devices.Enumeration import (
+    DeviceInformation,
+    DeviceInformationUpdate,
+    DeviceInformationKind,
+    DeviceWatcher,
 )
 from Windows.Foundation import TypedEventHandler
 
@@ -175,10 +180,10 @@ async def discover_by_enumeration(timeout: float = 5.0, **kwargs) -> List[BLEDev
     aqs_all_bluetooth_le_devices = (
         '(System.Devices.Aep.ProtocolId:="' '{bb7bb05e-5972-42b5-94fc-76eaa7084d49}")'
     )
-    watcher = Enumeration.DeviceInformation.CreateWatcher(
+    watcher = DeviceInformation.CreateWatcher(
         aqs_all_bluetooth_le_devices,
         requested_properties,
-        Enumeration.DeviceInformationKind.AssociationEndpoint,
+        DeviceInformationKind.AssociationEndpoint,
     )
 
     devices = {}
@@ -231,27 +236,19 @@ async def discover_by_enumeration(timeout: float = 5.0, **kwargs) -> List[BLEDev
             )
 
     added_token = watcher.add_Added(
-        TypedEventHandler[Enumeration.DeviceWatcher, Enumeration.DeviceInformation](
-            _added_handler
-        )
+        TypedEventHandler[DeviceWatcher, DeviceInformation](_added_handler)
     )
     updated_token = watcher.add_Updated(
-        TypedEventHandler[
-            Enumeration.DeviceWatcher, Enumeration.DeviceInformationUpdate
-        ](_updated_handler)
+        TypedEventHandler[DeviceWatcher, DeviceInformationUpdate](_updated_handler)
     )
     removed_token = watcher.add_Removed(
-        TypedEventHandler[
-            Enumeration.DeviceWatcher, Enumeration.DeviceInformationUpdate
-        ](_removed_handler)
+        TypedEventHandler[DeviceWatcher, DeviceInformationUpdate](_removed_handler)
     )
     enumeration_completed_token = watcher.add_EnumerationCompleted(
-        TypedEventHandler[Enumeration.DeviceWatcher, Object](
-            _enumeration_completed_handler
-        )
+        TypedEventHandler[DeviceWatcher, Object](_enumeration_completed_handler)
     )
     stopped_token = watcher.add_Stopped(
-        TypedEventHandler[Enumeration.DeviceWatcher, Object](_stopped_handler)
+        TypedEventHandler[DeviceWatcher, Object](_stopped_handler)
     )
 
     # Watcher works outside of the Python process.

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -76,7 +76,11 @@ class BleakScannerDotNet(BaseBleakScanner):
         self._signal_strength_filter = kwargs.get("SignalStrengthFilter", None)
         self._advertisement_filter = kwargs.get("AdvertisementFilter", None)
 
-    def _received_handler(self, sender, event_args):
+    def _received_handler(
+        self,
+        sender: BluetoothLEAdvertisementWatcher,
+        event_args: BluetoothLEAdvertisementReceivedEventArgs,
+    ):
         if sender == self.watcher:
             logger.debug("Received {0}.".format(_format_event_args(event_args)))
             if (
@@ -91,7 +95,11 @@ class BleakScannerDotNet(BaseBleakScanner):
         if self._callback is not None:
             self._callback(sender, event_args)
 
-    def _stopped_handler(self, sender, event_args):
+    def _stopped_handler(
+        self,
+        sender: BluetoothLEAdvertisementWatcher,
+        event_args: BluetoothLEAdvertisementWatcherStoppedEventArgs,
+    ):
         if sender == self.watcher:
             logger.debug(
                 "{0} devices found. Watcher status: {1}.".format(
@@ -103,17 +111,23 @@ class BleakScannerDotNet(BaseBleakScanner):
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.ScanningMode = self._scanning_mode
 
+        event_loop = asyncio.get_event_loop()
+
         self._received_token = self.watcher.add_Received(
             TypedEventHandler[
                 BluetoothLEAdvertisementWatcher,
                 BluetoothLEAdvertisementReceivedEventArgs,
-            ](self._received_handler)
+            ](
+                lambda s, e: event_loop.call_soon_threadsafe(
+                    self._received_handler, s, e
+                )
+            )
         )
         self._stopped_token = self.watcher.add_Stopped(
             TypedEventHandler[
                 BluetoothLEAdvertisementWatcher,
                 BluetoothLEAdvertisementWatcherStoppedEventArgs,
-            ](self._stopped_handler)
+            ](lambda s, e: event_loop.call_soon_threadsafe(self._stopped_handler, s, e))
         )
 
         if self._signal_strength_filter is not None:


### PR DESCRIPTION
Windows .NET event handler callbacks run on a background thread, so we need to use `call_soon_threadsafe()` to schedule the callbacks in the asyncio event loop. See commit messages for more details.