### PR TITLE
Fix minor WinRT backend bugs

### DIFF
--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -99,7 +99,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         # 0x21 is service data with 128-bit UUID
         for section in event_args.advertisement.get_sections_by_type(0x21):
             data = bytearray(CryptographicBuffer.copy_to_byte_array(section.data))
-            service_data[str(UUID(bytes=data[15::-1]))] = data[16:]
+            service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
 
         # Use the BLEDevice to populate all the fields for the advertisement data to return
         advertisement_data = AdvertisementData(

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -172,7 +172,8 @@ class BleakScannerWinRT(BaseBleakScanner):
             # TODO: Handle AdvertisementFilter parameters
             self._advertisement_filter = kwargs["AdvertisementFilter"]
 
-    async def get_discovered_devices(self) -> List[BLEDevice]:
+    @property
+    def discovered_devices(self) -> List[BLEDevice]:
         found = []
         for event_args in list(self._devices.values()):
             new_device = self._parse_event_args(event_args)

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -135,7 +135,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         if self._signal_strength_filter is not None:
             self.watcher.signal_strength_filter = self._signal_strength_filter
         if self._advertisement_filter is not None:
-            self.watcher._advertisement_filter = self._advertisement_filter
+            self.watcher.advertisement_filter = self._advertisement_filter
 
         self.watcher.start()
 


### PR DESCRIPTION
This pull request addresses some minor issues I found while trying out the WinRT backend, as documented in #536. After some gentle ribbing from @dlech, I decided to roll these changes up into a pull request.

For me, these changes were sufficient to allow me to scan for a custom BLE device using the local name as a scan filter, connect to it, and interact with the characteristics.

I ended up making three changes:
1. Updating the WinRT backend to implement the `discovered_devices` property instead of the old `get_discovered_devices()` method.
2. Fixing an assertion in the UUID construction when the device has 128-bit service UUIDs.
3. Fixing a typo in the advertisement filter attribute of watcher objects

For reference, I was able to filter on the local name with a variant on the following code:
```python
from winrt.windows.devices.bluetooth.advertisement import BluetoothLEAdvertisementFilter, BluetoothLEAdvertisementBytePattern
from winrt.windows.security.cryptography import CryptographicBuffer

# Match on the complete local name field (0x09)
local_name = "mydevice"
adv_filter = BluetoothLEAdvertisementFilter()
local_name_bytes = CryptographicBuffer.create_from_byte_array(list(bytearray(local_name.encode("ascii"))))
name_byte_pattern = BluetoothLEAdvertisementBytePattern(0x09, 0, local_name_bytes)
adv_filter.byte_patterns.append(name_byte_pattern)

devices = await bleak.BleakScanner.discover(AdvertisementFilter=adv_filter)
```

If you'd prefer, I can squash these changes into a single commit.