### PR TITLE
Replace get_discovered_devices with discovered_devices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,16 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 -------------
 
+Added
+~~~~~
+
+* Added ``BleakScanner.discovered_devices`` property.
+
+Changed
+~~~~~~~
+
+* Deprecated ``BleakScanner.get_discovered_devices()`` async method.
+
 Fixed
 ~~~~~
 

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -210,7 +210,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         if "Transport" not in self._filters:
             self._filters["Transport"] = Variant("s", "le")
 
-    async def get_discovered_devices(self) -> List[BLEDevice]:
+    @property
+    def discovered_devices(self) -> List[BLEDevice]:
         # Reduce output.
         discovered_devices = []
         for path, props in self._devices.items():

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -103,7 +103,8 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             "Need to evaluate which macOS versions to support first..."
         )
 
-    async def get_discovered_devices(self) -> List[BLEDevice]:
+    @property
+    def discovered_devices(self) -> List[BLEDevice]:
         found = []
         peripherals = self._manager.central_manager.retrievePeripheralsWithIdentifiers_(
             NSArray(self._identifiers.keys()),

--- a/bleak/backends/dotnet/scanner.py
+++ b/bleak/backends/dotnet/scanner.py
@@ -205,7 +205,8 @@ class BleakScannerDotNet(BaseBleakScanner):
             # TODO: Handle AdvertisementFilter parameters
             self._advertisement_filter = kwargs["AdvertisementFilter"]
 
-    async def get_discovered_devices(self) -> List[BLEDevice]:
+    @property
+    def discovered_devices(self) -> List[BLEDevice]:
         found = []
         for event_args in list(self._devices.values()):
             new_device = self.parse_eventargs(event_args)

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -45,8 +45,7 @@ It can also be used as an object, either in an asynchronous context manager way:
     async def run():
         async with BleakScanner() as scanner:
             await asyncio.sleep(5.0)
-            devices = await scanner.get_discovered_devices()
-        for d in devices:
+        for d in scanner.discovered_devices:
             print(d)
 
     loop = asyncio.get_event_loop()
@@ -68,9 +67,8 @@ or separately, calling ``start`` and ``stop`` methods on the scanner manually:
         await scanner.start()
         await asyncio.sleep(5.0)
         await scanner.stop()
-        devices = await scanner.get_discovered_devices()
 
-        for d in devices:
+        for d in scanner.discovered_devices:
             print(d)
 
     loop = asyncio.get_event_loop()


### PR DESCRIPTION
This adds a new `BleakScanner.discovered_devices` property to replace the `BleakScanner.get_discovered_devices()` async method.

A deprecation warning is added to `BleakScanner.get_discovered_devices()` and the documentation for that method.

Fixes #489

