### PR TITLE
updating docstring for dotnetclient connect method

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -720,7 +720,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
@@ -822,7 +822,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
         )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:
@@ -927,8 +929,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         assert_reply(reply)
 
     async def stop_notify(
-        self,
-        char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID],
+        self, char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID],
     ) -> None:
         """Deactivate notification/indication on a specified characteristic.
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -202,7 +202,7 @@ class BaseBleakClient(abc.ABC):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
@@ -218,7 +218,9 @@ class BaseBleakClient(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -173,10 +173,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             logger.debug(
                 "Retrieving characteristics for service {}".format(serviceUUID)
             )
-            characteristics = (
-                await manager.connected_peripheral_delegate.discoverCharacteristics_(
-                    service
-                )
+            characteristics = await manager.connected_peripheral_delegate.discoverCharacteristics_(
+                service
             )
 
             self.services.add_service(BleakGATTServiceCoreBluetooth(service))
@@ -186,10 +184,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 logger.debug(
                     "Retrieving descriptors for characteristic {}".format(cUUID)
                 )
-                descriptors = (
-                    await manager.connected_peripheral_delegate.discoverDescriptors_(
-                        characteristic
-                    )
+                descriptors = await manager.connected_peripheral_delegate.discoverDescriptors_(
+                    characteristic
                 )
 
                 self.services.add_characteristic(
@@ -300,14 +296,12 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             raise BleakError("Characteristic {} was not found!".format(char_specifier))
 
         value = NSData.alloc().initWithBytes_length_(data, len(data))
-        success = (
-            await manager.connected_peripheral_delegate.writeCharacteristic_value_type_(
-                characteristic.obj,
-                value,
-                CBCharacteristicWriteWithResponse
-                if response
-                else CBCharacteristicWriteWithoutResponse,
-            )
+        success = await manager.connected_peripheral_delegate.writeCharacteristic_value_type_(
+            characteristic.obj,
+            value,
+            CBCharacteristicWriteWithResponse
+            if response
+            else CBCharacteristicWriteWithoutResponse,
         )
         if success:
             logger.debug(
@@ -320,7 +314,9 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 )
             )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -219,11 +219,9 @@ class BleakClientDotNet(BaseBleakClient):
                 handle_connection_status_changed, sender.ConnectionStatus
             )
 
-        self._connection_status_changed_token = (
-            self._requester.add_ConnectionStatusChanged(
-                TypedEventHandler[BluetoothLEDevice, Object](
-                    _ConnectionStatusChanged_Handler
-                )
+        self._connection_status_changed_token = self._requester.add_ConnectionStatusChanged(
+            TypedEventHandler[BluetoothLEDevice, Object](
+                _ConnectionStatusChanged_Handler
             )
         )
 
@@ -683,7 +681,7 @@ class BleakClientDotNet(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -744,7 +742,9 @@ class BleakClientDotNet(BaseBleakClient):
                     )
                 )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:


### PR DESCRIPTION
The `write_gatt_char` and `write_gatt_descriptor` methods allow for both a `bytes` and `bytearray` object. Typing did only allow for a bytearray.
