### PR TITLE
During init() support raising a "BLE is unsupported"

### DIFF
--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -89,10 +89,10 @@ class CentralManagerDelegate(NSObject):
         # It doesn't take long for the callback to occur, so we should be able
         # to do a blocking wait here without anyone complaining.
         self._did_update_state_event.wait(1)
-        
+
         if self.central_manager.state() == CBManagerStateUnsupported:
             raise BleakError("BLE is unsupported")
-        
+
         if self.central_manager.state() != CBManagerStatePoweredOn:
             raise BleakError("Bluetooth device is turned off")
 

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -89,6 +89,10 @@ class CentralManagerDelegate(NSObject):
         # It doesn't take long for the callback to occur, so we should be able
         # to do a blocking wait here without anyone complaining.
         self._did_update_state_event.wait(1)
+        
+        if self.central_manager.state() == CBManagerStateUnsupported:
+            raise BleakError("BLE is unsupported")
+        
         if self.central_manager.state() != CBManagerStatePoweredOn:
             raise BleakError("Bluetooth device is turned off")
 


### PR DESCRIPTION
For some older devices the bluetooth stack does not support BLE.

The error message "Bluetooth device is turned off" can then be confusing, if on that device bluetooth is actually switched on (and working) but the actual problem is that BLE is not supported.
