### PR TITLE
Correct and improve Philips Hue example

### DIFF
--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -15,6 +15,8 @@ References:
 - https://www.reddit.com/r/Hue/comments/eq0y3y/philips_hue_bluetooth_developer_documentation/
 - https://gist.github.com/shinyquagsire23/f7907fdf6b470200702e75a30135caf3
 - https://github.com/Mic92/hue-ble-ctl/blob/master/hue-ble-ctl.py
+- https://github.com/npaun/philble/blob/master/philble/client.py
+- https://github.com/eb3095/hue-sync/blob/main/huelib/HueDevice.py
 
 Created on 2020-01-13 by hbldh <henrik.blidh@nedomkull.com>
 
@@ -28,7 +30,18 @@ from bleak import BleakClient
 
 LIGHT_CHARACTERISTIC = "932c32bd-0002-47a2-835a-a8d455b859dd"
 BRIGHTNESS_CHARACTERISTIC = "932c32bd-0003-47a2-835a-a8d455b859dd"
-COLOR_CHARACTERISTIC = "932c32bd-0004-47a2-835a-a8d455b859dd"
+TEMPERATURE_CHARACTERISTIC = "932c32bd-0004-47a2-835a-a8d455b859dd"
+COLOR_CHARACTERISTIC = "932c32bd-0005-47a2-835a-a8d455b859dd"
+
+
+def convert_rgb(rgb):
+    scale = 0xFF
+    adjusted = [max(1, chan) for chan in rgb]
+    total = sum(adjusted)
+    adjusted = [int(round(chan / total * scale)) for chan in adjusted]
+
+    # Unknown, Red, Blue, Green
+    return bytearray([0x1, adjusted[0], adjusted[2], adjusted[1]])
 
 
 async def run(address, debug=False):
@@ -52,6 +65,21 @@ async def run(address, debug=False):
         await asyncio.sleep(1.0)
         print("Turning Light on...")
         await client.write_gatt_char(LIGHT_CHARACTERISTIC, b"\x01")
+        await asyncio.sleep(1.0)
+
+        print("Setting color to RED...")
+        color = convert_rgb([255, 0, 0])
+        await client.write_gatt_char(COLOR_CHARACTERISTIC, color)
+        await asyncio.sleep(1.0)
+
+        print("Setting color to GREEN...")
+        color = convert_rgb([0, 255, 0])
+        await client.write_gatt_char(COLOR_CHARACTERISTIC, color)
+        await asyncio.sleep(1.0)
+
+        print("Setting color to BLUE...")
+        color = convert_rgb([0, 0, 255])
+        await client.write_gatt_char(COLOR_CHARACTERISTIC, color)
         await asyncio.sleep(1.0)
 
         for brightness in range(256):


### PR DESCRIPTION
The Hue example is missing examples of how to use color. I pulled the logic from another repo on the conversion to the correct format and added a reference line for it. I also added my own repo since I am using this and may expand in the future.

The color characteristic is wrong, its 0005, not 0004, 0004 appears to be color temperature (soft-white / blue-white). I haven't played with this or I would of expanded on it, so I just left the line for anyone looking for it.
