### PR TITLE
Caching BlueZ version. Fixes #602

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 ~~~~~
 * Allow 16-bit UUID string arguments to ``get_service()`` and ``get_characteristic()``.
 * Added ``register_uuids()`` to augment the uuid-to-description mapping.
+* Caching of BlueZ version in environment variables. Fixes #602.
 
 Fixed
 ~~~~~

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -44,6 +44,8 @@ if platform.system() == "Linux":
             raise BleakError(
                 "Bleak requires BlueZ >= 5.43. Found version {0} installed.".format(out)
             )
+        os.environ["BLEAK_BLUEZ_MAJOR_VERSION"] = major
+        os.environ["BLEAK_BLUEZ_MINOR_VERSION"] = minor
 
     from bleak.backends.bluezdbus.scanner import (
         BleakScannerBlueZDBus as BleakScanner,

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -85,10 +85,18 @@ class BleakClientBlueZDBus(BaseBleakClient):
         self._mtu_size: Optional[int] = None
 
         # get BlueZ version
-        p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
-        out, _ = p.communicate()
-        s = re.search(b"(\\d+).(\\d+)", out.strip(b"'"))
-        bluez_version = tuple(map(int, s.groups()))
+        if os.environ.get("BLEAK_BLUEZ_MAJOR_VERSION") and os.environ.get(
+            "BLEAK_BLUEZ_MINOR_VERSION"
+        ):
+            bluez_version = (
+                int(os.environ["BLEAK_BLUEZ_MAJOR_VERSION"]),
+                int(os.environ["BLEAK_BLUEZ_MINOR_VERSION"]),
+            )
+        else:
+            p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
+            out, _ = p.communicate()
+            s = re.search(b"(\\d+).(\\d+)", out.strip(b"'"))
+            bluez_version = tuple(map(int, s.groups()))
 
         # BlueZ version features
         self._can_write_without_response = (


### PR DESCRIPTION
This should suffice to solve #602.

Left the fallback. I think it could be removed, but it does not interfer a lot. 