### PR TITLE
Dotnet client fixed misspelled detach buffer function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+`Unreleased`_
+-------------
+
+Fixed
+~~~~~
+
+* Fixed ``AttributeError`` in ``write_gatt_descriptor()`` in Windows backend.
+  Merged #403.
+* Fixed wrong OS write method called in ``write_gatt_descriptor()`` in Windows
+  backend.  Merged #403.
+
+
 `0.10.0`_ (2020-12-11)
 ----------------------
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -711,7 +711,7 @@ class BleakClientDotNet(BaseBleakClient):
         with BleakDataWriter(data) as writer:
             write_result = await wrap_IAsyncOperation(
                 IAsyncOperation[GattWriteResult](
-                    descriptor.obj.WriteValueAsync(writer.DetachBuffer())
+                    descriptor.obj.WriteValueAsync(writer.detach_buffer())
                 ),
                 return_type=GattWriteResult,
             )

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -711,7 +711,7 @@ class BleakClientDotNet(BaseBleakClient):
         with BleakDataWriter(data) as writer:
             write_result = await wrap_IAsyncOperation(
                 IAsyncOperation[GattWriteResult](
-                    descriptor.obj.WriteValueAsync(writer.detach_buffer())
+                    descriptor.obj.WriteValueWithResultAsync(writer.detach_buffer())
                 ),
                 return_type=GattWriteResult,
             )


### PR DESCRIPTION
dotnet client descriptor now uses correct detach buffer function BleakDataWriter.detach_buffer() instead of BleakDataWriter.DetachBuffer()

Fix #402 