### PR TITLE
Example scripts now print one service per line.

### DIFF
--- a/examples/connect_by_bledevice.py
+++ b/examples/connect_by_bledevice.py
@@ -12,7 +12,9 @@ async def print_services(mac_addr: str):
     device = await BleakScanner.find_device_by_address(mac_addr)
     async with BleakClient(device) as client:
         svcs = await client.get_services()
-        print("Services:", svcs)
+        print("Services:")
+        for service in svcs:
+            print(service)
 
 
 mac_addr = (

--- a/examples/get_services.py
+++ b/examples/get_services.py
@@ -17,7 +17,9 @@ from bleak import BleakClient
 async def print_services(mac_addr: str):
     async with BleakClient(mac_addr) as client:
         svcs = await client.get_services()
-        print("Services:", svcs)
+        print("Services:")
+        for service in svcs:
+            print(service)
 
 
 mac_addr = (


### PR DESCRIPTION
Fixes #413 

Output now looks like:
```
$ python examples/get_services.py
Services:
00001801-0000-1000-8000-00805f9b34fb: Generic Attribute Profile
00001800-0000-1000-8000-00805f9b34fb: Generic Access Profile
0000180a-0000-1000-8000-00805f9b34fb: Device Information
abbafd00-e56a-484c-b832-8b17cf6cbfe8: Unknown
ac2f0045-8182-4be5-91e0-2992e6b40ebb: Unknown
abbaff00-e56a-484c-b832-8b17cf6cbfe8: Unknown
0000fe2c-0000-1000-8000-00805f9b34fb: Google Inc.
0000fe26-0000-1000-8000-00805f9b34fb: Google Inc.
```