### PR TITLE
Pairing improvement for .NET backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 ~~~~~
 
 * Added ``AdvertisementServiceData`` in BLEDevice in macOS devices
+* Protection levels (encryption) in Windows backend pairing. Solves #405.
+* Philips Hue lamp example script. Relates to #405.
 
 Fixed
 ~~~~~

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.11.0a1"
+__version__ = "0.11.0a2"

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -327,8 +327,15 @@ class BleakClientDotNet(BaseBleakClient):
             )
 
             if protection_level:
-                raise NotImplementedError(
-                    "Cannot set minimally required protection level yet..."
+                pairing_result = await wrap_IAsyncOperation(
+                    IAsyncOperation[DevicePairingResult](
+                        custom_pairing.PairAsync.Overloads[DevicePairingKinds, DevicePairingProtectionLevel]
+                        (
+                            ceremony,
+                            protection_level
+                        )
+                    ),
+                    return_type=DevicePairingResult,
                 )
             else:
                 pairing_result = await wrap_IAsyncOperation(

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -323,17 +323,17 @@ class BleakClientDotNet(BaseBleakClient):
                 args.Accept()
 
             pairing_requested_token = custom_pairing.add_PairingRequested(
-                TypedEventHandler[DeviceInformationCustomPairing, DevicePairingRequestedEventArgs](handler)
+                TypedEventHandler[
+                    DeviceInformationCustomPairing, DevicePairingRequestedEventArgs
+                ](handler)
             )
 
             if protection_level:
                 pairing_result = await wrap_IAsyncOperation(
                     IAsyncOperation[DevicePairingResult](
-                        custom_pairing.PairAsync.Overloads[DevicePairingKinds, DevicePairingProtectionLevel]
-                        (
-                            ceremony,
-                            protection_level
-                        )
+                        custom_pairing.PairAsync.Overloads[
+                            DevicePairingKinds, DevicePairingProtectionLevel
+                        ](ceremony, protection_level)
                     ),
                     return_type=DevicePairingResult,
                 )

--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -1,0 +1,60 @@
+"""
+Philips Hue lamp
+----------------
+
+Needs to be connected to with encrypted pairing to enable reading and writing.
+
+Reference:
+https://www.reddit.com/r/Hue/comments/eq0y3y/philips_hue_bluetooth_developer_documentation/
+
+Created on 2020-01-13 by hbldh <henrik.blidh@nedomkull.com>
+
+"""
+import platform
+import asyncio
+import logging
+
+from bleak import BleakClient
+
+
+LIGHT_CHARACTERISTIC = "932c32bd-0002-47a2-835a-a8d455b859dd"
+BRIGHTNESS_CHARACTERISTIC = "932c32bd-0003-47a2-835a-a8d455b859dd"
+COLOR_CHARACTERISTIC = "932c32bd-0004-47a2-835a-a8d455b859dd"
+
+
+async def run(address, debug=False):
+    log = logging.getLogger(__name__)
+    if debug:
+        import sys
+
+        log.setLevel(logging.DEBUG)
+        h = logging.StreamHandler(sys.stdout)
+        h.setLevel(logging.DEBUG)
+        log.addHandler(h)
+
+    async with BleakClient(address) as client:
+        x = await client.is_connected()
+        log.info("Connected: {0}".format(x))
+        x = await client.pair(protection_level=2)
+        log.info("Paired: {0}".format(x))
+
+        print("Turning Light off...")
+        await client.write_gatt_char(LIGHT_CHARACTERISTIC, b'\x00')
+        await asyncio.sleep(1.0)
+        print("Turning Light on...")
+        await client.write_gatt_char(LIGHT_CHARACTERISTIC, b'\x01')
+        await asyncio.sleep(1.0)
+
+        for brightness in range(256):
+            print(f"Set Brightness to {brightness}...")
+            await client.write_gatt_char(BRIGHTNESS_CHARACTERISTIC, bytearray([brightness, ]))
+            await asyncio.sleep(0.2)
+
+        await client.write_gatt_char(BRIGHTNESS_CHARACTERISTIC, bytearray([40, ]))
+
+
+if __name__ == "__main__":
+    address = "EB:F0:49:21:95:4F"
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    loop.run_until_complete(run(address, True))

--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -48,19 +48,33 @@ async def run(address, debug=False):
         log.info("Paired: {0}".format(x))
 
         print("Turning Light off...")
-        await client.write_gatt_char(LIGHT_CHARACTERISTIC, b'\x00')
+        await client.write_gatt_char(LIGHT_CHARACTERISTIC, b"\x00")
         await asyncio.sleep(1.0)
         print("Turning Light on...")
-        await client.write_gatt_char(LIGHT_CHARACTERISTIC, b'\x01')
+        await client.write_gatt_char(LIGHT_CHARACTERISTIC, b"\x01")
         await asyncio.sleep(1.0)
 
         for brightness in range(256):
             print(f"Set Brightness to {brightness}...")
-            await client.write_gatt_char(BRIGHTNESS_CHARACTERISTIC, bytearray([brightness, ]))
+            await client.write_gatt_char(
+                BRIGHTNESS_CHARACTERISTIC,
+                bytearray(
+                    [
+                        brightness,
+                    ]
+                ),
+            )
             await asyncio.sleep(0.2)
 
         print(f"Set Brightness to {40}...")
-        await client.write_gatt_char(BRIGHTNESS_CHARACTERISTIC, bytearray([40, ]))
+        await client.write_gatt_char(
+            BRIGHTNESS_CHARACTERISTIC,
+            bytearray(
+                [
+                    40,
+                ]
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -2,15 +2,24 @@
 Philips Hue lamp
 ----------------
 
-Needs to be connected to with encrypted pairing to enable reading and writing.
+Very important:
 
-Reference:
-https://www.reddit.com/r/Hue/comments/eq0y3y/philips_hue_bluetooth_developer_documentation/
+It seems that the device needs to be connected to in the official Philips Hue Bluetooth app
+and reset from there to be able to use with Bleak-type of BLE software. After that one needs to
+do a encrypted pairing to enable reading and writing of characteristics.
+
+ONLY TESTED IN WINDOWS BACKEND AS OF YET!
+
+References:
+
+- https://www.reddit.com/r/Hue/comments/eq0y3y/philips_hue_bluetooth_developer_documentation/
+- https://gist.github.com/shinyquagsire23/f7907fdf6b470200702e75a30135caf3
+- https://github.com/Mic92/hue-ble-ctl/blob/master/hue-ble-ctl.py
 
 Created on 2020-01-13 by hbldh <henrik.blidh@nedomkull.com>
 
 """
-import platform
+
 import asyncio
 import logging
 
@@ -50,6 +59,7 @@ async def run(address, debug=False):
             await client.write_gatt_char(BRIGHTNESS_CHARACTERISTIC, bytearray([brightness, ]))
             await asyncio.sleep(0.2)
 
+        print(f"Set Brightness to {40}...")
         await client.write_gatt_char(BRIGHTNESS_CHARACTERISTIC, bytearray([40, ]))
 
 


### PR DESCRIPTION
Added protection levels when trying to pair with devices in Windows backend. It works with ProtectionLevel = 2 (Encrypted) at least, which solves some problems, e.g. #405.

Also wrote a sample script for connecting to and controlling Philips Hue lamps, albeit only tested in Windows.