### PR TITLE
Use timeout passed into find_device_by_address in BleakScanner implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed
 
 * Fixed unawaited future when writing without response on CoreBluetooth backend.
   Fixes #586.
+* Fixed unused timeout in the implementation of BleakScanner's ``find_device_by_address()`` function. 
 
 
 `0.12.0`_  (2021-06-19)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Added
 * Allow 16-bit UUID string arguments to ``get_service()`` and ``get_characteristic()``.
 * Added ``register_uuids()`` to augment the uuid-to-description mapping.
 
+Fixed
+~~~~~
+* Fixed unused timeout in the implementation of BleakScanner's ``find_device_by_address()`` function. 
+
 
 `0.12.1`_ (2021-07-07)
 ----------------------
@@ -28,7 +32,6 @@ Fixed
 
 * Fixed unawaited future when writing without response on CoreBluetooth backend.
   Fixes #586.
-* Fixed unused timeout in the implementation of BleakScanner's ``find_device_by_address()`` function. 
 
 
 `0.12.0`_  (2021-06-19)

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -201,7 +201,7 @@ class BaseBleakScanner(abc.ABC):
         """
         device_identifier = device_identifier.lower()
         return await cls.find_device_by_filter(
-            lambda d, ad: d.address.lower() == device_identifier
+            lambda d, ad: d.address.lower() == device_identifier, timeout=timeout
         )
 
     @classmethod


### PR DESCRIPTION
This PR just fixes a little bug where the timeout passed into `find_device_by_address()` method of `BleakScanner` wouldn't be passed into the `find_device_by_filter()` called later rendering the timeout parameter unused. 