### PR TITLE
corebluetooth: work around macOS 12 scanner bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Added
 -----
 
 * Added ``service_uuids`` kwarg to  ``BleakScanner``. This can be used to work
-  around issue of scanning not working on macOS 12. Issue #635.
+  around issue of scanning not working on macOS 12. Fixes #230. Works around #635.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Added
+-----
+
+* Added ``service_uuids`` kwarg to  ``BleakScanner``. This can be used to work
+  around issue of scanning not working on macOS 12. Issue #635.
+
 Changed
 -------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 
 * Changed WinRT backend to use GATT session status instead of actual device
   connection status.
+* Changed handling of scan response data on WinRT backend. Advertising data
+  and scan response data is now combined in callbacks like other platforms.
 
 Fixed
 -----

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -53,10 +53,18 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
     ``SetDiscoveryFilter`` method in the `BlueZ docs
     <https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt?h=5.48&id=0d1e3b9c5754022c779da129025d493a198d49cf>`_
 
-    Keyword Args:
-        adapter (str): Bluetooth adapter to use for discovery.
-        filters (dict): A dict of filters to be applied on discovery.
-
+    Args:
+        **detection_callback (callable or coroutine):
+            Optional function that will be called each time a device is
+            discovered or advertising data has changed.
+        **service_uuids (List[str]):
+            Optional list of service UUIDs to filter on. Only advertisements
+            containing this advertising data will be received. Specifying this
+            also enables scanning while the screen is off on Android.
+        **adapter (str):
+            Bluetooth adapter to use for discovery.
+        **filters (dict):
+            A dict of filters to be applied on discovery.
     """
 
     def __init__(self, **kwargs):
@@ -72,6 +80,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         # Discovery filters
         self._filters: Dict[str, Variant] = {}
+        if self._service_uuids:
+            self._filters["UUIDs"] = Variant("as", self._service_uuids)
         self.set_scanning_filter(**kwargs)
 
     async def start(self):

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -104,15 +104,17 @@ class CentralManagerDelegate(NSObject):
     # User defined functions
 
     @objc.python_method
-    async def start_scan(self, scan_options) -> None:
+    async def start_scan(self, service_uuids) -> None:
         # remove old
         self.devices = {}
-        service_uuids = None
-        if "service_uuids" in scan_options:
-            service_uuids_str = scan_options["service_uuids"]
-            service_uuids = NSArray.alloc().initWithArray_(
-                list(map(CBUUID.UUIDWithString_, service_uuids_str))
+
+        service_uuids = (
+            NSArray.alloc().initWithArray_(
+                list(map(CBUUID.UUIDWithString_, service_uuids))
             )
+            if service_uuids
+            else None
+        )
 
         self.central_manager.scanForPeripheralsWithServices_options_(
             service_uuids, None

--- a/bleak/backends/p4android/defs.py
+++ b/bleak/backends/p4android/defs.py
@@ -20,6 +20,7 @@ BluetoothGattCharacteristic = autoclass("android.bluetooth.BluetoothGattCharacte
 BluetoothGattDescriptor = autoclass("android.bluetooth.BluetoothGattDescriptor")
 BluetoothProfile = autoclass("android.bluetooth.BluetoothProfile")
 PythonActivity = autoclass("org.kivy.android.PythonActivity")
+ParcelUuid = autoclass("android.os.ParcelUuid")
 activity = cast("android.app.Activity", PythonActivity.mActivity)
 context = cast("android.content.Context", activity.getApplicationContext())
 

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -20,12 +20,20 @@ logger = logging.getLogger(__name__)
 
 
 class BleakScannerP4Android(BaseBleakScanner):
-
-    __scanner = None
-
     """
     The python-for-android Bleak BLE Scanner.
+
+    Args:
+        **detection_callback (callable or coroutine):
+            Optional function that will be called each time a device is
+            discovered or advertising data has changed.
+        **service_uuids (List[str]):
+            Optional list of service UUIDs to filter on. Only advertisements
+            containing this advertising data will be received. Specifying this
+            also enables scanning while the screen is off on Android.
     """
+
+    __scanner = None
 
     def __init__(self, **kwargs):
         super(BleakScannerP4Android, self).__init__(**kwargs)
@@ -85,7 +93,13 @@ class BleakScannerP4Android(BaseBleakScanner):
         BleakScannerP4Android.__scanner = self
 
         filters = cast("java.util.List", defs.List())
-        # filters could be built with defs.ScanFilterBuilder
+        if self._service_uuids:
+            for uuid in self._service_uuids:
+                filters.add(
+                    defs.ScanFilterBuilder()
+                    .setServiceUuid(defs.ParcelUuid.fromString(uuid))
+                    .build()
+                )
 
         scanfuture = self.__callback.perform_and_wait(
             dispatchApi=self.__javascanner.startScan,

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -23,11 +23,8 @@ class BleakScannerP4Android(BaseBleakScanner):
 
     __scanner = None
 
-    """The python-for-android Bleak BLE Scanner.
-
-    Keyword Args:
-        filters (dict): A dict of filters to be applied on discovery. [unimplemented]
-
+    """
+    The python-for-android Bleak BLE Scanner.
     """
 
     def __init__(self, **kwargs):
@@ -37,9 +34,6 @@ class BleakScannerP4Android(BaseBleakScanner):
         self.__adapter = None
         self.__javascanner = None
         self.__callback = None
-
-        # Discovery filters
-        self._filters = kwargs.get("filters", {})
 
     def __del__(self):
         self.__stop()
@@ -196,8 +190,10 @@ class BleakScannerP4Android(BaseBleakScanner):
     async def stop(self):
         self.__stop()
 
-    async def set_scanning_filter(self, **kwargs):
-        self._filters = kwargs.get("filters", {})
+    def set_scanning_filter(self, **kwargs):
+        # If we do end up implementing this, this should accept List<ScanFilter>
+        # and ScanSettings java objects to pass to startScan().
+        raise NotImplementedError("not implemented in Android backend")
 
     @property
     def discovered_devices(self) -> List[BLEDevice]:

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -68,12 +68,28 @@ AdvertisementDataFilter = Callable[
 
 
 class BaseBleakScanner(abc.ABC):
-    """Interface for Bleak Bluetooth LE Scanners"""
+    """
+    Interface for Bleak Bluetooth LE Scanners
+
+    Args:
+        **detection_callback (callable or coroutine):
+            Optional function that will be called each time a device is
+            discovered or advertising data has changed.
+        **service_uuids (List[str]):
+            Optional list of service UUIDs to filter on. Only advertisements
+            containing this advertising data will be received. Required on
+            macOS 12 and later.
+    """
 
     def __init__(self, *args, **kwargs):
         super(BaseBleakScanner, self).__init__()
         self._callback: Optional[AdvertisementDataCallback] = None
         self.register_detection_callback(kwargs.get("detection_callback"))
+        self._service_uuids: Optional[List[str]] = (
+            [u.lower() for u in kwargs["service_uuids"]]
+            if "service_uuids" in kwargs
+            else None
+        )
 
     async def __aenter__(self):
         await self.start()

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -125,7 +125,9 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Backend specific. WinRT objects.
         if isinstance(address_or_ble_device, BLEDevice):
-            self._device_info = address_or_ble_device.details.bluetooth_address
+            self._device_info = (
+                address_or_ble_device.address.details.adv.bluetooth_address
+            )
         else:
             self._device_info = None
         self._requester = None
@@ -166,7 +168,7 @@ class BleakClientWinRT(BaseBleakClient):
             )
 
             if device:
-                self._device_info = device.details.bluetooth_address
+                self._device_info = device.details.adv.bluetooth_address
             else:
                 raise BleakError(
                     "Device with address {0} was not found.".format(self.address)

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import pathlib
-from typing import List
+from typing import Dict, List, NamedTuple, Optional
 from uuid import UUID
 
 from bleak_winrt.windows.devices.bluetooth.advertisement import (
@@ -32,6 +32,24 @@ def _format_event_args(e):
         return e.bluetooth_address
 
 
+class _RawAdvData(NamedTuple):
+    """
+    Platform-specific advertisement data.
+
+    Windows does not combine advertising data with type SCAN_RSP with other
+    advertising data like other platforms, so se have to do it ourselves.
+    """
+
+    adv: BluetoothLEAdvertisementReceivedEventArgs
+    """
+    The advertisement data received from the BluetoothLEAdvertisementWatcher.Received event.
+    """
+    scan: Optional[BluetoothLEAdvertisementReceivedEventArgs]
+    """
+    The scan response for the same device as *adv*.
+    """
+
+
 class BleakScannerWinRT(BaseBleakScanner):
     """The native Windows Bleak BLE Scanner.
 
@@ -47,8 +65,7 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         self.watcher = None
         self._stopped_event = None
-        self._devices = {}
-        self._scan_responses = {}
+        self._discovered_devices: Dict[int, _RawAdvData] = {}
 
         if "scanning_mode" in kwargs and kwargs["scanning_mode"].lower() == "passive":
             self._scanning_mode = BluetoothLEScanningMode.PASSIVE
@@ -69,45 +86,54 @@ class BleakScannerWinRT(BaseBleakScanner):
         """Callback for AdvertisementWatcher.Received"""
         # TODO: Cannot check for if sender == self.watcher in winrt?
         logger.debug("Received {0}.".format(_format_event_args(event_args)))
+
+        # get the previous advertising data or start a new one
+        raw_data = self._discovered_devices.get(
+            event_args.bluetooth_address, _RawAdvData(event_args, None)
+        )
+
+        # update the advertsing data depending on the advertising data type
         if event_args.advertisement_type == BluetoothLEAdvertisementType.SCAN_RESPONSE:
-            if event_args.bluetooth_address not in self._scan_responses:
-                self._scan_responses[event_args.bluetooth_address] = event_args
+            raw_data = _RawAdvData(raw_data.adv, event_args)
         else:
-            if event_args.bluetooth_address not in self._devices:
-                self._devices[event_args.bluetooth_address] = event_args
+            raw_data = _RawAdvData(event_args, raw_data.scan)
+
+        self._discovered_devices[event_args.bluetooth_address] = raw_data
 
         if self._callback is None:
             return
 
         # Get a "BLEDevice" from parse_event args
-        device = self._parse_event_args(event_args)
+        device = self._parse_adv_data(raw_data)
+
+        service_data = {}
 
         # Decode service data
-        service_data = {}
-        # 0x16 is service data with 16-bit UUID
-        for section in event_args.advertisement.get_sections_by_type(0x16):
-            data = bytes(section.data)
-            service_data[
-                f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
-            ] = data[2:]
-        # 0x20 is service data with 32-bit UUID
-        for section in event_args.advertisement.get_sections_by_type(0x20):
-            data = bytes(section.data)
-            service_data[
-                f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
-            ] = data[4:]
-        # 0x21 is service data with 128-bit UUID
-        for section in event_args.advertisement.get_sections_by_type(0x21):
-            data = bytes(section.data)
-            service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
+        for args in filter(lambda d: d is not None, raw_data):
+            # 0x16 is service data with 16-bit UUID
+            for section in args.advertisement.get_sections_by_type(0x16):
+                data = bytes(section.data)
+                service_data[
+                    f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
+                ] = data[2:]
+            # 0x20 is service data with 32-bit UUID
+            for section in args.advertisement.get_sections_by_type(0x20):
+                data = bytes(section.data)
+                service_data[
+                    f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
+                ] = data[4:]
+            # 0x21 is service data with 128-bit UUID
+            for section in args.advertisement.get_sections_by_type(0x21):
+                data = bytes(section.data)
+                service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
 
         # Use the BLEDevice to populate all the fields for the advertisement data to return
         advertisement_data = AdvertisementData(
-            local_name=event_args.advertisement.local_name,
+            local_name=device.name,
             manufacturer_data=device.metadata["manufacturer_data"],
             service_data=service_data,
             service_uuids=device.metadata["uuids"],
-            platform_data=(sender, event_args),
+            platform_data=(sender, raw_data),
         )
 
         self._callback(device, advertisement_data)
@@ -115,12 +141,15 @@ class BleakScannerWinRT(BaseBleakScanner):
     def _stopped_handler(self, sender, e):
         logger.debug(
             "{0} devices found. Watcher status: {1}.".format(
-                len(self._devices), self.watcher.status
+                len(self._discovered_devices), self.watcher.status
             )
         )
         self._stopped_event.set()
 
     async def start(self):
+        # start with fresh list of discovered devices
+        self._discovered_devices.clear()
+
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.scanning_mode = self._scanning_mode
 
@@ -177,35 +206,27 @@ class BleakScannerWinRT(BaseBleakScanner):
 
     @property
     def discovered_devices(self) -> List[BLEDevice]:
-        found = []
-        for event_args in list(self._devices.values()):
-            new_device = self._parse_event_args(event_args)
-            if (
-                not new_device.name
-                and event_args.bluetooth_address in self._scan_responses
-            ):
-                new_device.name = self._scan_responses[
-                    event_args.bluetooth_address
-                ].advertisement.local_name
-            found.append(new_device)
-
-        return found
+        return [self._parse_adv_data(d) for d in self._discovered_devices.values()]
 
     @staticmethod
-    def _parse_event_args(event_args):
-        bdaddr = _format_bdaddr(event_args.bluetooth_address)
+    def _parse_adv_data(raw_data: _RawAdvData) -> BLEDevice:
+        """
+        Combines advertising data from regular advertisement data and scan response.
+        """
+        bdaddr = _format_bdaddr(raw_data.adv.bluetooth_address)
         uuids = []
-        try:
-            for u in event_args.advertisement.service_uuids:
-                uuids.append(str(u))
-        except NotImplementedError as e:
-            # Cannot get service uuids for this device...
-            pass
         data = {}
-        for m in event_args.advertisement.manufacturer_data:
-            data[m.company_id] = bytes(m.data)
-        local_name = event_args.advertisement.local_name
-        rssi = event_args.raw_signal_strength_in_d_bm
+        local_name = None
+
+        for args in filter(lambda d: d is not None, raw_data):
+            for u in args.advertisement.service_uuids:
+                uuids.append(str(u))
+            for m in args.advertisement.manufacturer_data:
+                data[m.company_id] = bytes(m.data)
+            if args.advertisement.local_name is not None:
+                local_name = args.advertisement.local_name
+            rssi = args.raw_signal_strength_in_d_bm
+
         return BLEDevice(
-            bdaddr, local_name, event_args, rssi, uuids=uuids, manufacturer_data=data
+            bdaddr, local_name, raw_data, rssi, uuids=uuids, manufacturer_data=data
         )

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -106,6 +106,20 @@ class BleakScannerWinRT(BaseBleakScanner):
         # Get a "BLEDevice" from parse_event args
         device = self._parse_adv_data(raw_data)
 
+        # On Windows, we have to fake service UUID filtering. If we were to pass
+        # a BluetoothLEAdvertisementFilter to the BluetoothLEAdvertisementWatcher
+        # with the service UUIDs appropriately set, we would no longer receive
+        # scan response data (which commonly contains the local device name).
+        # So we have to do it like this instead.
+
+        if self._service_uuids:
+            for uuid in device.metadata["uuids"]:
+                if uuid in self._service_uuids:
+                    break
+            else:
+                # if there were no matching service uuids, the don't call the callback
+                return
+
         service_data = {}
 
         # Decode service data

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -9,20 +9,22 @@ Updated on 2020-10-11 by bernstern <bernie@allthenticate.net>
 """
 
 import asyncio
+import logging
+import sys
+
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-import logging
 
-logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
-    print(device.address, "RSSI:", device.rssi, advertisement_data)
+    logger.info(f"{device.address} RSSI: {device.rssi}, {advertisement_data}")
 
 
-async def main():
-    scanner = BleakScanner()
+async def main(service_uuids):
+    scanner = BleakScanner(service_uuids=service_uuids)
     scanner.register_detection_callback(simple_callback)
 
     while True:
@@ -32,4 +34,9 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
+    service_uuids = sys.argv[1:]
+    asyncio.run(main(service_uuids))


### PR DESCRIPTION
macOS has a bug (feature?) where advertising data is no longer received unless one or more service UUIDs are given in `scanForPeripheralsWithServices:options:`.

This implements a new kwarg on `BleakScanner` to allow users to provide such a list of UUIDs. This commit only implements it in the CoreBluetooth backend with other backends to follow.

If macOS 12 is detected and this kwarg is not given, an error will be logged explaining how to fix the problem.

Fixes #635.
