### PR TITLE
Detection callback improvments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 * Added AdvertisementData class used with detection callbacks across all supported platforms. Merge #334
 * Added BleakError raised during import on unsupported platforms.
 * Added rssi parameter to BLEDevice constructor.
+* Added detection_callback kwarg to BleakScanner constructor.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Changed
 
 * Updated minimum PyObjC version to 7.0.1.
 * Consolidated implementation of BleakScanner.register_detection_callback().
-  All platforms now take callback with single AdvertisementData argument.
+  All platforms now take callback with BLEDevice and AdvertisementData arguments.
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 
 * Added AdvertisementData class used with detection callbacks across all supported platforms. Merge #334
 * Added BleakError raised during import on unsupported platforms.
+* Added rssi parameter to BLEDevice constructor.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 * Updated minimum PyObjC version to 7.0.1.
 * Consolidated implementation of BleakScanner.register_detection_callback().
   All platforms now take callback with BLEDevice and AdvertisementData arguments.
+* Consolidated BleakScanner.find_device_by_address() implementations.
 
 Fixed
 ~~~~~

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -88,7 +88,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         timeout = kwargs.get("timeout", self._timeout)
         if self._device_path is None:
             device = await BleakScannerBlueZDBus.find_device_by_address(
-                self.address, timeout=timeout, device=self.device
+                self.address, timeout=timeout
             )
 
             if device:

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -197,6 +197,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
                     address,
                     name,
                     {"path": path, "props": props},
+                    props.get("RSSI", 0),
                     uuids=uuids,
                     manufacturer_data=manufacturer_data,
                 )

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -204,39 +204,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             )
         return discovered_devices
 
-    @classmethod
-    async def find_device_by_address(
-        cls, device_identifier: str, timeout: float = 10.0, **kwargs
-    ) -> BLEDevice:
-        """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address.
-
-        Args:
-            device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
-
-        Keyword Args:
-            device (str): Bluetooth device to use for discovery.
-
-        Returns:
-            The ``BLEDevice`` sought or ``None`` if not detected.
-
-        """
-        device_identifier = device_identifier.lower()
-        loop = asyncio.get_event_loop()
-        stop_scanning_event = asyncio.Event()
-        scanner = cls(timeout=timeout)
-
-        def stop_if_detected(d: BLEDevice, advertisement_data: AdvertisementData):
-            if any(
-                device.get("Address", "").lower() == device_identifier
-                for device in scanner._devices.values()
-            ):
-                loop.call_soon_threadsafe(stop_scanning_event.set)
-
-        return await scanner._find_device_by_address(
-            device_identifier, stop_scanning_event, stop_if_detected, timeout
-        )
-
     # Helper methods
 
     def parse_msg(self, message):

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -65,7 +65,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
     """
 
     def __init__(self, **kwargs):
-        super(BleakScannerBlueZDBus, self).__init__()
+        super(BleakScannerBlueZDBus, self).__init__(**kwargs)
 
         self._device = kwargs.get("device", "hci0")
         self._reactor = None

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -228,7 +228,7 @@ class CentralManagerDelegate(NSObject):
             device = BLEDeviceCoreBluetooth(address, name, details, delegate=self)
             self.devices[uuid_string] = device
 
-        device._rssi = float(RSSI)
+        device.rssi = RSSI
         device._update(advertisementData)
 
         for callback in self.callbacks.values():

--- a/bleak/backends/corebluetooth/device.py
+++ b/bleak/backends/corebluetooth/device.py
@@ -34,7 +34,6 @@ class BLEDeviceCoreBluetooth(BLEDevice):
 
     def __init__(self, *args, **kwargs):
         super(BLEDeviceCoreBluetooth, self).__init__(*args, **kwargs)
-        self._rssi = kwargs.get("rssi")
 
     def _update(self, advertisementData: NSDictionary):
         self._update_uuids(advertisementData)
@@ -60,7 +59,3 @@ class BLEDeviceCoreBluetooth(BLEDevice):
         mfg_id = int.from_bytes(mfg_bytes[0:2], byteorder="little")
         mfg_val = bytes(mfg_bytes[2:])
         self.metadata["manufacturer_data"] = {mfg_id: mfg_val}
-
-    @property
-    def rssi(self):
-        return self._rssi

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -1,7 +1,6 @@
-import asyncio
 import logging
 import pathlib
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from Foundation import NSArray
 from CoreBluetooth import CBPeripheral
@@ -144,35 +143,6 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             )
 
         return found
-
-    @classmethod
-    async def find_device_by_address(
-        cls, device_identifier: str, timeout: float = 10.0, **kwargs
-    ) -> Union[BLEDevice, None]:
-        """A convenience method for obtaining a ``BLEDevice`` object specified by macOS UUID address.
-
-        Args:
-            device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
-            timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
-
-        Returns:
-            The ``BLEDevice`` sought or ``None`` if not detected.
-
-        """
-        loop = asyncio.get_event_loop()
-        stop_scanning_event = asyncio.Event()
-        device_identifier = device_identifier.lower()
-        scanner = cls(timeout=timeout)
-
-        def stop_if_detected(d: BLEDevice, advertisement_data: AdvertisementData):
-            peripheral = advertisement_data.platform_data[0]
-
-            if str(peripheral.identifier().UUIDString()).lower() == device_identifier:
-                loop.call_soon_threadsafe(stop_scanning_event.set)
-
-        return await scanner._find_device_by_address(
-            device_identifier, stop_scanning_event, stop_if_detected, timeout
-        )
 
     # macOS specific methods
 

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -23,30 +23,17 @@ class BLEDevice(object):
     - When using macOS backend, ``details`` attribute will be a CBPeripheral object.
     """
 
-    def __init__(self, address, name, details=None, **kwargs):
+    def __init__(self, address, name, details=None, rssi=0, **kwargs):
         #: The Bluetooth address of the device on this machine.
         self.address = address
         #: The advertised name of the device.
         self.name = name if name else "Unknown"
         #: The OS native details required for connecting to the device.
         self.details = details
+        #: RSSI, if available
+        self.rssi = rssi
         #: Device specific details. Contains a ``uuids`` key which is a list of service UUIDs and a ``manufacturer_data`` field with a bytes-object from the advertised data.
         self.metadata = kwargs
-
-    @property
-    def rssi(self):
-        """Get the signal strength in dBm"""
-        if isinstance(self.details, dict) and "props" in self.details:
-            rssi = self.details["props"].get("RSSI", 0)  # Should not be set to 0...
-        elif hasattr(self.details, "RawSignalStrengthInDBm"):
-            rssi = self.details.RawSignalStrengthInDBm
-        elif hasattr(self.details, "Properties"):
-            rssi = {p.Key: p.Value for p in self.details.Properties}[
-                "System.Devices.Aep.SignalStrength"
-            ]
-        else:
-            rssi = None
-        return int(rssi) if rssi is not None else None
 
     def __str__(self):
         if self.name == "Unknown":

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -1,7 +1,7 @@
 import logging
 import asyncio
 import pathlib
-from typing import Union, List
+from typing import List
 from uuid import UUID
 
 from bleak.backends.device import BLEDevice
@@ -260,48 +260,3 @@ class BleakScannerDotNet(BaseBleakScanner):
 
         """
         return self.watcher.Status if self.watcher else None
-
-    @classmethod
-    async def find_device_by_address(
-        cls, device_identifier: str, timeout: float = 10.0, **kwargs
-    ) -> Union[BLEDevice, None]:
-        """A convenience method for obtaining a ``BLEDevice`` object specified by Bluetooth address.
-
-        Args:
-
-            device_identifier (str): The Bluetooth address of the Bluetooth peripheral.
-
-            timeout (float): Optional timeout to wait for detection of specified peripheral
-              before giving up. Defaults to 10.0 seconds.
-
-        Keyword Args:
-
-          scanning mode (str): Set to ``Passive`` to avoid the ``Active`` scanning mode.
-
-          SignalStrengthFilter (``Windows.Devices.Bluetooth.BluetoothSignalStrengthFilter``): A
-            BluetoothSignalStrengthFilter object used for configuration of Bluetooth LE advertisement
-            filtering that uses signal strength-based filtering.
-
-          AdvertisementFilter (``Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementFilter``): A
-            BluetoothLEAdvertisementFilter object used for configuration of Bluetooth LE
-            advertisement filtering that uses payload section-based filtering.
-
-        Returns:
-
-            The ``BLEDevice`` sought or ``None`` if not detected.
-
-        """
-
-        ulong_id = int(device_identifier.replace(":", ""), 16)
-        loop = asyncio.get_event_loop()
-        stop_scanning_event = asyncio.Event()
-        scanner = cls(timeout=timeout)
-
-        def stop_if_detected(d: BLEDevice, advertisement_data: AdvertisementData):
-            event_args = advertisement_data.platform_data[1]
-            if event_args.BluetoothAddress == ulong_id:
-                loop.call_soon_threadsafe(stop_scanning_event.set)
-
-        return await scanner._find_device_by_address(
-            device_identifier, stop_scanning_event, stop_if_detected, timeout
-        )

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -91,44 +91,45 @@ class BleakScannerDotNet(BaseBleakScanner):
             else:
                 if event_args.BluetoothAddress not in self._devices:
                     self._devices[event_args.BluetoothAddress] = event_args
-        if self._callback is not None:
-            # Get a "BLEDevice" from parse_event args
-            device = self.parse_eventargs(event_args)
 
-            # Decode service data
-            service_data = {}
-            # 0x16 is service data with 16-bit UUID
-            for section in event_args.Advertisement.GetSectionsByType(0x16):
-                with BleakDataReader(section.Data) as reader:
-                    data = reader.read()
-                    service_data[
-                        f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
-                    ] = data[2:]
-            # 0x20 is service data with 32-bit UUID
-            for section in event_args.Advertisement.GetSectionsByType(0x20):
-                with BleakDataReader(section.Data) as reader:
-                    data = reader.read()
-                    service_data[
-                        f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
-                    ] = data[4:]
-            # 0x21 is service data with 128-bit UUID
-            for section in event_args.Advertisement.GetSectionsByType(0x21):
-                with BleakDataReader(section.Data) as reader:
-                    data = reader.read()
-                    service_data[str(UUID(bytes=data[15::-1]))] = data[16:]
+        if self._callback is None:
+            return
 
-            # Use the BLEDevice to populate all the fields for the advertisement data to return
-            advertisement_data = AdvertisementData(
-                address=device.address,
-                local_name=device.name or "Unknown",
-                rssi=device.rssi,
-                manufacturer_data=device.metadata["manufacturer_data"],
-                service_data=service_data,
-                service_uuids=device.metadata["uuids"],
-                platform_data=(sender, event_args),
-            )
+        # Get a "BLEDevice" from parse_event args
+        device = self.parse_eventargs(event_args)
 
-            self._callback(advertisement_data)
+        # Decode service data
+        service_data = {}
+        # 0x16 is service data with 16-bit UUID
+        for section in event_args.Advertisement.GetSectionsByType(0x16):
+            with BleakDataReader(section.Data) as reader:
+                data = reader.read()
+                service_data[
+                    f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
+                ] = data[2:]
+        # 0x20 is service data with 32-bit UUID
+        for section in event_args.Advertisement.GetSectionsByType(0x20):
+            with BleakDataReader(section.Data) as reader:
+                data = reader.read()
+                service_data[
+                    f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
+                ] = data[4:]
+        # 0x21 is service data with 128-bit UUID
+        for section in event_args.Advertisement.GetSectionsByType(0x21):
+            with BleakDataReader(section.Data) as reader:
+                data = reader.read()
+                service_data[str(UUID(bytes=data[15::-1]))] = data[16:]
+
+        # Use the BLEDevice to populate all the fields for the advertisement data to return
+        advertisement_data = AdvertisementData(
+            local_name=device.name,
+            manufacturer_data=device.metadata["manufacturer_data"],
+            service_data=service_data,
+            service_uuids=device.metadata["uuids"],
+            platform_data=(sender, event_args),
+        )
+
+        self._callback(device, advertisement_data)
 
     def _stopped_handler(
         self,
@@ -296,7 +297,7 @@ class BleakScannerDotNet(BaseBleakScanner):
         stop_scanning_event = asyncio.Event()
         scanner = cls(timeout=timeout)
 
-        def stop_if_detected(advertisement_data: AdvertisementData):
+        def stop_if_detected(d: BLEDevice, advertisement_data: AdvertisementData):
             event_args = advertisement_data.platform_data[1]
             if event_args.BluetoothAddress == ulong_id:
                 loop.call_soon_threadsafe(stop_scanning_event.set)

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -122,7 +122,7 @@ class BleakScannerDotNet(BaseBleakScanner):
 
         # Use the BLEDevice to populate all the fields for the advertisement data to return
         advertisement_data = AdvertisementData(
-            local_name=device.name,
+            local_name=event_args.Advertisement.LocalName,
             manufacturer_data=device.metadata["manufacturer_data"],
             service_data=service_data,
             service_uuids=device.metadata["uuids"],

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -58,7 +58,7 @@ class BleakScannerDotNet(BaseBleakScanner):
     """
 
     def __init__(self, **kwargs):
-        super(BleakScannerDotNet, self).__init__()
+        super(BleakScannerDotNet, self).__init__(**kwargs)
 
         self.watcher = None
         self._devices = {}

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -229,8 +229,9 @@ class BleakScannerDotNet(BaseBleakScanner):
             with BleakDataReader(m.Data) as reader:
                 data[m.CompanyId] = reader.read()
         local_name = event_args.Advertisement.LocalName
+        rssi = event_args.RawSignalStrengthInDBm
         return BLEDevice(
-            bdaddr, local_name, event_args, uuids=uuids, manufacturer_data=data
+            bdaddr, local_name, event_args, rssi, uuids=uuids, manufacturer_data=data
         )
 
     # Windows specific

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+import inspect
 from typing import Callable, Dict, List, Optional, Tuple
 
 from bleak.backends.device import BLEDevice
@@ -10,27 +11,17 @@ class AdvertisementData:
     Wrapper around the advertisement data that each platform returns upon discovery
     """
 
-    def __init__(self, address: str, **kwargs):
+    def __init__(self, **kwargs):
         """
-        Required Args:
-            address (str): The platform specific address of the device
-
         Keyword Args:
             local_name (str): The name of the ble device advertising
-            rssi (int): Rssi value of the device
             manufacturer_data (dict): Manufacturer data from the device
             service_data (dict): Service data from the device
             service_uuids (list): UUIDs associated with the device
             platform_data (tuple): Tuple of platform specific advertisement data
         """
-        # Platform specific address of the device
-        self.address: str = address
-
         # The local name of the device
         self.local_name: Optional[str] = kwargs.get("local_name", None)
-
-        # Integer RSSI value from the device
-        self.rssi: int = kwargs.get("rssi", 0)
 
         # Dictionary of manufacturer data in bytes
         self.manufacturer_data: Dict[int, bytes] = kwargs.get("manufacturer_data", {})
@@ -44,24 +35,20 @@ class AdvertisementData:
         # Tuple of platform specific data
         self.platform_data: Tuple = kwargs.get("platform_data", ())
 
-    def __str__(self) -> str:
-        return repr(self)
-
     def __repr__(self) -> str:
-        kwargs = ""
+        kwargs = []
         if self.local_name:
-            kwargs += f", local_name={repr(self.local_name)}"
-        if self.rssi:
-            kwargs += f", rssi={repr(self.rssi)}"
+            kwargs.append(f"local_name={repr(self.local_name)}")
         if self.manufacturer_data:
-            kwargs += f", manufacturer_data={repr(self.manufacturer_data)}"
+            kwargs.append(f"manufacturer_data={repr(self.manufacturer_data)}")
         if self.service_data:
-            kwargs += f", service_data={repr(self.service_data)}"
+            kwargs.append(f"service_data={repr(self.service_data)}")
         if self.service_uuids:
-            kwargs += f", service_uuids={repr(self.service_uuids)}"
-        if self.platform_data:
-            kwargs += f", platform_data={repr(self.platform_data)}"
-        return f"AdvertisementData({repr(self.address)}{kwargs})"
+            kwargs.append(f"service_uuids={repr(self.service_uuids)}")
+        return f"AdvertisementData({', '.join(kwargs)})"
+
+
+AdvertisementDataCallback = Callable[[BLEDevice, AdvertisementData], None]
 
 
 class BaseBleakScanner(abc.ABC):
@@ -98,16 +85,27 @@ class BaseBleakScanner(abc.ABC):
         return devices
 
     def register_detection_callback(
-        self, callback: Optional[Callable[[AdvertisementData], None]]
+        self, callback: Optional[AdvertisementDataCallback]
     ) -> None:
         """Register a callback that is called when a device is discovered or has a property changed.
 
         If another callback has already been registered, it will be replaced with ``callback``.
+        ``None`` can be used to remove the current callback.
+
+        The ``callback`` is a function that takes two arguments: :class:`BLEDevice` and :class:`AdvertisementData`.
 
         Args:
-            callback: A function that takes one argument which will be an :class:`AdvertisementData` object
-                      or ``None`` remove an existing callback.
+            callback: A function or ``None``.
         """
+        if callback is not None:
+            error_text = "callback must be callable with 2 parameters"
+            if not callable(callback):
+                raise TypeError(error_text)
+
+            handler_signature = inspect.signature(callback)
+            if len(handler_signature.parameters) != 2:
+                raise TypeError(error_text)
+
         self._callback = callback
 
     @abc.abstractmethod

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -56,7 +56,8 @@ class BaseBleakScanner(abc.ABC):
 
     def __init__(self, *args, **kwargs):
         super(BaseBleakScanner, self).__init__()
-        self._callback: Optional[Callable[[AdvertisementData], None]] = None
+        self._callback: Optional[AdvertisementDataCallback] = None
+        self.register_detection_callback(kwargs.get("detection_callback"))
 
     async def __aenter__(self):
         await self.start()

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -59,8 +59,8 @@ or separately, calling ``start`` and ``stop`` methods on the scanner manually:
     import asyncio
     from bleak import BleakScanner
 
-    def detection_callback(*args):
-        print(args)
+    def detection_callback(device, advertisement_data):
+        print(device.address, "RSSI:", device.rssi, advertisement_data)
 
     async def run():
         scanner = BleakScanner()
@@ -80,10 +80,6 @@ In the manual mode, it is possible to add an own callback that you want to call 
 scanner detection, as can be seen above. There are also possibilities of adding scanning filters,
 which differ widely between OS backend implementations, so the instructions merit careful reading.
 
-Note that the when using :code:`BleakScanner.register_detection_callback(callback)`, your callback
-function will be passed an :class:`bleak.backends.scanner.AdvertisementData` class whose structure can be found in the base scanner file.
-`See detection_callback.py` example. Note that platform specific advertisement data can be found in the ``platform_data``
-field.
 
 Scanning Filters
 ----------------

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -10,14 +10,15 @@ Updated on 2020-10-11 by bernstern <bernie@allthenticate.net>
 
 import asyncio
 from bleak import BleakScanner
+from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 import logging
 
 logging.basicConfig()
 
 
-def simple_callback(callback_data: AdvertisementData):
-    print(callback_data)
+def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
+    print(device.address, "RSSI:", device.rssi, advertisement_data)
 
 
 async def run():


### PR DESCRIPTION
After using the changes from #334 a bit more, I found myself wanting a `BLEDevice` in addition to the `AdvertismentData`. This way if out find a device you like, you can pass the `BLEDevice` to `BleakClient()` directly without having to find it again in the list returned by `get_discovered_devices()`.

Technically, some things like the device identifier (address or UUID on Mac) and RSSI aren't part of the advertising data and were already in `BLEDevice` so I removed them from `AdvertisingData`. This also opened the opportunity to clean up some other things along the way.

@Bernstern, does this work for you?