### PR TITLE
bluez: syncronize disconnect and cleanup v2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Fixed
 * Fixed race on disconnect and cleanup of BlueZ matches when device disconnects early. Fixes #603.
 * Fixed memory leaks on Windows.
 * Fixed protocol error code descriptions on WinRT backend. Fixes #532.
+* Fixed race condition hitting assertation in BlueZ ``disconect()`` method. Fixes #641.
 
 
 `0.12.1`_ (2021-07-07)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -9,7 +9,7 @@ import os
 import re
 import subprocess
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 from uuid import UUID
 
 from dbus_next.aio import MessageBus
@@ -22,7 +22,7 @@ from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZ
 from bleak.backends.bluezdbus.descriptor import BleakGATTDescriptorBlueZDBus
 from bleak.backends.bluezdbus.scanner import BleakScannerBlueZDBus
 from bleak.backends.bluezdbus.service import BleakGATTServiceBlueZDBus
-from bleak.backends.bluezdbus.signals import MatchRules, add_match, remove_match
+from bleak.backends.bluezdbus.signals import MatchRules, add_match
 from bleak.backends.bluezdbus.utils import (
     assert_reply,
     extract_service_handle_from_path,
@@ -68,12 +68,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         # D-Bus message bus
         self._bus: Optional[MessageBus] = None
-        # match rules we are subscribed to that need to be removed on disconnect
-        self._rules: List[MatchRules] = []
         # D-Bus properties for the device
         self._properties: Dict[str, Any] = {}
-        # list of characteristic handles that have notifications enabled
-        self._subscriptions: List[int] = []
         # provides synchronization between get_services() and PropertiesChanged signal
         self._services_resolved_event: Optional[asyncio.Event] = None
         # indicates disconnect request in progress when not None
@@ -83,8 +79,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         # used to override mtu_size property
         self._mtu_size: Optional[int] = None
-        # setup a lock to handle concurrency
-        self._cleanup_lock = asyncio.Lock()
 
         # get BlueZ version
         p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
@@ -160,7 +154,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
             reply = await add_match(self._bus, rules)
             assert_reply(reply)
-            self._rules.append(rules)
 
             rules = MatchRules(
                 interface=defs.OBJECT_MANAGER_INTERFACE,
@@ -169,7 +162,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
             reply = await add_match(self._bus, rules)
             assert_reply(reply)
-            self._rules.append(rules)
 
             rules = MatchRules(
                 interface=defs.PROPERTIES_INTERFACE,
@@ -178,7 +170,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
             reply = await add_match(self._bus, rules)
             assert_reply(reply)
-            self._rules.append(rules)
 
             # Find the HCI device to use for scanning and get cached device properties
             reply = await self._bus.call(
@@ -371,39 +362,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
             except Exception:
                 pass
 
-    async def _remove_signal_handlers(self) -> None:
+    def _cleanup_all(self) -> None:
         """
-        Remove all pending notifications of the client. This method is used to
-        free the DBus matches that have been established.
+        Free all the allocated resource in DBus. Use this method to
+        eventually cleanup all otherwise leaked resources.
         """
-        logger.debug(f"_remove_signal_handlers({self._device_path})")
-
-        if self._bus is None:
-            logger.debug("no bus object")
-            return
-
-        self._bus.remove_message_handler(self._parse_msg)
-
-        for rule in self._rules:
-            try:
-                await remove_match(self._bus, rule)
-            except Exception as e:
-                logger.error(
-                    f"Failed to remove match {rule.member} ({self._device_path}): {e}"
-                )
-        self._rules = []
-
-        # There is no need to call stop_notify() here since the the device is
-        # already disconnected and we are about to close the D-Bus message bus
-        # which has the effect of clearing all notifications in BlueZ.
-        self._subscriptions = []
-
-    def _disconnect_message_bus(self) -> None:
-        """
-        Free the resources allocated for both the DBus bus.
-        Use this method upon final disconnection.
-        """
-        logger.debug(f"_disconnect_message_bus({self._device_path})")
+        logger.debug(f"_cleanup_all({self._device_path})")
 
         if not self._bus:
             logger.debug(f"already disconnected ({self._device_path})")
@@ -421,15 +385,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             # closed above. If not, calls made to it later could lead to
             # a stuck client.
             self._bus = None
-
-    async def _cleanup_all(self) -> None:
-        """
-        Free all the allocated resource in DBus. Use this method to
-        eventually cleanup all otherwise leaked resources.
-        """
-        async with self._cleanup_lock:
-            await self._remove_signal_handlers()
-            self._disconnect_message_bus()
 
             # Reset all stored services.
             self.services = BleakGATTServiceCollection()
@@ -977,7 +932,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
             )
 
         self._notification_callbacks[characteristic.path] = bleak_callback
-        self._subscriptions.append(characteristic.handle)
 
         reply = await self._bus.call(
             Message(
@@ -1022,10 +976,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
         assert_reply(reply)
 
         self._notification_callbacks.pop(characteristic.path, None)
-        try:
-            self._subscriptions.remove(characteristic.handle)
-        except ValueError:
-            pass
 
     # Internal Callbacks
 
@@ -1098,11 +1048,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
                         self._disconnect_monitor_event.set()
                         self._disconnect_monitor_event = None
 
-                    task = asyncio.ensure_future(self._cleanup_all())
+                    self._cleanup_all()
                     if self._disconnected_callback is not None:
-                        task.add_done_callback(
-                            lambda _: self._disconnected_callback(self)
-                        )
+                        self._disconnected_callback(self)
                     disconnecting_event = self._disconnecting_event
                     if disconnecting_event:
-                        task.add_done_callback(lambda _: disconnecting_event.set())
+                        disconnecting_event.set()


### PR DESCRIPTION
When the following sequence of events occured, `assert self._bus is None`
would be hit.

- A "Connected": False property change signal is sent over D-Bus.
- Bleak handles the event and calls the `_cleanup_all()` method.
- The `_cleanup_all()` sends a D-Bus message to unsubscribe from signals and awaits it.
- While the previous method is still awaiting, the disconnect method is called.
- This method hits an assertation because the connected property is false
  but there is still a D-Bus bus connection since `_cleanup_all()` is still using it.

This fixes the issue by making `_cleanup_all()` a syncronous method.
Since we are closing the bus connection, we should not need to remove
signal watchers first.

Fixes #641.
