### PR TITLE
Having async methods as notification handlers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Added
 * Keyword argument ``use_cached`` on .NET backend, to enable uncached reading
   of services, characteristics and descriptors in Windows.
 * Documentation on troubleshooting OS level caches for services.
+* New example added: Async callbacks with a queue and external consumer
 
 Fixed
 ~~~~~

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -2,6 +2,7 @@
 """
 BLE Client for BlueZ on Linux
 """
+import inspect
 import logging
 import asyncio
 import os
@@ -724,17 +725,18 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 )
             )
 
+        loop = asyncio.get_event_loop()
         if _wrap:
             self._notification_callbacks[
                 characteristic.path
             ] = _data_notification_wrapper(
-                callback, self._char_path_to_handle
+                callback, self._char_path_to_handle, loop
             )  # noqa | E123 error in flake8...
         else:
             self._notification_callbacks[
                 characteristic.path
             ] = _regular_notification_wrapper(
-                callback, self._char_path_to_handle
+                callback, self._char_path_to_handle, loop
             )  # noqa | E123 error in flake8...
 
         self._subscriptions.append(characteristic.handle)
@@ -889,19 +891,45 @@ class BleakClientBlueZDBus(BaseBleakClient):
                         )
 
 
-def _data_notification_wrapper(func, char_map):
-    @wraps(func)
-    def args_parser(sender, data):
-        if "Value" in data:
-            # Do a conversion from {'Value': [...]} to bytearray.
-            return func(char_map.get(sender, sender), bytearray(data.get("Value")))
+def _data_notification_wrapper(func, char_map, loop: asyncio.AbstractEventLoop):
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        def args_parser(sender, data):
+            if "Value" in data:
+                # Do a conversion from {'Value': [...]} to bytearray.
+                return asyncio.run_coroutine_threadsafe(
+                    func(char_map.get(sender, sender), bytearray(data.get("Value"))),
+                    loop
+                )
+
+    else:
+
+        @wraps(func)
+        def args_parser(sender, data):
+            if "Value" in data:
+                # Do a conversion from {'Value': [...]} to bytearray.
+                return loop.call_soon_threadsafe(
+                    func, char_map.get(sender, sender), bytearray(data.get("Value"))
+                )
 
     return args_parser
 
 
-def _regular_notification_wrapper(func, char_map):
-    @wraps(func)
-    def args_parser(sender, data):
-        return func(char_map.get(sender, sender), data)
+def _regular_notification_wrapper(func, char_map, loop: asyncio.AbstractEventLoop):
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        def args_parser(sender, data):
+            return asyncio.run_coroutine_threadsafe(
+                func(char_map.get(sender, sender), data),
+                loop
+            )
+
+    else:
+
+        @wraps(func)
+        def args_parser(sender, data):
+            return loop.call_soon_threadsafe(func, char_map.get(sender, sender), data)
 
     return args_parser

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -3,7 +3,7 @@ BLE Client for CoreBluetooth on macOS
 
 Created on 2019-06-26 by kevincar <kevincarrolldavis@gmail.com>
 """
-
+import inspect
 import logging
 import uuid
 from typing import Callable, Union
@@ -368,6 +368,14 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             callback (function): The function to be called on notification.
 
         """
+        if inspect.iscoroutinefunction(callback):
+
+            def bleak_callback(s, d):
+                asyncio.create_task(callback(s, d))
+
+        else:
+            bleak_callback = callback
+
         manager = self._central_manager_delegate
 
         if not isinstance(char_specifier, BleakGATTCharacteristic):
@@ -378,7 +386,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             raise BleakError("Characteristic {0} not found!".format(char_specifier))
 
         success = await manager.connected_peripheral_delegate.startNotify_cb_(
-            characteristic.obj, callback
+            characteristic.obj, bleak_callback
         )
         if not success:
             raise BleakError(

--- a/examples/async_callback_with_queue.py
+++ b/examples/async_callback_with_queue.py
@@ -1,0 +1,69 @@
+"""
+Async callbacks with a queue and external consumer
+--------------------------------------------------
+
+An example showing how async notification callbacks can be used to
+send data received through notifications to some external consumer of
+that data.
+
+Created on 2021-02-25 by hbldh <henrik.blidh@nedomkull.com>
+
+"""
+import sys
+import time
+import platform
+import asyncio
+import logging
+
+from bleak import BleakClient
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+h = logging.StreamHandler(sys.stdout)
+h.setLevel(logging.DEBUG)
+log.addHandler(h)
+
+ADDRESS = (
+    "24:71:89:cc:09:05"
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
+)
+NOTIFICATION_UUID = f"0000{0xFFE1:x}-0000-1000-8000-00805f9b34fb"
+
+
+async def run_ble_client(address: str, queue: asyncio.Queue):
+    async def callback_handler(sender, data):
+        await queue.put((time.time(), data))
+
+    async with BleakClient(address) as client:
+        log.info(f"Connected: {await client.is_connected()}")
+        await client.start_notify(NOTIFICATION_UUID, callback_handler)
+        await asyncio.sleep(10.0)
+        await client.stop_notify(NOTIFICATION_UUID)
+        # Send an "exit command to the consumer"
+        await queue.put((time.time(), None))
+
+
+async def run_queue_consumer(queue: asyncio.Queue):
+    while True:
+        # Use await asyncio.wait_for(queue.get(), timeout=1.0) if you want a timeout for getting data.
+        epoch, data = await queue.get()
+        if data is None:
+            log.info(
+                "Got message from client about disconnection. Exiting consumer loop..."
+            )
+            break
+        else:
+            log.info(f"Received callback data via async queue at {epoch}: {data}")
+
+
+async def main(address: str):
+    queue = asyncio.Queue()
+    client_task = run_ble_client(address, queue)
+    consumer_task = run_queue_consumer(queue)
+    await asyncio.gather(client_task, consumer_task)
+    log.info("Main method done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main(ADDRESS))

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -137,7 +137,8 @@ async def run(address, debug=False):
         battery_level = await client.read_gatt_char(BATTERY_LEVEL_UUID)
         print("Battery Level: {0}%".format(int(battery_level[0])))
 
-        def keypress_handler(sender, data):
+        async def keypress_handler(sender, data):
+            asyncio.get_event_loop().call_soon_threadsafe(lambda x: print(x), "Async!")
             print("{0}: {1}".format(sender, data))
 
         write_value = bytearray([0xA0])

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -138,7 +138,6 @@ async def run(address, debug=False):
         print("Battery Level: {0}%".format(int(battery_level[0])))
 
         async def keypress_handler(sender, data):
-            asyncio.get_event_loop().call_soon_threadsafe(lambda x: print(x), "Async!")
             print("{0}: {1}".format(sender, data))
 
         write_value = bytearray([0xA0])


### PR DESCRIPTION
I have gotten a steady stream of questions in my mailbox about having async methods for notification callbacks. This time I had recently seen the [`asyncio.run_coroutine_threadsafe`](https://docs.python.org/3.7/library/asyncio-task.html#asyncio.run_coroutine_threadsafe) method and saw that it might just do the trick in a pretty simple fashion. This is a PR to get feedback on this idea and also testing and sounding boards for macOS.

- Added handling of async callbacks for Windows.
  - [X] Implemented 
  - [X] Tested.
- Added handling of async callbacks for BlueZ.
  - [X] Implemented 
  - [ ] Tested.
- Added handling of async callbacks for Core Bluetooth.
  - [X] Implemented 
  - [ ] Tested.
