### PR TITLE
Add CI environment variable check to import.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Fixed
 * Corrections for the Philips Hue lamp example. Merged #505
 * Fixed BleakClientBlueZDBus.pair() method always returning True. Fixes #503.
 * Fixed write without response on BlueZ < 5.51.
+* Fixed failed import on CI server when BlueZ is not installed.
 
 
 `0.11.0`_ (2021-03-17)

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -17,6 +17,7 @@ from bleak.__version__ import __version__  # noqa
 from bleak.exc import BleakError
 
 _on_rtd = os.environ.get("READTHEDOCS") == "True"
+_on_ci = "CI" in os.environ
 
 _logger = logging.getLogger(__name__)
 _logger.addHandler(logging.NullHandler())
@@ -29,7 +30,7 @@ if bool(os.environ.get("BLEAK_LOGGING", False)):
     _logger.setLevel(logging.DEBUG)
 
 if platform.system() == "Linux":
-    if not _on_rtd:
+    if not _on_rtd and not _on_ci:
         # TODO: Check if BlueZ version 5.43 is sufficient.
         p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
         out, _ = p.communicate()


### PR DESCRIPTION
Importing `bleak` on CI will fail if `bluetoothctl` is not installed. This adds a check for the CI environment variable that is set by default in many CI environments (e.g. GitHub Actions, Travis CI, etc.). Since we aren't sure that the value will be the same on all CI platforms, we just check for the presence of the variable. The check extends the same workaround that is already in place for building on readthedocs.org.
