### PR TITLE
Fixed write without response on BlueZ < 5.51.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Fixed
 * Minor fix for disconnection event handling in BlueZ backend. Fixes #491.
 * Corrections for the Philips Hue lamp example. Merged #505
 * Fixed BleakClientBlueZDBus.pair() method always returning True. Fixes #503.
+* Fixed write without response on BlueZ < 5.51.
 
 
 `0.11.0`_ (2021-03-17)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -821,7 +821,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 )
             )
             assert_reply(reply)
-            fd = reply.body[0]
+            fd = reply.unix_fds[0]
             try:
                 os.write(fd, data)
             finally:


### PR DESCRIPTION
This is a regression from when we switched to dbus-next. It doesn't return the fds as part of the body but rather in a separate attribute.

See
- https://github.com/hbldh/bleak/discussions/531
- https://github.com/hbldh/bleak/pull/525#issuecomment-839353355