### PR TITLE
BlueZ: Fixed stop_notify() error logged on device disconnect.

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -390,15 +390,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     f"Failed to remove match {rule.member} ({self._device_path}): {e}"
                 )
 
-        # avoid reentrancy issues by taking a copy of self._subscriptions
-        old_subscriptions, self._subscriptions = self._subscriptions, []
-        for handle in old_subscriptions:
-            try:
-                await self.stop_notify(handle)
-            except Exception as e:
-                logger.error(
-                    f"Failed to stop notifications on characteristic {handle} ({self._device_path}): {e}"
-                )
+        # There is no need to call stop_notify() here since the the device is
+        # already disconnected and we are about to close the D-Bus message bus
+        # which has the effect of clearing all notifications in BlueZ.
+        self._subscriptions = []
 
     def _disconnect_message_bus(self) -> None:
         """


### PR DESCRIPTION
This removes the call to stop_notify() in the cleanup code path in the BlueZ backend. This was causing an error message to always be logged when notifications were enabled and a device was disconnected.

As described in the code comment. This call is not necessary and can be removed.

Fixes: #472

(No changelog since this bug was introduced in changes since the previous release)
