### PR TITLE
winrt: improve error message when connecting fails

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 Changed
 ~~~~~~~
 * Changed from ``winrt`` dependency to ``bleak-winrt``.
+* Improved error when connecting to device fails in WinRT backend. Fixes #647.
 
 Removed
 ~~~~~~~

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -154,6 +154,12 @@ class BleakClientWinRT(BaseBleakClient):
             )
         self._requester = await BluetoothLEDevice.from_bluetooth_address_async(*args)
 
+        if self._requester is None:
+            # https://github.com/microsoft/Windows-universal-samples/issues/1089#issuecomment-487586755
+            raise BleakError(
+                f"Failed to connect to {self._device_info}. If the device requires pairing, then pair first. If the device uses a random address, it may have changed."
+            )
+
         # Called on disconnect event or on failure to connect.
         def handle_disconnect():
             if self._connection_status_changed_token:
@@ -502,7 +508,7 @@ class BleakClientWinRT(BaseBleakClient):
     async def read_gatt_char(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
-        **kwargs
+        **kwargs,
     ) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
@@ -717,7 +723,7 @@ class BleakClientWinRT(BaseBleakClient):
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
         callback: Callable[[int, bytearray], None],
-        **kwargs
+        **kwargs,
     ) -> None:
         """Activate notifications/indications on a characteristic.
 


### PR DESCRIPTION
`BluetoothLEDevice.FromBluetoothAddressAsync()` can return null, so we need to handle this case. The link in the comment provides some insight in to what might cause this failure.
