### PR TITLE
Discovery filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Added
 * add mtu_size property for clients
 * WinRT backend added
 * Added ``BleakScanner.discovered_devices`` property.
+* Added ``BleakScanner.find_device_by_filter`` static method.
+* Added ``scanner_byname.py`` example.
+* Added optional command line argument to specify device to all applicable examples.
 
 Changed
 ~~~~~~~

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -62,7 +62,7 @@ AdvertisementDataCallback = Callable[
 ]
 
 AdvertisementDataFilter = Callable[
-    [BLEDevice, AdvertisementData],
+    [BLEDevice, Optional[AdvertisementData]],
     bool,
 ]
 
@@ -204,12 +204,12 @@ class BaseBleakScanner(abc.ABC):
 
     @classmethod
     async def find_device_by_filter(
-        cls, filterfunc, timeout: float = 10.0, **kwargs
+        cls, filterfunc: AdvertisementDataFilter, timeout: float = 10.0, **kwargs
     ) -> Optional[BLEDevice]:
         """A convenience method for obtaining a ``BLEDevice`` object specified by a filter function.
 
         Args:
-            filterfunc: A function that is called for every peripheral found. It should return True only for the wanted device.
+            filterfunc (AdvertisementDataFilter): A function that is called for every BLEDevice found. It should return True only for the wanted device.
             timeout (float): Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
 
         Keyword Args:

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -200,7 +200,9 @@ class BaseBleakScanner(abc.ABC):
 
         """
         device_identifier = device_identifier.lower()
-        return await cls.find_device_by_filter(lambda d, ad : d.address.lower() == device_identifier)
+        return await cls.find_device_by_filter(
+            lambda d, ad: d.address.lower() == device_identifier
+        )
 
     @classmethod
     async def find_device_by_filter(
@@ -232,8 +234,4 @@ class BaseBleakScanner(abc.ABC):
                 await asyncio.wait_for(stop_scanning_event.wait(), timeout=timeout)
             except asyncio.TimeoutError:
                 return None
-            return next(
-                d
-                for d in scanner.discovered_devices
-                if filterfunc(d, None)
-            )
+            return next(d for d in scanner.discovered_devices if filterfunc(d, None))

--- a/examples/async_callback_with_queue.py
+++ b/examples/async_callback_with_queue.py
@@ -29,6 +29,9 @@ ADDRESS = (
     else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
 )
 NOTIFICATION_UUID = f"0000{0xFFE1:x}-0000-1000-8000-00805f9b34fb"
+if len(sys.argv) == 3:
+    ADDRESS = sys.argv[1]
+    NOTIFICATION_UUID = sys.argv[2]
 
 
 async def run_ble_client(address: str, queue: asyncio.Queue):

--- a/examples/connect_by_bledevice.py
+++ b/examples/connect_by_bledevice.py
@@ -4,9 +4,19 @@ Connect by BLEDevice
 
 import asyncio
 import platform
+import sys
 
 from bleak import BleakClient, BleakScanner
 from bleak.exc import BleakError
+
+
+ADDRESS = (
+    "24:71:89:cc:09:05"
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
+)
+if len(sys.argv) == 2:
+    ADDRESS = sys.argv[1]
 
 
 async def print_services(ble_address: str):
@@ -20,10 +30,5 @@ async def print_services(ble_address: str):
             print(service)
 
 
-ble_address = (
-    "24:71:89:cc:09:05"
-    if platform.system() != "Darwin"
-    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
-)
 loop = asyncio.get_event_loop()
-loop.run_until_complete(print_services(ble_address))
+loop.run_until_complete(print_services(ADDRESS))

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -9,6 +9,7 @@ Updated on 2019-07-03 by hbldh <henrik.blidh@gmail.com>
 
 """
 
+import sys
 import logging
 import asyncio
 import platform
@@ -18,6 +19,14 @@ from bleak import _logger as logger
 
 
 CHARACTERISTIC_UUID = "f000aa65-0451-4000-b000-000000000000"  # <--- Change to the characteristic you want to enable notifications from.
+ADDRESS = (
+    "24:71:89:cc:09:05"  # <--- Change to your device's address here if you are using Windows or Linux
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"  # <--- Change to your device's address here if you are using macOS
+)
+if len(sys.argv) == 3:
+    ADDRESS = sys.argv[1]
+    CHARACTERISTIC_UUID = sys.argv[2]
 
 
 def notification_handler(sender, data):
@@ -48,11 +57,6 @@ if __name__ == "__main__":
     import os
 
     os.environ["PYTHONASYNCIODEBUG"] = str(1)
-    address = (
-        "24:71:89:cc:09:05"  # <--- Change to your device's address here if you are using Windows or Linux
-        if platform.system() != "Darwin"
-        else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"  # <--- Change to your device's address here if you are using macOS
-    )
     loop = asyncio.get_event_loop()
     # loop.set_debug(True)
-    loop.run_until_complete(run(address, True))
+    loop.run_until_complete(run(ADDRESS, True))

--- a/examples/get_services.py
+++ b/examples/get_services.py
@@ -8,10 +8,19 @@ Updated on 2019-03-25 by hbldh <henrik.blidh@nedomkull.com>
 
 """
 
+import sys
 import asyncio
 import platform
 
 from bleak import BleakClient
+
+ADDRESS = (
+    "24:71:89:cc:09:05"
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
+)
+if len(sys.argv) == 2:
+    ADDRESS = sys.argv[1]
 
 
 async def print_services(mac_addr: str):
@@ -22,10 +31,5 @@ async def print_services(mac_addr: str):
             print(service)
 
 
-mac_addr = (
-    "24:71:89:cc:09:05"
-    if platform.system() != "Darwin"
-    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
-)
 loop = asyncio.get_event_loop()
-loop.run_until_complete(print_services(mac_addr))
+loop.run_until_complete(print_services(ADDRESS))

--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -22,10 +22,15 @@ Created on 2020-01-13 by hbldh <henrik.blidh@nedomkull.com>
 
 """
 
+import sys
 import asyncio
 import logging
 
 from bleak import BleakClient
+
+ADDRESS = "EB:F0:49:21:95:4F"
+if len(sys.argv) == 2:
+    ADDRESS = sys.argv[1]
 
 
 LIGHT_CHARACTERISTIC = "932c32bd-0002-47a2-835a-a8d455b859dd"
@@ -106,7 +111,6 @@ async def run(address, debug=False):
 
 
 if __name__ == "__main__":
-    address = "EB:F0:49:21:95:4F"
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
-    loop.run_until_complete(run(address, True))
+    loop.run_until_complete(run(ADDRESS, True))

--- a/examples/scanner.py
+++ b/examples/scanner.py
@@ -10,6 +10,7 @@ Updated on 2020-08-12 by hbldh <henrik.blidh@nedomkull.com>
 
 import asyncio
 import platform
+import sys
 
 from bleak import BleakScanner
 
@@ -19,6 +20,8 @@ address = (
     if platform.system() != "Darwin"
     else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"  # <--- Change to your device's address here if you are using macOS
 )
+if len(sys.argv) == 2:
+    address = sys.argv[1]
 
 
 async def run():

--- a/examples/scanner_byname.py
+++ b/examples/scanner_byname.py
@@ -9,7 +9,6 @@ Updated on 2020-08-12 by hbldh <henrik.blidh@nedomkull.com>
 """
 
 import asyncio
-import platform
 import sys
 
 from bleak import BleakScanner

--- a/examples/scanner_byname.py
+++ b/examples/scanner_byname.py
@@ -16,13 +16,15 @@ from bleak import BleakScanner
 
 
 if len(sys.argv) != 2:
-    print(f'Usage: {sys.argv[0]} name')
+    print(f"Usage: {sys.argv[0]} name")
     sys.exit(1)
 wanted_name = sys.argv[1].lower()
 
 
 async def run():
-    device = await BleakScanner.find_device_by_filter(lambda d, ad : d.name and d.name.lower() == wanted_name)
+    device = await BleakScanner.find_device_by_filter(
+        lambda d, ad: d.name and d.name.lower() == wanted_name
+    )
     print(device)
 
 

--- a/examples/scanner_byname.py
+++ b/examples/scanner_byname.py
@@ -1,0 +1,30 @@
+"""
+Bleak Scanner
+-------------
+
+
+
+Updated on 2020-08-12 by hbldh <henrik.blidh@nedomkull.com>
+
+"""
+
+import asyncio
+import platform
+import sys
+
+from bleak import BleakScanner
+
+
+if len(sys.argv) != 2:
+    print(f'Usage: {sys.argv[0]} name')
+    sys.exit(1)
+wanted_name = sys.argv[1].lower()
+
+
+async def run():
+    device = await BleakScanner.find_device_by_filter(lambda d, ad : d.name and d.name.lower() == wanted_name)
+    print(device)
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run())

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -8,11 +8,21 @@ descriptors of a connected GATT server.
 Created on 2019-03-25 by hbldh <henrik.blidh@nedomkull.com>
 
 """
+
+import sys
 import platform
 import asyncio
 import logging
 
 from bleak import BleakClient
+
+ADDRESS = (
+    "24:71:89:cc:09:05"
+    if platform.system() != "Darwin"
+    else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
+)
+if len(sys.argv) == 2:
+    ADDRESS = sys.argv[1]
 
 
 async def run(address, debug=False):
@@ -59,11 +69,6 @@ async def run(address, debug=False):
 
 
 if __name__ == "__main__":
-    address = (
-        "24:71:89:cc:09:05"
-        if platform.system() != "Darwin"
-        else "B9EA5233-37EF-4DD6-87A8-2A875E821C46"
-    )
     loop = asyncio.get_event_loop()
     loop.set_debug(True)
-    loop.run_until_complete(run(address, True))
+    loop.run_until_complete(run(ADDRESS, True))


### PR DESCRIPTION
This change adds a new method `BleakScanner.find_device_by_filter(filterfunc)` that finds the first device that matches the filter function.

There's a new example `scanner_byname.py` that is similar to `scanner.py` but you specify the name of the BLE device you are looking for in stead of the address.

(I haven't merged the commits, in case you want to partially accept this).