### PR TITLE
Obviously misplaced code

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Fixed
 * Fixed ``BaseBleakClient.services_resolved`` not reset on disconnect on BlueZ
   backend. Merged #401.
 * Fixed RSSI missing in discovered devices on macOS backend. Merged #400.
+* Fixed a broken check for the correct adapter in ``BleakClientBlueZDBus``.
 
 
 `0.10.0`_ (2020-12-11)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -113,10 +113,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         def _services_resolved_callback(message):
             iface, changed, invalidated = message.body
-            is_resolved = defs.DEVICE_INTERFACE and changed.get(
+            is_resolved = iface == defs.DEVICE_INTERFACE and changed.get(
                 "ServicesResolved", False
             )
-            if iface == is_resolved:
+            if is_resolved:
                 logger.info("Services resolved for %s", str(self))
                 self.services_resolved = True
 


### PR DESCRIPTION
The test in `bleak.backends.bluezdbus.client.py::connect::_services_resolved_callback` is quite obviously misplaced.