### PR TITLE
Fixed calling BleakClient.is_connected() on Mac before connection.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Fixed
 * Fix event callbacks on Windows not running in asyncio event loop thread.
 * Fixed ``BleakScanner.discover()`` on older versions of macOS. Fixes #331.
 * Fixed disconnect callback on BlueZ backend.
+* Fixed calling BleakClient.is_connected() on Mac before connection.
 
 Removed
 ~~~~~~~

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -120,7 +120,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     async def is_connected(self) -> bool:
         """Checks for current active connection"""
         manager = self._central_manager_delegate
-        return manager.isConnected
+        return False if manager is None else manager.isConnected
 
     async def pair(self, *args, **kwargs) -> bool:
         """Attempt to pair with a peripheral.


### PR DESCRIPTION
If `BleakClient.is_connected()` is called before `BleakClient.connect()`, `self._central_manager_delegate` will be `None`, which was leading to a crash.

Fixes #385
