### PR TITLE
Fix linux_autodoc_mock_import in docs/conf.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
 
 * Handling of undetected devices in ``connect_by_bledevice.py`` example. Fixes #487.
 * Added ``Optional`` typehint for ``BleakScanner.find_device_by_address``.
+* Fixed ``linux_autodoc_mock_import`` in ``docs/conf.py``.
 
 
 `0.11.0`_ (2021-03-17)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 
 
 windows_autodoc_mock_import = ["clr", "Windows", "System", "BleakBridge"]
-linux_autodoc_mock_import = ["dbus-next"]
+linux_autodoc_mock_import = ["dbus_next"]
 macos_autodoc_mock_import = [
     "objc",
     "Foundation",


### PR DESCRIPTION
This expects the module name rather than the package name, so we have to use an underscore instead of a dash.

