### PR TITLE
Fixed ``BleakScanner.discover()`` on older versions of macOS.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Fixed
 -----
 
 * Fixed use of bare exceptions.
-* Fixed #374 "BleakClientBlueZDBus.start_notify() misses initial notifications with fast Bluetooth devices"
+* Fixed #374 "BleakClientBlueZDBus.start_notify() misses initial notifications with fast Bluetooth devices".
+* Fixed ``BleakScanner.discover()`` on older versions of macOS. Fixes #331.
 
 Removed
 ~~~~~~~

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -3,6 +3,8 @@ import asyncio
 import pathlib
 from typing import Callable, Union, List
 
+from Foundation import NSArray
+
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
@@ -75,7 +77,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
     async def get_discovered_devices(self) -> List[BLEDevice]:
         found = []
         peripherals = self._manager.central_manager.retrievePeripheralsWithIdentifiers_(
-            self._identifiers.keys(),
+            NSArray(self._identifiers.keys()),
         )
 
         for i, peripheral in enumerate(peripherals):


### PR DESCRIPTION
Fixes #331
Fixes #352
