### PR TITLE
CoreBluetooth: update PyObjC to 7.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 --------------
 
+Changed
+-------
+Update minimum PyObjC version to 7.0.1.
+
 Fixed
 -----
 

--- a/Pipfile
+++ b/Pipfile
@@ -5,9 +5,9 @@ name = "pypi"
 
 [packages]
 txdbus = {version = ">=1.1.1", sys_platform = "== 'linux'"}
-pyobjc-core = {version = ">=6.2", sys_platform = "== 'darwin'"}
-pyobjc-framework-CoreBluetooth = {version = ">=6.2", sys_platform = "== 'darwin'"}
-pyobjc-framework-libdispatch = {version = ">=6.2", sys_platform = "== 'darwin'"}
+pyobjc-core = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
+pyobjc-framework-CoreBluetooth = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
+pyobjc-framework-libdispatch = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pythonnet = {version = ">=2.5.1", sys_platform = "== 'win32'"}
 
 [dev-packages]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 txdbus>=1.1.1; sys_platform=="linux"
-pyobjc-core>=6.2;sys_platform == 'darwin'
-pyobjc-framework-CoreBluetooth>=6.2;sys_platform == 'darwin'
-pyobjc-framework-libdispatch>=6.2;sys_platform == 'darwin'
+pyobjc-core>=7.0.1;sys_platform == 'darwin'
+pyobjc-framework-CoreBluetooth>=7.0.1;sys_platform == 'darwin'
+pyobjc-framework-libdispatch>=7.0.1;sys_platform == 'darwin'
 pythonnet>=2.5.1; sys_platform == 'win32'


### PR DESCRIPTION
This avoids a crash on macOS <= 10.15 in PyObjC 7.0.0.

Fixes #372
