### PR TITLE
Fix propagation of CoreBluetooth errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Fixed
 * Fixed BleakClientBlueZDBus.pair() method always returning True. Fixes #503.
 * Fixed waiting for notification start/stop to complete in CoreBluetooth backend.
 * Fixed write without response on BlueZ < 5.51.
+* Fixed error propagation for CoreBluetooth events
 
 
 `0.11.0`_ (2021-03-17)


### PR DESCRIPTION
Errors from CBPeripeheralDelegate calls were being raised in the asyncio
event loop, but not in the correct task. In order to reach the user's
code, the error has to be passed through the event to the user call that
is awaiting the event.

Without these changes, e.g. ATT errors sent by the peripheral caused
error messages to be printed, but since the event that the user's call
was waiting on was never set, the user's code was blocked.

The implementation was adapted from https://github.com/hbldh/bleak/pull/209

I have not been able to test with anything older than macOS Big Sur (11.4).

flake8, tox and pytest report loads of unrelated errors, but I did not see any
new errors from these changes.

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.6+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
