### PR TITLE
BlueZ: add lazy-get/check version method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,7 @@ Fixed
 * Fixed protocol error code descriptions on WinRT backend. Fixes #532.
 * Fixed race condition hitting assertation in BlueZ ``disconect()`` method. Fixes #641.
 * Fixed enumerating services on a device with HID service on WinRT backend. Fixes #599.
-
+* Fixed subprocess running to check BlueZ version each time a client is created. Fixes #602.
 
 `0.12.1`_ (2021-07-07)
 ----------------------

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -5,15 +5,14 @@
 __author__ = """Henrik Blidh"""
 __email__ = "henrik.blidh@gmail.com"
 
-import re
 import os
 import sys
 import logging
 import platform
-import subprocess
 import asyncio
 
-from bleak.__version__ import __version__  # noqa
+from bleak.__version__ import __version__  # noqa: F401
+from bleak.backends.bluezdbus import check_bluez_version
 from bleak.exc import BleakError
 
 _on_rtd = os.environ.get("READTHEDOCS") == "True"
@@ -32,19 +31,8 @@ if bool(os.environ.get("BLEAK_LOGGING", False)):
 if _on_rtd:
     pass
 elif platform.system() == "Linux":
-    if not _on_ci:
-        # TODO: Check if BlueZ version 5.43 is sufficient.
-        p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
-        out, _ = p.communicate()
-        s = re.search(b"(\\d+).(\\d+)", out.strip(b"'"))
-        if not s:
-            raise BleakError("Could not determine BlueZ version: {0}".format(out))
-
-        major, minor = s.groups()
-        if not (int(major) == 5 and int(minor) >= 43):
-            raise BleakError(
-                "Bleak requires BlueZ >= 5.43. Found version {0} installed.".format(out)
-            )
+    if not _on_ci and not check_bluez_version(5, 43):
+        raise BleakError("Bleak requires BlueZ >= 5.43.")
 
     from bleak.backends.bluezdbus.scanner import (
         BleakScannerBlueZDBus as BleakScanner,

--- a/bleak/backends/bluezdbus/__init__.py
+++ b/bleak/backends/bluezdbus/__init__.py
@@ -1,0 +1,28 @@
+import re
+import subprocess
+
+from ...exc import BleakError
+
+
+def check_bluez_version(major: int, minor: int) -> bool:
+    """
+    Checks the BlueZ version.
+
+    Returns:
+        ``True`` if the BlueZ major version is equal to *major* and the minor
+        version is greater than or equal to *minor*, otherwise ``False``.
+    """
+    # lazy-get the version and store it so we only have to run subprocess once
+    if not hasattr(check_bluez_version, "version"):
+        p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
+        out, _ = p.communicate()
+        s = re.search(b"(\\d+).(\\d+)", out.strip(b"'"))
+
+        if not s:
+            raise BleakError(f"Could not determine BlueZ version: {out.decode()}")
+
+        setattr(check_bluez_version, "version", tuple(map(int, s.groups())))
+
+    bluez_major, bluez_minor = getattr(check_bluez_version, "version")
+
+    return bluez_major == major and bluez_minor >= minor


### PR DESCRIPTION
This adds a new method to the BlueZ bakckend for checking the BlueZ version. This lazy-gets the version from bluetoothctl so that the subprocess only runs once.

Fixes #602.
