### PR TITLE
Use predefined service uuids

### DIFF
--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -15,6 +15,7 @@ import sys
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+from bleak.uuids import uuid16_dict, uuid128_dict
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,16 @@ def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
 
 
 async def main(service_uuids):
+    if len(service_uuids) > 0 and service_uuids[0] == "all":
+        # in Macos Monterey the service_uuids need to be specified.
+        # Instead of discovering valid uuids with a different tool
+        # you can add `all` as argument and it will add all defined
+        # uuid's from bleak/uuids as a starting point.
+        logger.info("Adding all known service uuids")
+        service_uuids.pop(0)
+        for item in uuid16_dict:
+            service_uuids.append("{0:04x}".format(item))
+        service_uuids.extend(uuid128_dict.keys())
     scanner = BleakScanner(service_uuids=service_uuids)
     scanner.register_detection_callback(simple_callback)
 


### PR DESCRIPTION
On macos the service_uuids need to be filled. Main issue for
beginners is to retrieve some valid uuids. Instead of using an
external tool like nRF we could use predefined ones in bleak/uuids.

Implementation works with 128bit and 16bit UUIDs.

Related-to #635

Signed-off-by: Marc Koderer <marc@koderer.com>
