### PR TITLE
Adding option to avoid using cached services in .NET backend.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Added
 * Added ``AdvertisementServiceData`` in BLEDevice in macOS devices
 * Protection levels (encryption) in Windows backend pairing. Solves #405.
 * Philips Hue lamp example script. Relates to #405.
+* Keyword arguments to ``get_services`` method on ``BleakClient``.
+* Keyword argument ``use_cached`` on .NET backend, to enable uncached reading
+  of services, characteristics and descriptors in Windows.
 
 Fixed
 ~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 * Keyword arguments to ``get_services`` method on ``BleakClient``.
 * Keyword argument ``use_cached`` on .NET backend, to enable uncached reading
   of services, characteristics and descriptors in Windows.
+* Documentation on troubleshooting OS level caches for services.
 
 Fixed
 ~~~~~

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.11.0a2"
+__version__ = "0.11.0a3"

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -365,7 +365,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
     # GATT services methods
 
-    async def get_services(self) -> BleakGATTServiceCollection:
+    async def get_services(self, **kwargs) -> BleakGATTServiceCollection:
         """Get all services registered for this GATT server.
 
         Returns:

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -131,7 +131,7 @@ class BaseBleakClient(abc.ABC):
     # GATT services methods
 
     @abc.abstractmethod
-    async def get_services(self) -> BleakGATTServiceCollection:
+    async def get_services(self, **kwargs) -> BleakGATTServiceCollection:
         """Get all services registered for this GATT server.
 
         Returns:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -151,7 +151,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         """
         raise NotImplementedError("Pairing is not available in Core Bluetooth.")
 
-    async def get_services(self) -> BleakGATTServiceCollection:
+    async def get_services(self, **kwargs) -> BleakGATTServiceCollection:
         """Get all services registered for this GATT server.
 
         Returns:

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -124,7 +124,7 @@ class BleakClientDotNet(BaseBleakClient):
             and kwargs["address_type"] in ("public", "random")
             else None
         )
-        self._use_cached = kwargs.get('use_cached', True)
+        self._use_cached = kwargs.get("use_cached", True)
 
     def __str__(self):
         return "BleakClientDotNet ({0})".format(self.address)

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -96,9 +96,11 @@ class BleakClientDotNet(BaseBleakClient):
 
     Args:
         address_or_ble_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to connect to or the `BLEDevice` object representing it.
+        use_cached (bool): If set to `True`, then the OS level BLE cache is used for
+                getting services, characteristics and descriptors. Defaults to ``True``.
 
     Keyword Args:
-            timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
+        timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
 
     """
 
@@ -122,6 +124,7 @@ class BleakClientDotNet(BaseBleakClient):
             and kwargs["address_type"] in ("public", "random")
             else None
         )
+        self._use_cached = kwargs.get('use_cached', True)
 
     def __str__(self):
         return "BleakClientDotNet ({0})".format(self.address)
@@ -133,6 +136,8 @@ class BleakClientDotNet(BaseBleakClient):
 
         Keyword Args:
             timeout (float): Timeout for required ``BleakScanner.find_device_by_address`` call. Defaults to 10.0.
+            use_cached (bool): If set to `True`, then the OS level BLE cache is used for
+                getting services, characteristics and descriptors. Defaults to ``True``.
 
         Returns:
             Boolean representing connection status.
@@ -140,6 +145,7 @@ class BleakClientDotNet(BaseBleakClient):
         """
         # Try to find the desired device.
         timeout = kwargs.get("timeout", self._timeout)
+        use_cached = kwargs.get("use_cached", self._use_cached)
         if self._device_info is None:
             device = await BleakScannerDotNet.find_device_by_address(
                 self.address, timeout=timeout
@@ -238,7 +244,7 @@ class BleakClientDotNet(BaseBleakClient):
         finally:
             self._connect_events.remove(event)
 
-        await self.get_services()
+        await self.get_services(use_cached=use_cached)
 
         return True
 
@@ -408,13 +414,19 @@ class BleakClientDotNet(BaseBleakClient):
 
     # GATT services methods
 
-    async def get_services(self) -> BleakGATTServiceCollection:
+    async def get_services(self, **kwargs) -> BleakGATTServiceCollection:
         """Get all services registered for this GATT server.
+
+        Keyword Args:
+
+            use_cached (bool): If set to `True`, then the OS level BLE cache is used for
+                getting services, characteristics and descriptors.
 
         Returns:
            A :py:class:`bleak.backends.service.BleakGATTServiceCollection` with this device's services tree.
 
         """
+        use_cached = kwargs.get("use_cached", self._use_cached)
         # Return the Service Collection.
         if self._services_resolved:
             return self.services
@@ -422,7 +434,11 @@ class BleakClientDotNet(BaseBleakClient):
             logger.debug("Get Services...")
             services_result = await wrap_IAsyncOperation(
                 IAsyncOperation[GattDeviceServicesResult](
-                    self._requester.GetGattServicesAsync()
+                    self._requester.GetGattServicesAsync(
+                        BluetoothCacheMode.Cached
+                        if use_cached
+                        else BluetoothCacheMode.Uncached
+                    )
                 ),
                 return_type=GattDeviceServicesResult,
             )
@@ -448,7 +464,11 @@ class BleakClientDotNet(BaseBleakClient):
             for service in services_result.Services:
                 characteristics_result = await wrap_IAsyncOperation(
                     IAsyncOperation[GattCharacteristicsResult](
-                        service.GetCharacteristicsAsync()
+                        service.GetCharacteristicsAsync(
+                            BluetoothCacheMode.Cached
+                            if use_cached
+                            else BluetoothCacheMode.Uncached
+                        )
                     ),
                     return_type=GattCharacteristicsResult,
                 )
@@ -482,7 +502,11 @@ class BleakClientDotNet(BaseBleakClient):
                 for characteristic in characteristics_result.Characteristics:
                     descriptors_result = await wrap_IAsyncOperation(
                         IAsyncOperation[GattDescriptorsResult](
-                            characteristic.GetDescriptorsAsync()
+                            characteristic.GetDescriptorsAsync(
+                                BluetoothCacheMode.Cached
+                                if use_cached
+                                else BluetoothCacheMode.Uncached
+                            )
                         ),
                         return_type=GattDescriptorsResult,
                     )
@@ -542,8 +566,8 @@ class BleakClientDotNet(BaseBleakClient):
             char_specifier (BleakGATTCharacteristic, int, str or UUID): The characteristic to read from,
                 specified by either integer handle, UUID or directly by the
                 BleakGATTCharacteristic object representing it.
-            use_cached (bool): `False` forces Windows to read the value from the
-                device again and not use its own cached value. Defaults to `False`.
+            use_cached (bool): ``False`` forces Windows to read the value from the
+                device again and not use its own cached value. Defaults to ``False``.
 
         Returns:
             (bytearray) The read data.
@@ -600,8 +624,8 @@ class BleakClientDotNet(BaseBleakClient):
 
         Args:
             handle (int): The handle of the descriptor to read from.
-            use_cached (bool): `False` forces Windows to read the value from the
-                device again and not use its own cached value. Defaults to `False`.
+            use_cached (bool): ``False`` forces Windows to read the value from the
+                device again and not use its own cached value. Defaults to ``False``.
 
         Returns:
             (bytearray) The read data.

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -144,3 +144,57 @@ On Linux, `Wireshark`_ can be used to capture and view Bluetooth traffic.
 
 
 .. _Wireshark Wiki: https://gitlab.com/wireshark/wireshark/-/wikis/CaptureSetup
+
+
+------------------------------------------
+Handling OS Caching of BLE Device Services
+------------------------------------------
+
+If you develop your own BLE peripherals, and frequently change services, characteristics and/or descriptors, then
+Bleak might report outdated versions of your peripheral's services due to OS level caching. The caching is done to
+speed up the connections with peripherals where services do not change and is enabled by default on most operating
+systems and thus also in Bleak.
+
+There are ways to avoid this on different backends though, and if you experience these kinds of problems, the steps
+below might help you to circumvent the caches.
+
+Windows 10
+==========
+
+The Windows .NET backend has the most straightforward means of handling the os caches. When creating a BleakClient, one
+can use the keyword argument `use_cached`:
+
+.. code-block:: python
+
+    async with BleakClient(address, use_cached=False) as client:
+        print(f"Connected: {await client.is_connected()}")
+        // Do whatever it is you want to do.
+
+The keyword argument is also present in the :py:meth:`bleak.backends.client.BleakClient.connect` method to use if you
+don't want to use the async context manager:
+
+.. code-block:: python
+
+    client = BleakClient(address)
+    await client.connect(use_cached=True)
+    print(f"Connected: {await client.is_connected()}")
+    // Do whatever it is you want to do.
+    await client.disconnect()
+
+macOS
+=====
+
+The OS level caching handling on macOS has not been explored yet.
+
+
+Linux
+=====
+
+When you change the structure of services/characteristics on a device, you have to remove the device from
+BlueZ so that it will read everything again. Otherwise BlueZ gives the cached values from the first time
+the device was connected. You can use the ``bluetoothctl`` command line tool to do this:
+
+.. code-block:: shell
+
+    bluetoothctl -- remove [mac_address]
+


### PR DESCRIPTION
## Added
* Keyword arguments to ``get_services`` method on ``BleakClient``.
* Keyword argument ``use_cached`` on .NET backend, to enable uncached reading of services, characteristics and descriptors in Windows.

Setting ``use_cached`` to ``True`` by default, since reading them from device noticably increased the connection time. Devices with mutable services are more rare than the opposite I think.

This might solve #429.