### PR TITLE
bluez: syncronize disconnect and cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Fixed
 * Fixed race on disconnect and cleanup of BlueZ matches when device disconnects early. Fixes #603.
 * Fixed memory leaks on Windows.
 * Fixed protocol error code descriptions on WinRT backend. Fixes #532.
+* Fixed race condition hitting assertation in BlueZ ``disconect()`` method. Fixes #641.
 
 
 `0.12.1`_ (2021-07-07)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -2,6 +2,7 @@
 """
 BLE Client for BlueZ on Linux
 """
+from asyncio.tasks import sleep
 import inspect
 import logging
 import asyncio
@@ -446,6 +447,13 @@ class BleakClientBlueZDBus(BaseBleakClient):
             asyncio.TimeoutError if the device was not disconnected within 10 seconds
         """
         logger.debug(f"Disconnecting ({self._device_path})")
+
+        # If cleanup is already scheduled or in progress from "Connect" D-Bus
+        # property change then we need to wait for it to finish to ensure a
+        # consistant state.
+        await asyncio.sleep(0)
+        async with self._cleanup_lock:
+            pass
 
         if self._bus is None:
             # No connection exists. Either one hasn't been created or


### PR DESCRIPTION
When the following sequence of events occurred, `assert self._bus is None`
would be hit.

- A "Connected": False property change signal is sent over D-Bus.
- Bleak handles the event and calls the `_cleanup_all()` method.
- The `_cleanup_all()` sends a D-Bus message to unsubscribe from signals and awaits it.
- While the previous method is still awaiting, the disconnect method is called.
- This method hits an assertion because the connected property is false   but there is still a D-Bus bus connection since `_cleanup_all()` is still using it.

This fixes the issue by ensuring that we are not in the middle of `_cleanup_all()`
before proceeding with the `disconnect()` method.

Fixes #641.
