### PR TITLE
Fixed notification value should be bytearray on CoreBluetooth.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Fixed
 * Fixed write without response on BlueZ < 5.51.
 * Fixed error propagation for CoreBluetooth events
 * Fixed failed import on CI server when BlueZ is not installed.
+* Fixed notification ``value`` should be ``bytearray`` on CoreBluetooth. Fixes #560.
 
 
 `0.11.0`_ (2021-03-17)

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -298,7 +298,7 @@ class PeripheralDelegate(NSObject):
         self,
         peripheral: CBPeripheral,
         characteristic: CBCharacteristic,
-        value: bytes,
+        value: NSData,
         error: NSError,
     ):
         cUUID = characteristic.UUID().UUIDString()
@@ -307,7 +307,7 @@ class PeripheralDelegate(NSObject):
         if error is None:
             notify_callback = self._characteristic_notify_callbacks.get(c_handle)
             if notify_callback:
-                notify_callback(c_handle, value)
+                notify_callback(c_handle, bytearray(value))
 
         future = self._characteristic_read_futures.get(cUUID)
         if not future:


### PR DESCRIPTION
This fixes the `value` passed to the notification callback not being cast to `bytearray` like other backends.

Fixes #560