### PR TITLE
BleakClient use adapter kwarg

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,3 +18,4 @@ Contributors
 * Chad Spensky <chad@allthenticate.net>
 * Bernie Conrad <bernie@allthenticate.net>
 * Jonathan Soto <jsotogaviard@alum.mit.edu>
+* Kyle J. Williams <kyle@kjwill.tech>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Added
 * Allow 16-bit UUID string arguments to ``get_service()`` and ``get_characteristic()``.
 * Added ``register_uuids()`` to augment the uuid-to-description mapping.
 
+Fixed
+~~~~~
+
+* Fixed BleakClient ignoring the `adapter` kwarg. Fixes #607.
+
 
 `0.12.1`_ (2021-07-07)
 ----------------------

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -203,7 +203,7 @@ class BaseBleakScanner(abc.ABC):
         return await cls.find_device_by_filter(
             lambda d, ad: d.address.lower() == device_identifier,
             timeout=timeout,
-            **kwargs
+            **kwargs,
         )
 
     @classmethod

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -201,7 +201,9 @@ class BaseBleakScanner(abc.ABC):
         """
         device_identifier = device_identifier.lower()
         return await cls.find_device_by_filter(
-            lambda d, ad: d.address.lower() == device_identifier
+            lambda d, ad: d.address.lower() == device_identifier,
+            timeout=timeout,
+            **kwargs
         )
 
     @classmethod


### PR DESCRIPTION
Fixed BleakClient ignoring the `adapter` kwarg. Fixes #607.