### PR TITLE
change typing on data parameter in `write_gatt_char` and `write_gatt_descriptor`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 ~~~~~
 
+* Change typing of data parameter to ``Union[bytes, bytearray]``
 * WinRT backend added
 * Added ``BleakScanner.discovered_devices`` property.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Changed
 * Deprecated ``BleakScanner.get_discovered_devices()`` async method.
 * Added capability to handle async functions as detection callbacks in ``BleakScanner``.
 * Added error description in addition to error name when ``BleakDBusError`` is converted to string
-* Change typing of data parameter in write methods to ``Union[bytes, bytearray]``
+* Change typing of data parameter in write methods to ``Union[bytes, bytearray, memoryview]``
 
 Fixed
 ~~~~~

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -720,7 +720,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
@@ -822,7 +822,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
         )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -731,7 +731,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID],
-        data: Union[bytes, bytearray],
+        data: Union[bytes, bytearray, memoryview],
         response: bool = False,
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
@@ -834,7 +834,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         )
 
     async def write_gatt_descriptor(
-        self, handle: int, data: Union[bytes, bytearray]
+        self, handle: int, data: Union[bytes, bytearray, memoryview]
     ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -202,7 +202,7 @@ class BaseBleakClient(abc.ABC):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: Union[bytes, bytearray],
+        data: Union[bytes, bytearray, memoryview],
         response: bool = False,
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
@@ -219,7 +219,7 @@ class BaseBleakClient(abc.ABC):
 
     @abc.abstractmethod
     async def write_gatt_descriptor(
-        self, handle: int, data: Union[bytes, bytearray]
+        self, handle: int, data: Union[bytes, bytearray, memoryview]
     ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -202,7 +202,7 @@ class BaseBleakClient(abc.ABC):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation on the specified GATT characteristic.
@@ -218,7 +218,9 @@ class BaseBleakClient(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -283,7 +283,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: Union[bytes, bytearray],
+        data: Union[bytes, bytearray, memoryview],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -327,7 +327,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             )
 
     async def write_gatt_descriptor(
-        self, handle: int, data: Union[bytes, bytearray]
+        self, handle: int, data: Union[bytes, bytearray, memoryview]
     ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -277,7 +277,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -320,7 +320,9 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 )
             )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -683,7 +683,7 @@ class BleakClientDotNet(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -744,7 +744,9 @@ class BleakClientDotNet(BaseBleakClient):
                     )
                 )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -688,7 +688,7 @@ class BleakClientDotNet(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: Union[bytes, bytearray],
+        data: Union[bytes, bytearray, memoryview],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -750,7 +750,7 @@ class BleakClientDotNet(BaseBleakClient):
                 )
 
     async def write_gatt_descriptor(
-        self, handle: int, data: Union[bytes, bytearray]
+        self, handle: int, data: Union[bytes, bytearray, memoryview]
     ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -614,7 +614,7 @@ class BleakClientWinRT(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: Union[bytes, bytearray],
+        data: Union[bytes, bytearray, memoryview],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -670,7 +670,7 @@ class BleakClientWinRT(BaseBleakClient):
                 )
 
     async def write_gatt_descriptor(
-        self, handle: int, data: Union[bytes, bytearray]
+        self, handle: int, data: Union[bytes, bytearray, memoryview]
     ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -609,7 +609,7 @@ class BleakClientWinRT(BaseBleakClient):
     async def write_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        data: bytearray,
+        data: Union[bytes, bytearray],
         response: bool = False,
     ) -> None:
         """Perform a write operation of the specified GATT characteristic.
@@ -664,7 +664,9 @@ class BleakClientWinRT(BaseBleakClient):
                     )
                 )
 
-    async def write_gatt_descriptor(self, handle: int, data: bytearray) -> None:
+    async def write_gatt_descriptor(
+        self, handle: int, data: Union[bytes, bytearray]
+    ) -> None:
         """Perform a write operation on the specified GATT descriptor.
 
         Args:


### PR DESCRIPTION
The write_gatt_char and write_gatt_descriptor methods allow for both a bytes and bytearray object. Typing did only allow for a bytearray.