### PR TITLE
Add hack for getting MTU on BlueZ backend.

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -81,6 +81,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # used to ensure device gets disconnected if event loop crashes
         self._disconnect_monitor_event: Optional[asyncio.Event] = None
 
+        # used to override mtu_size property
+        self._mtu_size: Optional[int] = None
+
         # get BlueZ version
         p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
         out, _ = p.communicate()
@@ -137,8 +140,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         # Create system bus
         self._bus = await MessageBus(
-            bus_type=BusType.SYSTEM,
-            negotiate_unix_fd=self._write_without_response_workaround_needed,
+            bus_type=BusType.SYSTEM, negotiate_unix_fd=True
         ).connect()
 
         try:
@@ -570,13 +572,59 @@ class BleakClientBlueZDBus(BaseBleakClient):
             False if self._bus is None else self._properties.get("Connected", False)
         )
 
+    async def _acquire_mtu(self) -> None:
+        """Acquires the MTU for this device by calling the "AcquireWrite" or
+        "AcquireNotify" method of the first characteristic that has such a method.
+
+        This method only needs to be called once, after connecting to the device
+        but before accessing the ``mtu_size`` property.
+
+        If a device uses encryption on characteristics, it will need to be bonded
+        first before calling this method.
+        """
+        # This will try to get the "best" characteristic for getting the MTU.
+        # We would rather not start notifications if we don't have to.
+        try:
+            method = "AcquireWrite"
+            char = next(
+                c
+                for c in self.services.characteristics.values()
+                if "write-without-response" in c.properties
+            )
+        except StopIteration:
+            method = "AcquireNotify"
+            char = next(
+                c
+                for c in self.services.characteristics.values()
+                if "notify" in c.properties
+            )
+
+        reply = await self._bus.call(
+            Message(
+                destination=defs.BLUEZ_SERVICE,
+                path=char.path,
+                interface=defs.GATT_CHARACTERISTIC_INTERFACE,
+                member=method,
+                signature="a{sv}",
+                body=[{}],
+            )
+        )
+        assert_reply(reply)
+
+        # we aren't actually using the write or notify, we just want the MTU
+        os.close(reply.unix_fds[0])
+        self._mtu_size = reply.body[1]
+
     @property
     def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
-        warnings.warn(
-            "MTU size not supported with BlueZ; this function returns the default value of 23. Note that the actual MTU size might be larger"
-        )
-        return 23
+        if self._mtu_size is None:
+            warnings.warn(
+                "Using default MTU value. Call _assign_mtu() or set _mtu_size first to avoid this warning."
+            )
+            return 23
+
+        return self._mtu_size
 
     # GATT services methods
 


### PR DESCRIPTION
BlueZ doesn't have a good way to get the negotiated MTU, but we can get it by abusing existing D-Bus methods.

Since the workaround is async and could cause unwanted side effects for some devices, it opt-in as seen in the example code.
