### PR TITLE
requirements: bump bleak-winrt to v1.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
   connection status.
 * Changed handling of scan response data on WinRT backend. Advertising data
   and scan response data is now combined in callbacks like other platforms.
+* Updated ``bleak-winrt`` dependency to v1.1.0. Fixes #698.
 
 Fixed
 -----

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ dbus-next = {version = ">=0.2.2", sys_platform = "== 'linux'"}
 pyobjc-core = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-CoreBluetooth = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-libdispatch = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
-bleak-winrt = {version = ">=1.0.1", sys_platform = "== 'win32'"}
+bleak-winrt = {version = ">=1.1.0", sys_platform = "== 'win32'"}
 
 [dev-packages]
 pytest = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dbus-next>=0.2.2; sys_platform=="linux"
 pyobjc-core>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-CoreBluetooth>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-libdispatch>=7.0.1;sys_platform == 'darwin'
-bleak-winrt>=1.0.1; sys_platform == 'win32'
+bleak-winrt>=1.1.0; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIRED = [
     'pyobjc-framework-CoreBluetooth;platform_system=="Darwin"',
     'pyobjc-framework-libdispatch;platform_system=="Darwin"',
     # Windows reqs
-    'bleak-winrt>=1.0.1;platform_system=="Windows"',
+    'bleak-winrt>=1.1.0;platform_system=="Windows"',
 ]
 
 TEST_REQUIRED = ["pytest", "pytest-cov"]


### PR DESCRIPTION
This removes the explicit apartment initialization that breaks apps that have already initialized a single threaded apartment.

Fixes: https://github.com/hbldh/bleak/issues/698
