### PR TITLE
change from get_event_loop() to get_running_loop()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Changed
 * Refactored GATT error handling in WinRT backend.
 * Changed Windows Bluetooth packet capture instructions. Fixes #653.
 * Replaced usage of deprecated ``@abc.abstractproperty``.
+* Use ``asyncio.get_running_loop()`` instead of ``asyncio.get_event_loop()``.
 
 Removed
 -------

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -58,7 +58,7 @@ class CentralManagerDelegate(NSObject):
         if self is None:
             return None
 
-        self.event_loop = asyncio.get_event_loop()
+        self.event_loop = asyncio.get_running_loop()
         self._connect_futures: Dict[NSUUID, asyncio.Future] = {}
 
         self.devices: Dict[str, BLEDeviceCoreBluetooth] = {}

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -46,7 +46,7 @@ class PeripheralDelegate(NSObject):
         self.peripheral = peripheral
         self.peripheral.setDelegate_(self)
 
-        self._event_loop = asyncio.get_event_loop()
+        self._event_loop = asyncio.get_running_loop()
         self._services_discovered_future = self._event_loop.create_future()
 
         self._service_characteristic_discovered_futures: Dict[int, asyncio.Future] = {}

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -220,7 +220,7 @@ class BleakClientWinRT(BaseBleakClient):
 
                 handle_disconnect()
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def _ConnectionStatusChanged_Handler(sender, args):
             logger.debug(
@@ -685,7 +685,7 @@ class BleakClientWinRT(BaseBleakClient):
                 "characteristic does not support notifications or indications"
             )
 
-        fcn = _notification_wrapper(bleak_callback, asyncio.get_event_loop())
+        fcn = _notification_wrapper(bleak_callback, asyncio.get_running_loop())
         event_handler_token = characteristic_obj.add_value_changed(fcn)
         self._notification_callbacks[characteristic.handle] = event_handler_token
         try:

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -124,7 +124,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.scanning_mode = self._scanning_mode
 
-        event_loop = asyncio.get_event_loop()
+        event_loop = asyncio.get_running_loop()
         self._stopped_event = asyncio.Event()
 
         self._received_token = self.watcher.add_received(

--- a/examples/uart_service.py
+++ b/examples/uart_service.py
@@ -54,7 +54,7 @@ async def uart_terminal():
 
         print("Connected, start typing and press ENTER...")
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         while True:
             # This waits until you type a line and press ENTER.


### PR DESCRIPTION
Since we have dropped support for Python 3.6, we can now use the preferred `asyncio.get_running_loop()` instead of `asyncio.get_event_loop()`.

