### PR TITLE
Fixed disconnect callback on BlueZ backend.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,16 +11,18 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 --------------
 
 Changed
--------
-Update minimum PyObjC version to 7.0.1.
+~~~~~~~
+
+* Update minimum PyObjC version to 7.0.1.
 
 Fixed
------
+~~~~~
 
 * Fixed use of bare exceptions.
 * Fixed #374 "BleakClientBlueZDBus.start_notify() misses initial notifications with fast Bluetooth devices".
 * Fix event callbacks on Windows not running in asyncio event loop thread.
 * Fixed ``BleakScanner.discover()`` on older versions of macOS. Fixes #331.
+* Fixed disconnect callback on BlueZ backend.
 
 Removed
 ~~~~~~~

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -9,7 +9,7 @@ import re
 import subprocess
 import uuid
 import warnings
-from functools import wraps, partial
+from functools import wraps
 from typing import Callable, Union
 
 from twisted.internet.error import ConnectionDone
@@ -878,7 +878,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     task = asyncio.get_event_loop().create_task(self._cleanup_all())
                     if self._disconnected_callback is not None:
                         task.add_done_callback(
-                            partial(self._disconnected_callback, self)
+                            lambda _: self._disconnected_callback(self)
                         )
 
 


### PR DESCRIPTION
`add_done_callback()` calls the callback with one argument. This was causing `self._disconnected_callback()` to be called with two arguments but as in the disconnect example, it only expects one argument.

By replacing the partial function with a lambda expression, we can just ignore the extra argument.
