### PR TITLE
Fix read and set of D-Bus properties in BleakClientBlueZDBus.pair()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Fixed
 * Fixed ``linux_autodoc_mock_import`` in ``docs/conf.py``.
 * Minor fix for disconnection event handling in BlueZ backend. Fixes #491.
 * Corrections for the Philips Hue lamp example. Merged #505
+* Fixed BleakClientBlueZDBus.pair() method always returning True. Fixes #503.
 
 
 `0.11.0`_ (2021-03-17)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -499,7 +499,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
         )
         assert_reply(reply)
-        if reply.body[0]:
+        if reply.body[0].value:
+            logger.debug(
+                f"BLE device @ {self.address} already paired with {self._adapter}"
+            )
             return True
 
         # Set device as trusted.
@@ -510,7 +513,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 interface=defs.PROPERTIES_INTERFACE,
                 member="Set",
                 signature="ssv",
-                body=[defs.DEVICE_INTERFACE, "Trusted", True],
+                body=[defs.DEVICE_INTERFACE, "Trusted", Variant("b", True)],
             )
         )
         assert_reply(reply)
@@ -541,7 +544,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         )
         assert_reply(reply)
 
-        return reply.body[0]
+        return reply.body[0].value
 
     async def unpair(self) -> bool:
         """Unpair with the peripheral.


### PR DESCRIPTION
When checking if device is already paired in `BleakClientBlueZDBus`
`pair()` method, result of call reading the Paired property
reply.body[0] is object type `dbus_next.signature.Variant` and always
evaluated to `True`, even if the actual value represented was `False`.
Test:
```python
>>> reply.body[0]
<dbus_next.signature.Variant ('b', False)>
>>> bool(reply.body[0])
True
>>> reply.body[0].value
False
>>> bool(reply.body[0].value)
False
```
Moreover, when setting the Trusted property, the following exception
was raised:
```plain
    dbus_next.errors.SignatureBodyMismatchError: DBus VARIANT type "v"
    must be Python type "Variant", got <class 'bool'>
```