### PR TITLE
corebluetooth: fix crash on disconnect

### DIFF
--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -72,8 +72,14 @@ class PeripheralDelegate(NSObject):
 
         These can be used to handle any pending futures when a peripheral is disconnected.
         """
+        services_discovered_future = (
+            (self._services_discovered_future,)
+            if hasattr(self, "_services_discovered_future")
+            else ()
+        )
+
         return itertools.chain(
-            (self._services_discovered_future,),
+            services_discovered_future,
             self._service_characteristic_discovered_futures.values(),
             self._characteristic_descriptor_discover_futures.values(),
             self._characteristic_read_futures.values(),


### PR DESCRIPTION
Fixes the following exception:

    Traceback (most recent call last):
    File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/asyncio/events.py", line 80, in _run
        self._context.run(self._callback, *self._args)
    File "/Users/david/work/bleak/bleak/backends/corebluetooth/CentralManagerDelegate.py", line 358, in did_disconnect_peripheral
        callback()
    File "/Users/david/work/bleak/bleak/backends/corebluetooth/client.py", line 105, in disconnect_callback
        for future in self._delegate.futures():
    File "/Users/david/work/bleak/bleak/backends/corebluetooth/PeripheralDelegate.py", line 77, in futures
        if self._services_discovered_future
    AttributeError: 'PeripheralDelegate' object has no attribute '_services_discovered_future'

Problem was introduced by commit ad59f6e8e35cbab8276d654faafa7856c1fd8b9b.

