### PR TITLE
Use correct method when writing descriptor in WinRT backend.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 ~~~~~
 * Fixed unused timeout in the implementation of BleakScanner's ``find_device_by_address()`` function.
 * Fixed BleakClient ignoring the `adapter` kwarg. Fixes #607.
+* Fixed writing descriptors in WinRT backend. Fixes #615.
 
 
 `0.12.1`_ (2021-07-07)

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -683,7 +683,7 @@ class BleakClientWinRT(BaseBleakClient):
         if not descriptor:
             raise BleakError("Descriptor with handle {0} was not found!".format(handle))
 
-        write_result = await descriptor.obj.write_value_async(
+        write_result = await descriptor.obj.write_value_with_result_async(
             CryptographicBuffer.create_from_byte_array(list(data))
         )
 


### PR DESCRIPTION
We always use the "with result" variant of Windows API functions to get more information about failures. This was probably just overlooked when porting the Windows backend to WinRT.

Fixes #615.
