### PR TITLE
CoreBluetooth: fix unawaited future for write without response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,16 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
 
+`Unreleased`_
+-------------
+
+Fixed
+~~~~~
+
+* Fixed unawaited future when writing without response on CoreBluetooth backend.
+  Fixes #586.
+
+
 `0.12.0`_  (2021-06-19)
 -----------------------
 


### PR DESCRIPTION
In CoreBluetooth, there is no feedback for write without response, so we just have to send it and hope for the best. In this case we should not create a future since it gets registered with the event loop but it is never awaited.

Fixes #586
