### PR TITLE
Changed Service identification to handles instead of UUID

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,13 @@ Fixed
   backend. Merged #401.
 * Fixed RSSI missing in discovered devices on macOS backend. Merged #400.
 * Fixed a broken check for the correct adapter in ``BleakClientBlueZDBus``.
+* Fixed #445 and #362 for Windows.
+
+Changed
+~~~~~~~
+
+* Using handles to identify the services. Added `handle` abstract property to `BleakGATTService`
+  and storing the services by handle instead of UUID.
 
 
 `0.10.0`_ (2020-12-11)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Added
 * Keyword argument ``use_cached`` on .NET backend, to enable uncached reading
   of services, characteristics and descriptors in Windows.
 * Documentation on troubleshooting OS level caches for services.
+* ``handle`` property on ``BleakGATTService`` objects
+* ``service_handle`` property on ``BleakGATTCharacteristic`` objects
 
 Fixed
 ~~~~~
@@ -39,6 +41,11 @@ Changed
 
 * Using handles to identify the services. Added `handle` abstract property to `BleakGATTService`
   and storing the services by handle instead of UUID.
+
+Removed
+~~~~~~~
+* Removed all ``__str__`` methods from backend service, characteristic and descriptor implementations
+  in favour of those in the abstract base classes.
 
 
 `0.10.0`_ (2020-12-11)

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -29,11 +29,14 @@ _GattCharacteristicsFlagsEnum = {
 class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
     """GATT Characteristic implementation for the BlueZ DBus backend"""
 
-    def __init__(self, obj: dict, object_path: str, service_uuid: str):
+    def __init__(
+        self, obj: dict, object_path: str, service_uuid: str, service_handle: int
+    ):
         super(BleakGATTCharacteristicBlueZDBus, self).__init__(obj)
         self.__descriptors = []
         self.__path = object_path
         self.__service_uuid = service_uuid
+        self.__service_handle = service_handle
 
         # D-Bus object path contains handle as last 4 characters of 'charYYYY'
         self._handle = int(object_path[-4:], 16)
@@ -42,6 +45,10 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
         return self.__service_uuid
+
+    @property
+    def service_handle(self) -> int:
+        return self.__service_handle
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -416,7 +416,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
         for char, object_path in _chars:
             _service = list(filter(lambda x: x.path == char["Service"], self.services))
             self.services.add_characteristic(
-                BleakGATTCharacteristicBlueZDBus(char, object_path, _service[0].uuid)
+                BleakGATTCharacteristicBlueZDBus(
+                    char, object_path, _service[0].uuid, _service[0].handle
+                )
             )
 
             # D-Bus object path contains handle as last 4 characters of 'charYYYY'

--- a/bleak/backends/bluezdbus/service.py
+++ b/bleak/backends/bluezdbus/service.py
@@ -18,6 +18,11 @@ class BleakGATTServiceBlueZDBus(BleakGATTService):
         return self.obj["UUID"]
 
     @property
+    def handle(self) -> str:
+        """The integer handle of this service"""
+        raise NotImplementedError("This needs to be implemented!")
+
+    @property
     def characteristics(self) -> List[BleakGATTCharacteristicBlueZDBus]:
         """List of characteristics for this service"""
         return self.__characteristics

--- a/bleak/backends/bluezdbus/service.py
+++ b/bleak/backends/bluezdbus/service.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from bleak.backends.bluezdbus.utils import extract_service_handle_from_path
 from bleak.backends.service import BleakGATTService
 from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus
 
@@ -11,6 +12,7 @@ class BleakGATTServiceBlueZDBus(BleakGATTService):
         super().__init__(obj)
         self.__characteristics = []
         self.__path = path
+        self.__handle = extract_service_handle_from_path(path)
 
     @property
     def uuid(self) -> str:
@@ -20,7 +22,7 @@ class BleakGATTServiceBlueZDBus(BleakGATTService):
     @property
     def handle(self) -> str:
         """The integer handle of this service"""
-        raise NotImplementedError("This needs to be implemented!")
+        return self.__handle
 
     @property
     def characteristics(self) -> List[BleakGATTCharacteristicBlueZDBus]:

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -2,11 +2,13 @@
 import asyncio
 import re
 
+from bleak import BleakError
 from bleak.uuids import uuidstr_to_str
 
 from bleak.backends.bluezdbus import defs
 
 _mac_address_regex = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
+_service_handle_regex = re.compile('service([0-9A-Fa-f]*)')
 
 
 def validate_mac_address(address):
@@ -46,3 +48,11 @@ def format_GATT_object(object_path, interfaces):
     return "\n{0}\n\t{1}\n\t{2}\n\t{3}".format(
         _type, object_path, _uuid, uuidstr_to_str(_uuid)
     )
+
+
+def extract_service_handle_from_path(path):
+    try:
+        return int(_service_handle_regex.search(path).groups()[-1], 16)
+    except Exception as e:
+        raise BleakError(f"Could not parse service handle from path: {path} ({e})")
+

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -8,7 +8,6 @@ from bleak.uuids import uuidstr_to_str
 from bleak.backends.bluezdbus import defs
 
 _mac_address_regex = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
-_service_handle_regex = re.compile("service([0-9A-Fa-f]*)")
 
 
 def validate_mac_address(address):
@@ -52,6 +51,6 @@ def format_GATT_object(object_path, interfaces):
 
 def extract_service_handle_from_path(path):
     try:
-        return int(_service_handle_regex.search(path).groups()[-1], 16)
+        return int(path[-4:], 16)
     except Exception as e:
-        raise BleakError(f"Could not parse service handle from path: {path} ({e})")
+        raise BleakError(f"Could not parse service handle from path: {path}") from e

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -8,7 +8,7 @@ from bleak.uuids import uuidstr_to_str
 from bleak.backends.bluezdbus import defs
 
 _mac_address_regex = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
-_service_handle_regex = re.compile('service([0-9A-Fa-f]*)')
+_service_handle_regex = re.compile("service([0-9A-Fa-f]*)")
 
 
 def validate_mac_address(address):
@@ -55,4 +55,3 @@ def extract_service_handle_from_path(path):
         return int(_service_handle_regex.search(path).groups()[-1], 16)
     except Exception as e:
         raise BleakError(f"Could not parse service handle from path: {path} ({e})")
-

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -34,12 +34,18 @@ class BleakGATTCharacteristic(abc.ABC):
         self.obj = obj
 
     def __str__(self):
-        return "{0}: {1}".format(self.uuid, self.description)
+        return f"{self.uuid} (Handle: {self.handle}): {self.description}"
 
     @property
     @abc.abstractmethod
     def service_uuid(self) -> str:
         """The UUID of the Service containing this characteristic"""
+        raise NotImplementedError()
+
+    @property
+    @abc.abstractmethod
+    def service_handle(self) -> int:
+        """The integer handle of the Service containing this characteristic"""
         raise NotImplementedError()
 
     @property

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -58,6 +58,7 @@ _GattCharacteristicsPropertiesEnum = {
 class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     """GATT Characteristic implementation for the CoreBluetooth backend"""
 
+
     def __init__(self, obj: CBCharacteristic):
         super().__init__(obj)
         self.__descriptors = []
@@ -73,6 +74,11 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
         return cb_uuid_to_str(self.obj.service().UUID())
+
+    @property
+    def service_handle(self) -> int:
+        return int(self.obj.service().startHandle())
+
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -58,7 +58,6 @@ _GattCharacteristicsPropertiesEnum = {
 class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     """GATT Characteristic implementation for the CoreBluetooth backend"""
 
-
     def __init__(self, obj: CBCharacteristic):
         super().__init__(obj)
         self.__descriptors = []
@@ -78,7 +77,6 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     @property
     def service_handle(self) -> int:
         return int(self.obj.service().startHandle())
-
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -69,9 +69,6 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
         ]
         self._uuid = cb_uuid_to_str(self.obj.UUID())
 
-    def __str__(self):
-        return "{0}: {1}".format(self.uuid, self.description)
-
     @property
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -21,9 +21,6 @@ class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):
         self.__characteristic_uuid = characteristic_uuid
         self.__characteristic_handle = characteristic_handle
 
-    def __str__(self):
-        return "{0}: (Handle: {1})".format(self.uuid, self.handle)
-
     @property
     def characteristic_handle(self) -> int:
         """handle for the characteristic that this descriptor belongs to"""

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -17,6 +17,11 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
         self.__characteristics = []
 
     @property
+    def handle(self) -> str:
+        """The integer handle of this service"""
+        raise NotImplementedError("This needs to be implemented!")
+
+    @property
     def uuid(self) -> str:
         """UUID for this service."""
         return cb_uuid_to_str(self.obj.UUID())

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -15,11 +15,12 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
     def __init__(self, obj: CBService):
         super().__init__(obj)
         self.__characteristics = []
+        self.__handle = int(self.obj.startHandle())
 
     @property
-    def handle(self) -> str:
+    def handle(self) -> int:
         """The integer handle of this service"""
-        raise NotImplementedError("This needs to be implemented!")
+        return self.__handle
 
     @property
     def uuid(self) -> str:

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -15,6 +15,8 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
     def __init__(self, obj: CBService):
         super().__init__(obj)
         self.__characteristics = []
+        # N.B. the `startHandle` method of the CBService is an undocumented Core Bluetooth feature,
+        # which Bleak takes advantage of in order to have a service handle to use.
         self.__handle = int(self.obj.startHandle())
 
     @property

--- a/bleak/backends/descriptor.py
+++ b/bleak/backends/descriptor.py
@@ -109,7 +109,7 @@ class BleakGATTDescriptor(abc.ABC):
         self.obj = obj
 
     def __str__(self):
-        return "{0}: {1}".format(self.uuid, self.description)
+        return f"{self.uuid} (Handle: {self.handle}): {self.description}"
 
     @property
     @abc.abstractmethod

--- a/bleak/backends/dotnet/characteristic.py
+++ b/bleak/backends/dotnet/characteristic.py
@@ -54,13 +54,15 @@ class BleakGATTCharacteristicDotNet(BleakGATTCharacteristic):
             if (self.obj.CharacteristicProperties & v)
         ]
 
-    def __str__(self):
-        return "[{0}] {1}: {2}".format(self.handle, self.uuid, self.description)
-
     @property
     def service_uuid(self) -> str:
         """The uuid of the Service containing this characteristic"""
         return self.obj.Service.Uuid.ToString()
+
+    @property
+    def service_handle(self) -> int:
+        """The integer handle of the Service containing this characteristic"""
+        return int(self.obj.Service.AttributeHandle)
 
     @property
     def handle(self) -> int:

--- a/bleak/backends/dotnet/descriptor.py
+++ b/bleak/backends/dotnet/descriptor.py
@@ -18,9 +18,6 @@ class BleakGATTDescriptorDotNet(BleakGATTDescriptor):
         self.__characteristic_uuid = characteristic_uuid
         self.__characteristic_handle = characteristic_handle
 
-    def __str__(self):
-        return "{0}: (Handle: {1})".format(self.uuid, self.handle)
-
     @property
     def characteristic_handle(self) -> int:
         """handle for the characteristic that this descriptor belongs to"""

--- a/bleak/backends/dotnet/service.py
+++ b/bleak/backends/dotnet/service.py
@@ -19,6 +19,11 @@ class BleakGATTServiceDotNet(BleakGATTService):
         ]
 
     @property
+    def handle(self) -> str:
+        """The handle of this service"""
+        return int(self.obj.AttributeHandle)
+
+    @property
     def uuid(self) -> str:
         """UUID for this service."""
         return self.obj.Uuid.ToString()

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -7,7 +7,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 from uuid import UUID
-from typing import List, Union, Iterator
+from typing import Dict, List, Union, Iterator
 
 from bleak import BleakError
 from bleak.uuids import uuidstr_to_str
@@ -85,10 +85,12 @@ class BleakGATTServiceCollection(object):
 
     def __getitem__(
         self, item: Union[str, int, UUID]
-    ) -> Union[BleakGATTService, BleakGATTCharacteristic, BleakGATTDescriptor]:
+    ) -> Union[BleakGATTService, BleakGATTCharacteristic, BleakGATTDescriptor, None]:
         """Get a service, characteristic or descriptor from uuid or handle"""
-        return self.services.get(
-            str(item), self.characteristics.get(item, self.descriptors.get(item, None))
+        return (
+            self.get_service(item)
+            or self.get_characteristic(item)
+            or self.get_descriptor(item)
         )
 
     def __iter__(self) -> Iterator[BleakGATTService]:
@@ -96,17 +98,17 @@ class BleakGATTServiceCollection(object):
         return iter(self.services.values())
 
     @property
-    def services(self) -> dict:
+    def services(self) -> Dict[int, BleakGATTService]:
         """Returns dictionary of handles mapping to BleakGATTService"""
         return self.__services
 
     @property
-    def characteristics(self) -> dict:
+    def characteristics(self) -> Dict[int, BleakGATTCharacteristic]:
         """Returns dictionary of handles mapping to BleakGATTCharacteristic"""
         return self.__characteristics
 
     @property
-    def descriptors(self) -> dict:
+    def descriptors(self) -> Dict[int, BleakGATTDescriptor]:
         """Returns a dictionary of integer handles mapping to BleakGATTDescriptor"""
         return self.__descriptors
 

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -7,7 +7,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 from uuid import UUID
-from typing import Dict, List, Union, Iterator
+from typing import Dict, List, Optional, Union, Iterator
 
 from bleak import BleakError
 from bleak.uuids import uuidstr_to_str
@@ -85,7 +85,9 @@ class BleakGATTServiceCollection(object):
 
     def __getitem__(
         self, item: Union[str, int, UUID]
-    ) -> Union[BleakGATTService, BleakGATTCharacteristic, BleakGATTDescriptor, None]:
+    ) -> Optional[
+        Union[BleakGATTService, BleakGATTCharacteristic, BleakGATTDescriptor]
+    ]:
         """Get a service, characteristic or descriptor from uuid or handle"""
         return (
             self.get_service(item)

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -26,8 +26,8 @@ async def run(address, debug=False):
         log.addHandler(h)
 
     async with BleakClient(address) as client:
-        x = await client.is_connected()
-        log.info("Connected: {0}".format(x))
+        is_connected = await client.is_connected()
+        log.info(f"Connected: {is_connected}")
 
         for service in client.services:
             log.info(f"[Service] {service}")
@@ -35,27 +35,34 @@ async def run(address, debug=False):
                 if "read" in char.properties:
                     try:
                         value = bytes(await client.read_gatt_char(char.uuid))
+                        log.info(
+                            f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
+                        )
                     except Exception as e:
                         value = str(e).encode()
+                        log.error(
+                            f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
+                        )
+
                 else:
                     value = None
-                log.info(
-                    f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
-                )
+                    log.info(
+                        f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
+                    )
 
                 for descriptor in char.descriptors:
                     try:
                         value = bytes(
                             await client.read_gatt_descriptor(descriptor.handle)
                         )
+                        log.info(
+                            f"\t\t[Descriptor] {descriptor}) | Value: {value}"
+                        )
                     except Exception as e:
                         value = str(e).encode()
-                    log.info(
-                        f"\t\t[Descriptor] {descriptor}) | Value: {value} ".format(
-                            descriptor.uuid,
-                            descriptor.handle,
+                        log.error(
+                            f"\t\t[Descriptor] {descriptor}) | Value: {value}"
                         )
-                    )
 
 
 if __name__ == "__main__":

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -55,14 +55,10 @@ async def run(address, debug=False):
                         value = bytes(
                             await client.read_gatt_descriptor(descriptor.handle)
                         )
-                        log.info(
-                            f"\t\t[Descriptor] {descriptor}) | Value: {value}"
-                        )
+                        log.info(f"\t\t[Descriptor] {descriptor}) | Value: {value}")
                     except Exception as e:
                         value = str(e).encode()
-                        log.error(
-                            f"\t\t[Descriptor] {descriptor}) | Value: {value}"
-                        )
+                        log.error(f"\t\t[Descriptor] {descriptor}) | Value: {value}")
 
 
 if __name__ == "__main__":

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -30,7 +30,7 @@ async def run(address, debug=False):
         log.info("Connected: {0}".format(x))
 
         for service in client.services:
-            log.info("[Service] {0}: {1}".format(service.uuid, service.description))
+            log.info(f"[Service] {service}")
             for char in service.characteristics:
                 if "read" in char.properties:
                     try:
@@ -40,19 +40,20 @@ async def run(address, debug=False):
                 else:
                     value = None
                 log.info(
-                    "\t[Characteristic] {0}: (Handle: {1}) ({2}) | Name: {3}, Value: {4} ".format(
-                        char.uuid,
-                        char.handle,
-                        ",".join(char.properties),
-                        char.description,
-                        value,
-                    )
+                    f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
                 )
+
                 for descriptor in char.descriptors:
-                    value = await client.read_gatt_descriptor(descriptor.handle)
+                    try:
+                        value = bytes(
+                            await client.read_gatt_descriptor(descriptor.handle)
+                        )
+                    except Exception as e:
+                        value = str(e).encode()
                     log.info(
-                        "\t\t[Descriptor] {0}: (Handle: {1}) | Value: {2} ".format(
-                            descriptor.uuid, descriptor.handle, bytes(value)
+                        f"\t\t[Descriptor] {descriptor}) | Value: {value} ".format(
+                            descriptor.uuid,
+                            descriptor.handle,
                         )
                     )
 

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -39,9 +39,8 @@ async def run(address, debug=False):
                             f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
                         )
                     except Exception as e:
-                        value = str(e).encode()
                         log.error(
-                            f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {value}"
+                            f"\t[Characteristic] {char} ({','.join(char.properties)}), Value: {e}"
                         )
 
                 else:
@@ -57,8 +56,7 @@ async def run(address, debug=False):
                         )
                         log.info(f"\t\t[Descriptor] {descriptor}) | Value: {value}")
                     except Exception as e:
-                        value = str(e).encode()
-                        log.error(f"\t\t[Descriptor] {descriptor}) | Value: {value}")
+                        log.error(f"\t\t[Descriptor] {descriptor}) | Value: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Identifying Services by UUID is wrong, since a peripheral can have multiple services with the same UUID. The proper identifier should be the handle instead. From previously having thought the service handles was not present in the APIs that Bleak use, I have now done a depper investigation and foudn that I was wrong, they were there and they were quite easily obtained as well.

This should once and for all prevent the `This service is already present in this BleakGATTServiceCollection!` error from occuring for users.

- [X] Windows backend
- [X] BlueZ backend
- [x] CoreBluetooth backend (tested in OS X 10.11 only)

Fixes #445 and #362.

This PR also removes all `__str__` methods from subclasses of `BleakGATT*` in favour of the ones in the abstract base classes.
