### PR TITLE
winrt: default to not use cache for services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 Changed
 ~~~~~~~
 * Changed from ``winrt`` dependency to ``bleak-winrt``.
+* Changed WinRT client to default to not use cache when enumerating services. Fixes #646.
 
 Removed
 ~~~~~~~

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -106,7 +106,7 @@ class BleakClientWinRT(BaseBleakClient):
         )
 
         self._connection_status_changed_token = None
-        self._use_cached = kwargs.get("use_cached", True)
+        self._use_cached = kwargs.get("use_cached", False)
 
     def __str__(self):
         return "BleakClientWinRT ({0})".format(self.address)


### PR DESCRIPTION
All other platforms already default to not use cache. Also, using cache is problematic for DIY devices that don't announce that services have changed.

Fixes #646.

