### PR TITLE
drop pytest-runner

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,6 @@ pyyaml = "*"
 wheel = "*"
 watchdog = "*"
 coverage = "*"
-pytest-runner = "*"
 black = "*"
 
 [pipenv]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,4 @@ Sphinx>=1.7.7
 sphinx-rtd-theme>=1.0.0
 PyYAML>=3.13
 pytest>=3.9.2
-pytest-runner>=4.2
 pytest-cov>=2.5.1

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ REQUIRED = [
     'bleak-winrt>=1.0.1;platform_system=="Windows"',
 ]
 
-TEST_REQUIRED = ["pytest", "pytest-cov"]
-
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = "\n" + f.read()
@@ -87,7 +85,6 @@ setup(
     entry_points={"console_scripts": ["bleak-lescan=bleak:cli"]},
     install_requires=REQUIRED,
     test_suite="tests",
-    tests_require=TEST_REQUIRED,
     include_package_data=True,
     license="MIT",
     project_urls={


### PR DESCRIPTION
Apparently there are some security concerns about pytest-runner. We weren't using it anyway, so we can remove it.
