### PR TITLE
Adding mtu_size client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 ~~~~~
 
-* get_mtu_size for macOS client
+* add mtu_size property for clients
 * WinRT backend added
 * Added ``BleakScanner.discovered_devices`` property.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 ~~~~~
 
+* get_mtu_size for macOS client
 * WinRT backend added
 * Added ``BleakScanner.discovered_devices`` property.
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -98,6 +98,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
             bluez_version[0] == 5 and bluez_version[1] >= 48
         )
 
+        # set default MTU size
+        self._mtu_size = 23
+
     # Connectivity methods
 
     async def connect(self, **kwargs) -> bool:
@@ -334,6 +337,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
             # Get all services. This means making the actual connection.
             await self.get_services()
 
+            # Get the MTU size, assuming the server has at least one
+            # notify or write-without-response characteristic
+            # If not, we use default ATT MTU size of 23
+            self._mtu_size = await self.get_mtu_size(self.services)
+
             return True
         except BaseException:
             await self._cleanup_all()
@@ -569,6 +577,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
         return self._DeprecatedIsConnectedReturn(
             False if self._bus is None else self._properties.get("Connected", False)
         )
+
+    @property
+    def mtu_size(self) -> bool:
+        """Get ATT MTU size for active connection"""
+        return self._mtu_size
 
     # GATT services methods
 
@@ -1047,32 +1060,38 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     if disconnecting_event:
                         task.add_done_callback(lambda _: disconnecting_event.set())
 
-    async def get_mtu_size(
-        self, char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID]
-    ):
-        if not self.is_connected:
-            raise BleakError("Not connected")
+    async def get_mtu_size(self, services : BleakGATTServiceCollection):
 
-        if not isinstance(char_specifier, BleakGATTCharacteristicBlueZDBus):
-            characteristic = self.services.get_characteristic(char_specifier)
-        else:
-            characteristic = char_specifier
+        characteristic = None
 
-        member = "AcquireWrite"
+        for service in services:
+            for char in service.characteristics:
+                if "write-without-response" in char.properties:
+                    member = "AcquireWrite"
+                    characteristic = char
+                    break
+                elif "notify" in char.properties:
+                    member = "AcquireNotify"
+                    characteristic = char
+                    break
+            if (characteristic != None):
+                break
 
-        if "notify" in characteristic.properties:
-            member = "AcquireNotify"
-
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path=characteristic.path,
-                interface=defs.GATT_CHARACTERISTIC_INTERFACE,
-                member=member,
-                signature="a{sv}",
-                body=[{}],
+        if (characteristic != None):
+            reply = await self._bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path=characteristic.path,
+                    interface=defs.GATT_CHARACTERISTIC_INTERFACE,
+                    member=member,
+                    signature="a{sv}",
+                    body=[{}],
+                )
             )
-        )
 
-        assert_reply(reply)
-        return reply.body[1]
+            assert_reply(reply)
+            fd = reply.body[0]
+            os.close(fd)
+            return reply.body[1]
+        else:
+            return 23

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -571,7 +571,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         )
 
     @property
-    def mtu_size(self) -> bool:
+    def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
         warnings.warn(
             "MTU size not supported with BlueZ; this function returns the default value of 23. Note that the actual MTU size might be larger"

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -1060,7 +1060,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     if disconnecting_event:
                         task.add_done_callback(lambda _: disconnecting_event.set())
 
-    async def get_mtu_size(self, services : BleakGATTServiceCollection):
+    async def get_mtu_size(self, services: BleakGATTServiceCollection):
 
         characteristic = None
 
@@ -1074,10 +1074,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     member = "AcquireNotify"
                     characteristic = char
                     break
-            if (characteristic != None):
+            if characteristic != None:
                 break
 
-        if (characteristic != None):
+        if characteristic != None:
             reply = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -1072,9 +1072,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
         else:
             characteristic = char_specifier
 
-        if char_property is "notify":
+        if char_property == "notify":
             member = "AcquireNotify"
-        elif char_property is "write-without-response":
+        elif char_property == "write-without-response":
             member = "AcquireWrite"
         else:
             raise BleakError(

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -1047,8 +1047,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     if disconnecting_event:
                         task.add_done_callback(lambda _: disconnecting_event.set())
 
-
-    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID]):
+    async def get_mtu_size(
+        self, char_specifier: Union[BleakGATTCharacteristicBlueZDBus, int, str, UUID]
+    ):
         if not self.is_connected:
             raise BleakError("Not connected")
 
@@ -1060,7 +1061,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         member = "AcquireWrite"
 
         if "notify" in characteristic.properties:
-            member="AcquireNotify"
+            member = "AcquireNotify"
 
         reply = await self._bus.call(
             Message(
@@ -1075,4 +1076,3 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         assert_reply(reply)
         return reply.body[1]
-

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -20,7 +20,10 @@ from Foundation import (
     NSData,
     NSError,
 )
-from CoreBluetooth import CBCharacteristicWriteWithResponse, CBCharacteristicWriteWithoutResponse
+from CoreBluetooth import (
+    CBCharacteristicWriteWithResponse,
+    CBCharacteristicWriteWithoutResponse,
+)
 
 from bleak.exc import BleakError
 
@@ -132,7 +135,12 @@ class PeripheralDelegate(NSObject):
     def getMtuSize(self) -> int:
         """Use type CBCharacteristicWriteWithoutResponse to get maximum write value length based on the
         the negotiated ATT MTU size. Add the ATT header length (+3) to get the actual ATT MTU size"""
-        return self.peripheral.maximumWriteValueLengthForType_(CBCharacteristicWriteWithoutResponse) + 3
+        return (
+            self.peripheral.maximumWriteValueLengthForType_(
+                CBCharacteristicWriteWithoutResponse
+            )
+            + 3
+        )
 
     async def readDescriptor_(
         self, descriptor: CBDescriptor, use_cached=True

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -20,7 +20,7 @@ from Foundation import (
     NSData,
     NSError,
 )
-from CoreBluetooth import CBCharacteristicWriteWithResponse
+from CoreBluetooth import CBCharacteristicWriteWithResponse, CBCharacteristicWriteWithoutResponse
 
 from bleak.exc import BleakError
 
@@ -128,6 +128,11 @@ class PeripheralDelegate(NSObject):
             return characteristic.value()
         else:
             return b""
+
+    def getMtuSize(self) -> int:
+        """Use type CBCharacteristicWriteWithoutResponse to get maximum write value length based on the
+        the negotiated ATT MTU size. Add the ATT header length (+3) to get the actual ATT MTU size"""
+        return self.peripheral.maximumWriteValueLengthForType_(CBCharacteristicWriteWithoutResponse) + 3
 
     async def readDescriptor_(
         self, descriptor: CBDescriptor, use_cached=True

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -126,7 +126,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         )
 
     @property
-    def mtu_size(self) -> bool:
+    def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
         manager = self._central_manager_delegate
         return manager.connected_peripheral_delegate.getMtuSize()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -442,3 +442,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         if not RSSI:
             return None
+
+    def get_mtu_size(self):
+        manager = self._central_manager_delegate
+        return manager.connected_peripheral_delegate.getMtuSize()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -125,6 +125,12 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             False if manager is None else manager.isConnected
         )
 
+    @property
+    def mtu_size(self) -> bool:
+        """Get ATT MTU size for active connection"""
+        manager = self._central_manager_delegate
+        return manager.connected_peripheral_delegate.getMtuSize()
+
     async def pair(self, *args, **kwargs) -> bool:
         """Attempt to pair with a peripheral.
 
@@ -442,9 +448,3 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         if not RSSI:
             return None
-
-    async def get_mtu_size(
-        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
-    ):
-        manager = self._central_manager_delegate
-        return manager.connected_peripheral_delegate.getMtuSize()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -443,6 +443,6 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         if not RSSI:
             return None
 
-    def get_mtu_size(self):
+    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]):
         manager = self._central_manager_delegate
         return manager.connected_peripheral_delegate.getMtuSize()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -443,6 +443,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         if not RSSI:
             return None
 
-    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]):
+    async def get_mtu_size(
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
+    ):
         manager = self._central_manager_delegate
         return manager.connected_peripheral_delegate.getMtuSize()

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -305,6 +305,11 @@ class BleakClientDotNet(BaseBleakClient):
             else self._requester.ConnectionStatus == BluetoothConnectionStatus.Connected
         )
 
+    @property
+    def mtu_size(self) -> bool:
+        """Get ATT MTU size for active connection"""
+        return self._session.MaxPduSize
+
     async def pair(self, protection_level=None, **kwargs) -> bool:
         """Attempts to pair with the device.
 
@@ -913,11 +918,6 @@ class BleakClientDotNet(BaseBleakClient):
         characteristic.obj.remove_ValueChanged(
             self._notification_callbacks.pop(characteristic.handle)
         )
-
-    async def get_mtu_size(
-        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
-    ):
-        return self._session.MaxPduSize
 
 
 def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -306,7 +306,7 @@ class BleakClientDotNet(BaseBleakClient):
         )
 
     @property
-    def mtu_size(self) -> bool:
+    def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
         return self._session.MaxPduSize
 

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -914,8 +914,11 @@ class BleakClientDotNet(BaseBleakClient):
             self._notification_callbacks.pop(characteristic.handle)
         )
 
-    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]):
+    async def get_mtu_size(
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
+    ):
         return self._session.MaxPduSize
+
 
 def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):
     @wraps(func)

--- a/bleak/backends/dotnet/client.py
+++ b/bleak/backends/dotnet/client.py
@@ -914,6 +914,8 @@ class BleakClientDotNet(BaseBleakClient):
             self._notification_callbacks.pop(characteristic.handle)
         )
 
+    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]):
+        return self._session.MaxPduSize
 
 def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):
     @wraps(func)

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -280,6 +280,11 @@ class BleakClientWinRT(BaseBleakClient):
             == BluetoothConnectionStatus.CONNECTED
         )
 
+    @property
+    def mtu_size(self) -> bool:
+        """Get ATT MTU size for active connection"""
+        return self._session.MaxPduSize
+
     async def pair(self, protection_level: int = None, **kwargs) -> bool:
         """Attempts to pair with the device.
 
@@ -815,11 +820,6 @@ class BleakClientWinRT(BaseBleakClient):
                 characteristic.handle
             )
             characteristic.obj.remove_value_changed(event_handler_token)
-
-    async def get_mtu_size(
-        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
-    ):
-        return self._session.MaxPduSize
 
 
 def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -281,9 +281,9 @@ class BleakClientWinRT(BaseBleakClient):
         )
 
     @property
-    def mtu_size(self) -> bool:
+    def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
-        return self._session.MaxPduSize
+        return self._session.max_pdu_size
 
     async def pair(self, protection_level: int = None, **kwargs) -> bool:
         """Attempts to pair with the device.

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -816,8 +816,11 @@ class BleakClientWinRT(BaseBleakClient):
             )
             characteristic.obj.remove_value_changed(event_handler_token)
 
-    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]):
+    async def get_mtu_size(
+        self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
+    ):
         return self._session.MaxPduSize
+
 
 def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):
     @wraps(func)

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -816,6 +816,8 @@ class BleakClientWinRT(BaseBleakClient):
             )
             characteristic.obj.remove_value_changed(event_handler_token)
 
+    async def get_mtu_size(self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]):
+        return self._session.MaxPduSize
 
 def _notification_wrapper(func: Callable, loop: asyncio.AbstractEventLoop):
     @wraps(func)


### PR DESCRIPTION
Adding a simple method to the macOS client to get the current ATT MTU size.
The ATT MTU size includes the ATT header, while CoreBluetooth returns the maximum ATT payload size, hence the +3 in the getMtuSize method.

