### PR TITLE
CoreBluetooth scan start/stop improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ Changed
 * Improved type hints in CoreBluetooth backend.
 * Use delegate callbacks for get_rssi() on CoreBluetooth backend.
 * Use ``@objc.python_method`` where possible in ``PeripheralDelegate`` class.
+* Using ObjC key-value observer to wait for ``BleakScanner.start()`` and ``stop()``
+  in CoreBluetooth backend.
 
 Fixed
 ~~~~~
@@ -57,6 +59,8 @@ Fixed
   callbacks are pending. Fixes #535.
 * Fixed deadlock when using more than one service, characteristic or descriptor
   with the same UUID on CoreBluetooth backend.
+* Fixed exception raised when calling ``BleakScanner.stop()`` when already
+  stopped in CoreBluetooth backend.
 
 
 `0.11.0`_ (2021-03-17)

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -89,14 +89,11 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             self._callback(device, advertisement_data)
 
         self._manager.callbacks[id(self)] = callback
-        self._manager.start_scan({})
+        await self._manager.start_scan({})
 
     async def stop(self):
-        del self._manager.callbacks[id(self)]
-        try:
-            await self._manager.stop_scan()
-        except Exception as e:
-            logger.warning("stopScan method could not be called: {0}".format(e))
+        await self._manager.stop_scan()
+        self._manager.callbacks.pop(id(self), None)
 
     def set_scanning_filter(self, **kwargs):
         """Set scanning filter for the scanner.

--- a/typings/Foundation/__init__.pyi
+++ b/typings/Foundation/__init__.pyi
@@ -1,4 +1,4 @@
-from typing import Optional, Type, TypeVar
+from typing import NewType, Optional, Type, TypeVar
 
 TNSObject = TypeVar("TNSObject", bound=NSObject)
 
@@ -6,6 +6,16 @@ class NSObject:
     @classmethod
     def alloc(cls: Type[TNSObject]) -> TNSObject: ...
     def init(self: TNSObject) -> Optional[TNSObject]: ...
+    def addObserver_forKeyPath_options_context_(
+        self,
+        observer: NSObject,
+        keyPath: NSString,
+        options: NSKeyValueObservingOptions,
+        context: int,
+    ) -> None: ...
+    def removeObserver_forKeyPath_(
+        self, observer: NSObject, keyPath: NSString
+    ) -> None: ...
 
 class NSDictionary(NSObject): ...
 class NSUUID(NSObject): ...
@@ -15,3 +25,16 @@ class NSData(NSObject): ...
 class NSArray(NSObject): ...
 class NSNumber(NSValue): ...
 class NSValue(NSObject): ...
+
+NSKeyValueObservingOptions = NewType("NSKeyValueObservingOptions", int)
+NSKeyValueObservingOptionNew: NSKeyValueObservingOptions
+NSKeyValueObservingOptionOld: NSKeyValueObservingOptions
+NSKeyValueObservingOptionInitial: NSKeyValueObservingOptions
+NSKeyValueObservingOptionPrior: NSKeyValueObservingOptions
+
+NSKeyValueChangeKey = NewType("NSKeyValueChangeKey", NSString)
+NSKeyValueChangeIndexesKey: NSKeyValueChangeKey
+NSKeyValueChangeKindKey: NSKeyValueChangeKey
+NSKeyValueChangeNewKey: NSKeyValueChangeKey
+NSKeyValueChangeNotificationIsPriorKey: NSKeyValueChangeKey
+NSKeyValueChangeOldKey: NSKeyValueChangeKey

--- a/typings/objc/__init__.py
+++ b/typings/objc/__init__.py
@@ -1,7 +1,21 @@
-from typing import Type, TypeVar
+from typing import Optional, Type, TypeVar
+
+from Foundation import NSObject
 
 T = TypeVar("T")
 
 
 def super(cls: Type[T], self: T) -> T:
     ...
+
+
+def macos_available(major: int, minor: int, patch: int = 0) -> bool:
+    ...
+
+
+class WeakRef:
+    def __init__(self, object: NSObject) -> None:
+        ...
+
+    def __call__(self) -> Optional[NSObject]:
+        ...


### PR DESCRIPTION
This makes use of ObjC-style key-value observer to monitor the `isScanning` property on `CBCentralManager`. This allows us to avoid the polling wait.

Previously, the wait was only implemented when stopping scanning, so it is added to the start as well.

Also, the higher-level function is fixed to allow calling `stop()` multiple times without raising an error. This is needed since the
`stop()` method can be called by `__aexit__()` even if the scanner is already stopped.

