### PR TITLE
Fix rssi values in BLE scanner

### DIFF
--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -228,8 +228,8 @@ class CentralManagerDelegate(NSObject):
             device = BLEDeviceCoreBluetooth(address, name, details, delegate=self)
             self.devices[uuid_string] = device
 
-        device.rssi = RSSI
         device._update(advertisementData)
+        device._update_rssi(RSSI)
 
         for callback in self.callbacks.values():
             if callback:

--- a/bleak/backends/corebluetooth/device.py
+++ b/bleak/backends/corebluetooth/device.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from Foundation import NSDictionary
+from Foundation import NSDictionary, NSNumber
 
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
@@ -38,6 +38,9 @@ class BLEDeviceCoreBluetooth(BLEDevice):
     def _update(self, advertisementData: NSDictionary):
         self._update_uuids(advertisementData)
         self._update_manufacturer(advertisementData)
+
+    def _update_rssi(self, RSSI: NSNumber):
+        self.rssi = RSSI
 
     def _update_uuids(self, advertisementData: NSDictionary):
         cbuuids = advertisementData.get("kCBAdvDataServiceUUIDs", [])

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -113,6 +113,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             address = peripheral.identifier().UUIDString()
             name = peripheral.name() or "Unknown"
             details = peripheral
+            rssi = self._manager.devices[address].rssi
 
             advertisementData = self._identifiers[peripheral.identifier()]
             manufacturer_binary_data = advertisementData.get(
@@ -136,6 +137,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
                     address,
                     name,
                     details,
+                    rssi=rssi,
                     uuids=uuids,
                     manufacturer_data=manufacturer_data,
                     delegate=self._manager.central_manager.delegate(),


### PR DESCRIPTION
In latest bleak version 0.10.0 the RSSI values of devices returned by `get_discovered_devices` are all zero.
This comes from `BLEDevice` class which has a `rssi=0` keyword argument default to zero. 
This PR updates this value with the real `RSSI` value.

@dlech I don't know if this is the best way to solve this, so feel free to change anything before merging 👍 

PD: Also for some reason bleak version in develop branch is still `0.9.1`, I guess this should be updated as well.