### PR TITLE
winrt: fix AttributeError in _stopped_handler()

### DIFF
--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -113,11 +113,13 @@ class BleakScannerWinRT(BaseBleakScanner):
         self._callback(device, advertisement_data)
 
     def _stopped_handler(self, sender, e):
-        logger.debug(
-            "{0} devices found. Watcher status: {1}.".format(
-                len(self._devices), self.watcher.status
+        # self.watcher can be None if we stopped the watcher in stop()
+        if self.watcher is not None:
+            logger.debug(
+                "{0} devices found. Watcher status: {1}.".format(
+                    len(self._devices), self.watcher.status
+                )
             )
-        )
 
     async def start(self):
         self.watcher = BluetoothLEAdvertisementWatcher()


### PR DESCRIPTION
Fixes #556 by first checking that `self.watcher is not None` before attempting to access the watcher status.

This edge case can come up if the watcher's stop event handler has a chance to fire when we manually stop the watcher as part of the scanner's `stop()` method.