### PR TITLE
Fixed deadlock in CoreBluetooth backend when device disconnects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ Fixed
 * Fixed write without response on BlueZ < 5.51.
 * Fixed error propagation for CoreBluetooth events
 * Fixed failed import on CI server when BlueZ is not installed.
+* Fixed deadlock in CoreBluetooth backend when device disconnects while
+  callbacks are pending. Fixes #535.
 
 
 `0.11.0`_ (2021-03-17)


### PR DESCRIPTION
This fixes #535. In the CoreBluetooth backend, when a device disconnects, none of the peripheral delegate callbacks will be called. So if any futures are pending, they will be waiting forever. This adds a disconnect hook that will raise an exception in all pending futures to avoid this deadlock.

