### PR TITLE
Remove hardcoded timeout values

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Contributors
 * Bernie Conrad <bernie@allthenticate.net>
 * Jonathan Soto <jsotogaviard@alum.mit.edu>
 * Kyle J. Williams <kyle@kjwill.tech>
+* Vyacheslav Linnik <vyacheslav.linnik@gmail.com>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Fixed
   of the same characteristic are used. Fixes #675.
 * Fixed reading a characteristic on CoreBluetooth backend also triggers notification
   callback.
+* Removed hardcoded timeout values in all backends.
 
 
 `0.13.0`_ (2021-10-20)

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -258,14 +258,18 @@ class BleakClientWinRT(BaseBleakClient):
 
         return True
 
-    async def disconnect(self) -> bool:
+    async def disconnect(self, **kwargs) -> bool:
         """Disconnect from the specified GATT server.
+
+        Keyword Args:
+            timeout (float): Defaults to 10.0.
 
         Returns:
             Boolean representing if device is disconnected.
 
         """
         logger.debug("Disconnecting from BLE device...")
+        timeout = kwargs.get("timeout", self._timeout)
         # Remove notifications.
         for handle, event_handler_token in list(self._notification_callbacks.items()):
             char = self.services.get_characteristic(handle)
@@ -289,7 +293,7 @@ class BleakClientWinRT(BaseBleakClient):
             self._disconnect_events.append(event)
             try:
                 self._requester.close()
-                await asyncio.wait_for(event.wait(), timeout=10)
+                await asyncio.wait_for(event.wait(), timeout=timeout)
             finally:
                 self._disconnect_events.remove(event)
 


### PR DESCRIPTION
This PR removes hardcoded timeout values in all backends in favor of default `BaseBleakClient._timeout` or kwargs `timeout=...` argument.

Otherwise it would be impossible to connect with slow devices even if timeout option is given:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.9/asyncio/locks.py", line 226, in wait
    await fut
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.9/asyncio/tasks.py", line 492, in wait_for
    fut.result()
asyncio.exceptions.CancelledError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/user/.../test.py", line 70, in <module>
    asyncio.run(main(address))
  File "/usr/lib64/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib64/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/user/.../test.py", line 30, in main
    await client.connect(timeout=60)
  File "/home/user/.../__pypackages__/3.9/lib/bleak/backends/bluezdbus/client.py", line 317, in connect
    await self.get_services()
  File "/home/user/.../__pypackages__/3.9/lib/bleak/backends/bluezdbus/client.py", line 592, in get_services
    await asyncio.wait_for(self._services_resolved_event.wait(), 5)
  File "/usr/lib64/python3.9/asyncio/tasks.py", line 494, in wait_for
    raise exceptions.TimeoutError() from exc
asyncio.exceptions.TimeoutError
```