### PR TITLE
Fix for the 'Unknown' name in scan results on Windows 10. 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 * Fixed ``BaseBleakClient.services_resolved`` not reset on disconnect on BlueZ
   backend. Merged #401.
 * Fixed RSSI missing in discovered devices on macOS backend. Merged #400.
+* Fixed scan result shows 'Unknown' name of the ``BLEDevice``. Fixes #371.
 
 
 `0.10.0`_ (2020-12-11)

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -27,7 +27,7 @@ class BLEDevice(object):
         #: The Bluetooth address of the device on this machine.
         self.address = address
         #: The advertised name of the device.
-        self.name = name if name else "Unknown"
+        self.name = name
         #: The OS native details required for connecting to the device.
         self.details = details
         #: RSSI, if available
@@ -36,7 +36,7 @@ class BLEDevice(object):
         self.metadata = kwargs
 
     def __str__(self):
-        if self.name == "Unknown":
+        if not self.name:
             if "manufacturer_data" in self.metadata:
                 ks = list(self.metadata["manufacturer_data"].keys())
                 if len(ks):
@@ -46,7 +46,7 @@ class BLEDevice(object):
                     )
                     # TODO: Evaluate how to interpret the value of the company identifier...
                     return "{0}: {1} ({2})".format(self.address, mf, value)
-        return "{0}: {1}".format(self.address, self.name)
+        return "{0}: {1}".format(self.address, self.name or "Unknown")
 
     def __repr__(self):
         return str(self)


### PR DESCRIPTION
Updated `BLEDevice` constructor to remove setting self.name to `Unknown` if not name. 
Updated `BLEDevice.__str__` conditional to check not self.name instead of equality to `Unknown` .
Updated second return statement in `BLEDevice.__str__` to use `self.name` or `Unknown`.

Updated changelog