### PR TITLE
Consolidated implementation of BleakScanner.register_detection_callback()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,12 +12,15 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 Added
 ~~~~~
+
 * Added AdvertisementData class used with detection callbacks across all supported platforms. Merge #334
 
 Changed
 ~~~~~~~
 
-* Update minimum PyObjC version to 7.0.1.
+* Updated minimum PyObjC version to 7.0.1.
+* Consolidated implementation of BleakScanner.register_detection_callback().
+  All platforms now take callback with single AdvertisementData argument.
 
 Fixed
 ~~~~~

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -1,7 +1,7 @@
 import logging
 import asyncio
 import pathlib
-from typing import Callable, List
+from typing import List
 
 from bleak.backends.scanner import BaseBleakScanner, AdvertisementData
 from bleak.backends.device import BLEDevice
@@ -82,8 +82,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         self._adapter_path = None
         self._interface = None
-
-        self._callback = None
 
     async def start(self):
         loop = asyncio.get_event_loop()
@@ -204,15 +202,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
                 )
             )
         return discovered_devices
-
-    def register_detection_callback(self, callback: Callable):
-        """Set a function to be called on each device discovery by scanner and when a discovered device has a changed property.
-
-        Args:
-            callback: Function accepting one argument of type ``txdbus.message.SignalMessage``
-
-        """
-        self._callback = callback
 
     @classmethod
     async def find_device_by_address(

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import pathlib
-from typing import Callable, Union, List
+from typing import Union, List
 
 from Foundation import NSArray
 
@@ -33,7 +33,6 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
 
     def __init__(self, **kwargs):
         super(BleakScannerCoreBluetooth, self).__init__(**kwargs)
-        self._callback = None
         self._identifiers = None
         self._manager = CentralManagerDelegate.alloc().init()
         self._timeout = kwargs.get("timeout", 5.0)
@@ -44,6 +43,9 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         def callback(p, a, r):
             # update identifiers for scanned device
             self._identifiers.setdefault(p.identifier(), {}).update(a)
+
+            if not self._callback:
+                return
 
             # Process service data
             service_data_dict_raw = a.get("kCBAdvDataServiceData", {})
@@ -141,18 +143,6 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             )
 
         return found
-
-    def register_detection_callback(self, callback: Callable):
-        """Set a function to act as callback on discovered devices or devices with changed properties.
-
-        Args:
-            callback: Function accepting three arguments:
-             peripheral
-             advertisementData
-             rssi
-
-        """
-        self._callback = callback
 
     @classmethod
     async def find_device_by_address(

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -1,7 +1,7 @@
 import logging
 import asyncio
 import pathlib
-from typing import Callable, Union, List
+from typing import Union, List
 from uuid import UUID
 
 from bleak.backends.device import BLEDevice
@@ -63,8 +63,6 @@ class BleakScannerDotNet(BaseBleakScanner):
         self.watcher = None
         self._devices = {}
         self._scan_responses = {}
-
-        self._callback = None
 
         self._received_token = None
         self._stopped_token = None
@@ -234,20 +232,6 @@ class BleakScannerDotNet(BaseBleakScanner):
         return BLEDevice(
             bdaddr, local_name, event_args, uuids=uuids, manufacturer_data=data
         )
-
-    def register_detection_callback(self, callback: Callable):
-        """Set a function to act as Received Event Handler.
-
-        Documentation for the Event Handler:
-        https://docs.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementwatcher.received
-
-        Args:
-            callback: Function accepting two arguments:
-             sender (``Windows.Devices.Bluetooth.AdvertisementBluetoothLEAdvertisementWatcher``) and
-             eventargs (``Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementReceivedEventArgs``)
-
-        """
-        self._callback = callback
 
     # Windows specific
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -1,8 +1,67 @@
 import abc
 import asyncio
-from typing import Callable, List
+from typing import Callable, Dict, List, Optional, Tuple
 
 from bleak.backends.device import BLEDevice
+
+
+class AdvertisementData:
+    """
+    Wrapper around the advertisement data that each platform returns upon discovery
+    """
+
+    def __init__(self, address: str, **kwargs):
+        """
+        Required Args:
+            address (str): The platform specific address of the device
+
+        Keyword Args:
+            local_name (str): The name of the ble device advertising
+            rssi (int): Rssi value of the device
+            manufacturer_data (dict): Manufacturer data from the device
+            service_data (dict): Service data from the device
+            service_uuids (list): UUIDs associated with the device
+            platform_data (tuple): Tuple of platform specific advertisement data
+        """
+        # Platform specific address of the device
+        self.address: str = address
+
+        # The local name of the device
+        self.local_name: Optional[str] = kwargs.get("local_name", None)
+
+        # Integer RSSI value from the device
+        self.rssi: int = kwargs.get("rssi", 0)
+
+        # Dictionary of manufacturer data in bytes
+        self.manufacturer_data: Dict[int, bytes] = kwargs.get("manufacturer_data", {})
+
+        # Dictionary of service data
+        self.service_data: Dict[str, bytes] = kwargs.get("service_data", {})
+
+        # List of UUIDs
+        self.service_uuids: List[str] = kwargs.get("service_uuids", [])
+
+        # Tuple of platform specific data
+        self.platform_data: Tuple = kwargs.get("platform_data", ())
+
+    def __str__(self) -> str:
+        return repr(self)
+
+    def __repr__(self) -> str:
+        kwargs = ""
+        if self.local_name:
+            kwargs += f", local_name={repr(self.local_name)}"
+        if self.rssi:
+            kwargs += f", rssi={repr(self.rssi)}"
+        if self.manufacturer_data:
+            kwargs += f", manufacturer_data={repr(self.manufacturer_data)}"
+        if self.service_data:
+            kwargs += f", service_data={repr(self.service_data)}"
+        if self.service_uuids:
+            kwargs += f", service_uuids={repr(self.service_uuids)}"
+        if self.platform_data:
+            kwargs += f", platform_data={repr(self.platform_data)}"
+        return f"AdvertisementData({repr(self.address)}{kwargs})"
 
 
 class BaseBleakScanner(abc.ABC):
@@ -10,6 +69,7 @@ class BaseBleakScanner(abc.ABC):
 
     def __init__(self, *args, **kwargs):
         super(BaseBleakScanner, self).__init__()
+        self._callback: Optional[Callable[[AdvertisementData], None]] = None
 
     async def __aenter__(self):
         await self.start()
@@ -37,10 +97,18 @@ class BaseBleakScanner(abc.ABC):
             devices = await scanner.get_discovered_devices()
         return devices
 
-    @abc.abstractmethod
-    def register_detection_callback(self, callback: Callable):
-        """Register a callback that is called when a device is discovered or has a property changed."""
-        raise NotImplementedError()
+    def register_detection_callback(
+        self, callback: Optional[Callable[[AdvertisementData], None]]
+    ) -> None:
+        """Register a callback that is called when a device is discovered or has a property changed.
+
+        If another callback has already been registered, it will be replaced with ``callback``.
+
+        Args:
+            callback: A function that takes one argument which will be an :class:`AdvertisementData` object
+                      or ``None`` remove an existing callback.
+        """
+        self._callback = callback
 
     @abc.abstractmethod
     async def start(self):
@@ -111,62 +179,3 @@ class BaseBleakScanner(abc.ABC):
             await self.stop()
 
         return device
-
-
-class AdvertisementData:
-    """
-    Wrapper around the advertisement data that each platform returns upon discovery
-    """
-
-    def __init__(self, address, **kwargs):
-        """
-        Required Args:
-            address (str): The platform specific address of the device
-
-        Keyword Args:
-            local_name (str): The name of the ble device advertising
-            rssi (int): Rssi value of the device
-            manufacturer_data (dict): Manufacturer data from the device
-            service_data (dict): Service data from the device
-            service_uuids (list): UUIDs associated with the device
-            platform_data (tuple): Tuple of platform specific advertisement data
-        """
-        # Platform specific address of the device
-        self.address = address
-
-        # The local name of the device
-        self.local_name = kwargs.get("local_name", None)
-
-        # Integer RSSI value from the device
-        self.rssi = kwargs.get("rssi", 0)
-
-        # Dictionary of manufacturer data in bytes
-        self.manufacturer_data = kwargs.get("manufacturer_data", {})
-
-        # Dictionary of service data
-        self.service_data = kwargs.get("service_data", {})
-
-        # List of UUIDs
-        self.service_uuids = kwargs.get("service_uuids", [])
-
-        # Tuple of platform specific data
-        self.platform_data = kwargs.get("platform_data", ())
-
-    def __str__(self):
-        return repr(self)
-
-    def __repr__(self) -> str:
-        kwargs = ""
-        if self.local_name:
-            kwargs += f", local_name={repr(self.local_name)}"
-        if self.rssi:
-            kwargs += f", rssi={repr(self.rssi)}"
-        if self.manufacturer_data:
-            kwargs += f", manufacturer_data={repr(self.manufacturer_data)}"
-        if self.service_data:
-            kwargs += f", service_data={repr(self.service_data)}"
-        if self.service_uuids:
-            kwargs += f", service_uuids={repr(self.service_uuids)}"
-        if self.platform_data:
-            kwargs += f", platform_data={repr(self.platform_data)}"
-        return f"AdvertisementData({repr(self.address)}{kwargs})"


### PR DESCRIPTION
Since #334, all backends have the same implementation of `BleakScanner.register_detection_callback()` and the documentation was out of date.

This consolidates the implementation in the abstract base class and updates the type hints and documentation.
