### PR TITLE
Release/0.14.0

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -36,27 +36,3 @@ jobs:
                     path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
                 # Use always() to always run this step to publish test results when there are test failures
                 if: ${{ always() }}
-    build_android:
-        name: "Build Android"
-        runs-on: ubuntu-20.04
-        steps:
-            -   uses: actions/checkout@v2
-            -   name: Upgrade pip. setuptools and wheel
-                run: python -m pip install --upgrade pip setuptools wheel
-            -   name: Install dependencies
-                run: pip install buildozer cython
-            -   name: Cache buildozer files
-                uses: actions/cache@v2
-                id: buildozer-cache
-                with:
-                    path: |
-                        ~/.buildozer
-                        examples/kivy/.buildozer
-                    key: build-cache-buildozer
-            -   name: Clean bleak recipe for cache
-                if: steps.buildozer-cache.outputs.cache-hit == 'true'
-                working-directory: examples/kivy
-                run: buildozer android p4a -- clean-recipe-build --local-recipes $(pwd)/../../bleak/backends/p4android/recipes bleak
-            -   name: Build Kivy example
-                working-directory: examples/kivy
-                run: buildozer android debug

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -1,0 +1,29 @@
+name: Build and Test
+
+on: workflow_dispatch
+
+jobs:
+    build_android:
+        name: "Build Android"
+        runs-on: ubuntu-20.04
+        steps:
+            -   uses: actions/checkout@v2
+            -   name: Upgrade pip. setuptools and wheel
+                run: python -m pip install --upgrade pip setuptools wheel
+            -   name: Install dependencies
+                run: pip install buildozer cython
+            -   name: Cache buildozer files
+                uses: actions/cache@v2
+                id: buildozer-cache
+                with:
+                    path: |
+                        ~/.buildozer
+                        examples/kivy/.buildozer
+                    key: build-cache-buildozer
+            -   name: Clean bleak recipe for cache
+                if: steps.buildozer-cache.outputs.cache-hit == 'true'
+                working-directory: examples/kivy
+                run: buildozer android p4a -- clean-recipe-build --local-recipes $(pwd)/../../bleak/backends/p4android/recipes bleak
+            -   name: Build Kivy example
+                working-directory: examples/kivy
+                run: buildozer android debug

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,7 +5,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
   deploy:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 
 * Added ``service_uuids`` kwarg to  ``BleakScanner``. This can be used to work
   around issue of scanning not working on macOS 12. Fixes #230. Works around #635.
+* Added UUIDs for LEGO Powered Up Smart Hubs.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,8 +10,15 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+
+* Changed WinRT backend to use GATT session status instead of actual device
+  connection status.
+
 Fixed
 -----
+
 * Fixed ``InvalidStateError`` in CoreBluetooth backend when read and notification
   of the same characteristic are used. Fixes #675.
 * Fixed reading a characteristic on CoreBluetooth backend also triggers notification

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-`Unreleased`_
-=============
+`0.14.0`_ (2022-01-10)
+======================
 
 Added
 -----
@@ -33,7 +33,7 @@ Fixed
   of the same characteristic are used. Fixes #675.
 * Fixed reading a characteristic on CoreBluetooth backend also triggers notification
   callback.
-* Fixed in Linux, scanner callback not setting metadata parameters   
+* Fixed in Linux, scanner callback not setting metadata parameters. Merged #715.
 
 
 `0.13.0`_ (2021-10-20)
@@ -623,7 +623,8 @@ Fixed
 * Bleak created.
 
 
-.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.13.0...develop
+.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.14.0...develop
+.. _0.14.0: https://github.com/hbldh/bleak/compare/v0.13.0...v0.14.0
 .. _0.13.0: https://github.com/hbldh/bleak/compare/v0.12.1...v0.13.0
 .. _0.12.1: https://github.com/hbldh/bleak/compare/v0.12.0...v0.12.1
 .. _0.12.0: https://github.com/hbldh/bleak/compare/v0.11.0...v0.12.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
   connection status.
 * Changed handling of scan response data on WinRT backend. Advertising data
   and scan response data is now combined in callbacks like other platforms.
+* Updated ``bleak-winrt`` dependency to v1.1.0. Fixes #698.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,19 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Added
+-----
+
+* Added ``service_uuids`` kwarg to  ``BleakScanner``. This can be used to work
+  around issue of scanning not working on macOS 12. Fixes #230. Works around #635.
+
 Changed
 -------
 
 * Changed WinRT backend to use GATT session status instead of actual device
   connection status.
+* Changed handling of scan response data on WinRT backend. Advertising data
+  and scan response data is now combined in callbacks like other platforms.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,13 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Fixed ``InvalidStateError`` in CoreBluetooth backend when read and notification
+  of the same characteristic are used. Fixes #675.
+* Fixed reading a characteristic on CoreBluetooth backend also triggers notification
+  callback.
+
 
 `0.13.0`_ (2021-10-20)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
   of the same characteristic are used. Fixes #675.
 * Fixed reading a characteristic on CoreBluetooth backend also triggers notification
   callback.
+* Fixed in Linux, scanner callback not setting metadata parameters   
 
 
 `0.13.0`_ (2021-10-20)

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,6 @@ pyyaml = "*"
 wheel = "*"
 watchdog = "*"
 coverage = "*"
-pytest-runner = "*"
 black = "*"
 
 [pipenv]

--- a/Pipfile
+++ b/Pipfile
@@ -24,3 +24,7 @@ wheel = "*"
 watchdog = "*"
 coverage = "*"
 pytest-runner = "*"
+black = "*"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ dbus-next = {version = ">=0.2.2", sys_platform = "== 'linux'"}
 pyobjc-core = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-CoreBluetooth = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-libdispatch = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
-bleak-winrt = {version = ">=1.0.1", sys_platform = "== 'win32'"}
+bleak-winrt = {version = ">=1.1.0", sys_platform = "== 'win32'"}
 
 [dev-packages]
 pytest = "*"

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.13.0"
+__version__ = "0.14.0a1"

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.14.0a1"
+__version__ = "0.14.0"

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -53,10 +53,18 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
     ``SetDiscoveryFilter`` method in the `BlueZ docs
     <https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt?h=5.48&id=0d1e3b9c5754022c779da129025d493a198d49cf>`_
 
-    Keyword Args:
-        adapter (str): Bluetooth adapter to use for discovery.
-        filters (dict): A dict of filters to be applied on discovery.
-
+    Args:
+        **detection_callback (callable or coroutine):
+            Optional function that will be called each time a device is
+            discovered or advertising data has changed.
+        **service_uuids (List[str]):
+            Optional list of service UUIDs to filter on. Only advertisements
+            containing this advertising data will be received. Specifying this
+            also enables scanning while the screen is off on Android.
+        **adapter (str):
+            Bluetooth adapter to use for discovery.
+        **filters (dict):
+            A dict of filters to be applied on discovery.
     """
 
     def __init__(self, **kwargs):
@@ -72,6 +80,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         # Discovery filters
         self._filters: Dict[str, Variant] = {}
+        if self._service_uuids:
+            self._filters["UUIDs"] = Variant("as", self._service_uuids)
         self.set_scanning_filter(**kwargs)
 
     async def start(self):

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -281,6 +281,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             props["Alias"],
             {"path": path, "props": props},
             props.get("RSSI", 0),
+            uuids=_service_uuids,
+            manufacturer_data=_manufacturer_data,
         )
 
         self._callback(device, advertisement_data)

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -104,15 +104,17 @@ class CentralManagerDelegate(NSObject):
     # User defined functions
 
     @objc.python_method
-    async def start_scan(self, scan_options) -> None:
+    async def start_scan(self, service_uuids) -> None:
         # remove old
         self.devices = {}
-        service_uuids = None
-        if "service_uuids" in scan_options:
-            service_uuids_str = scan_options["service_uuids"]
-            service_uuids = NSArray.alloc().initWithArray_(
-                list(map(CBUUID.UUIDWithString_, service_uuids_str))
+
+        service_uuids = (
+            NSArray.alloc().initWithArray_(
+                list(map(CBUUID.UUIDWithString_, service_uuids))
             )
+            if service_uuids
+            else None
+        )
 
         self.central_manager.scanForPeripheralsWithServices_options_(
             service_uuids, None

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -152,25 +152,38 @@ class CentralManagerDelegate(NSObject):
         try:
             self._disconnect_callbacks[peripheral.identifier()] = disconnect_callback
             future = self.event_loop.create_future()
+
             self._connect_futures[peripheral.identifier()] = future
-            self.central_manager.connectPeripheral_options_(peripheral, None)
-            await asyncio.wait_for(future, timeout=timeout)
+            try:
+                self.central_manager.connectPeripheral_options_(peripheral, None)
+                await asyncio.wait_for(future, timeout=timeout)
+            finally:
+                del self._connect_futures[peripheral.identifier()]
+
         except asyncio.TimeoutError:
             logger.debug(f"Connection timed out after {timeout} seconds.")
             del self._disconnect_callbacks[peripheral.identifier()]
             future = self.event_loop.create_future()
+
             self._disconnect_futures[peripheral.identifier()] = future
-            self.central_manager.cancelPeripheralConnection_(peripheral)
-            await future
+            try:
+                self.central_manager.cancelPeripheralConnection_(peripheral)
+                await future
+            finally:
+                del self._disconnect_futures[peripheral.identifier()]
+
             raise
 
     @objc.python_method
     async def disconnect(self, peripheral: CBPeripheral) -> None:
         future = self.event_loop.create_future()
+
         self._disconnect_futures[peripheral.identifier()] = future
-        self.central_manager.cancelPeripheralConnection_(peripheral)
-        await future
-        del self._disconnect_callbacks[peripheral.identifier()]
+        try:
+            self.central_manager.cancelPeripheralConnection_(peripheral)
+            await future
+        finally:
+            del self._disconnect_callbacks[peripheral.identifier()]
 
     @objc.python_method
     def _changed_is_scanning(self, is_scanning: bool) -> None:
@@ -280,7 +293,7 @@ class CentralManagerDelegate(NSObject):
     def did_connect_peripheral(
         self, central: CBCentralManager, peripheral: CBPeripheral
     ) -> None:
-        future = self._connect_futures.pop(peripheral.identifier(), None)
+        future = self._connect_futures.get(peripheral.identifier(), None)
         if future is not None:
             future.set_result(True)
 
@@ -301,7 +314,7 @@ class CentralManagerDelegate(NSObject):
         peripheral: CBPeripheral,
         error: Optional[NSError],
     ) -> None:
-        future = self._connect_futures.pop(peripheral.identifier(), None)
+        future = self._connect_futures.get(peripheral.identifier(), None)
         if future is not None:
             if error is not None:
                 future.set_exception(BleakError(f"failed to connect: {error}"))
@@ -331,7 +344,7 @@ class CentralManagerDelegate(NSObject):
     ) -> None:
         logger.debug("Peripheral Device disconnected!")
 
-        future = self._disconnect_futures.pop(peripheral.identifier(), None)
+        future = self._disconnect_futures.get(peripheral.identifier(), None)
         if future is not None:
             if error is not None:
                 future.set_exception(BleakError(f"disconnect failed: {error}"))

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -87,29 +87,39 @@ class PeripheralDelegate(NSObject):
     @objc.python_method
     async def discover_services(self) -> NSArray:
         future = self._event_loop.create_future()
-        self._services_discovered_future = future
-        self.peripheral.discoverServices_(None)
-        await future
 
-        return self.peripheral.services()
+        self._services_discovered_future = future
+        try:
+            self.peripheral.discoverServices_(None)
+            return await future
+        finally:
+            del self._services_discovered_future
 
     @objc.python_method
     async def discover_characteristics(self, service: CBService) -> NSArray:
         future = self._event_loop.create_future()
-        self._service_characteristic_discovered_futures[service.startHandle()] = future
-        self.peripheral.discoverCharacteristics_forService_(None, service)
-        await future
 
-        return service.characteristics()
+        self._service_characteristic_discovered_futures[service.startHandle()] = future
+        try:
+            self.peripheral.discoverCharacteristics_forService_(None, service)
+            return await future
+        finally:
+            del self._service_characteristic_discovered_futures[service.startHandle()]
 
     @objc.python_method
     async def discover_descriptors(self, characteristic: CBCharacteristic) -> NSArray:
         future = self._event_loop.create_future()
+
         self._characteristic_descriptor_discover_futures[
             characteristic.handle()
         ] = future
-        self.peripheral.discoverDescriptorsForCharacteristic_(characteristic)
-        await future
+        try:
+            self.peripheral.discoverDescriptorsForCharacteristic_(characteristic)
+            await future
+        finally:
+            del self._characteristic_descriptor_discover_futures[
+                characteristic.handle()
+            ]
 
         return characteristic.descriptors()
 
@@ -121,13 +131,13 @@ class PeripheralDelegate(NSObject):
             return characteristic.value()
 
         future = self._event_loop.create_future()
+
         self._characteristic_read_futures[characteristic.handle()] = future
-        self.peripheral.readValueForCharacteristic_(characteristic)
-        await asyncio.wait_for(future, timeout=5)
-        if characteristic.value():
-            return characteristic.value()
-        else:
-            return b""
+        try:
+            self.peripheral.readValueForCharacteristic_(characteristic)
+            return await asyncio.wait_for(future, timeout=5)
+        finally:
+            del self._characteristic_read_futures[characteristic.handle()]
 
     @objc.python_method
     async def read_descriptor(
@@ -137,11 +147,13 @@ class PeripheralDelegate(NSObject):
             return descriptor.value()
 
         future = self._event_loop.create_future()
-        self._descriptor_read_futures[descriptor.handle()] = future
-        self.peripheral.readValueForDescriptor_(descriptor)
-        await future
 
-        return descriptor.value()
+        self._descriptor_read_futures[descriptor.handle()] = future
+        try:
+            self.peripheral.readValueForDescriptor_(descriptor)
+            return await future
+        finally:
+            del self._descriptor_read_futures[descriptor.handle()]
 
     @objc.python_method
     async def write_characteristic(
@@ -149,35 +161,40 @@ class PeripheralDelegate(NSObject):
         characteristic: CBCharacteristic,
         value: NSData,
         response: CBCharacteristicWriteType,
-    ) -> bool:
+    ) -> None:
         # in CoreBluetooth there is no indication of success or failure of
         # CBCharacteristicWriteWithoutResponse
         if response == CBCharacteristicWriteWithResponse:
             future = self._event_loop.create_future()
+
             self._characteristic_write_futures[characteristic.handle()] = future
-
-        self.peripheral.writeValue_forCharacteristic_type_(
-            value, characteristic, response
-        )
-
-        if response == CBCharacteristicWriteWithResponse:
-            await future
-
-        return True
+            try:
+                self.peripheral.writeValue_forCharacteristic_type_(
+                    value, characteristic, response
+                )
+                await future
+            finally:
+                del self._characteristic_write_futures[characteristic.handle()]
+        else:
+            self.peripheral.writeValue_forCharacteristic_type_(
+                value, characteristic, response
+            )
 
     @objc.python_method
-    async def write_descriptor(self, descriptor: CBDescriptor, value: NSData) -> bool:
+    async def write_descriptor(self, descriptor: CBDescriptor, value: NSData) -> None:
         future = self._event_loop.create_future()
-        self._descriptor_write_futures[descriptor.handle()] = future
-        self.peripheral.writeValue_forDescriptor_(value, descriptor)
-        await future
 
-        return True
+        self._descriptor_write_futures[descriptor.handle()] = future
+        try:
+            self.peripheral.writeValue_forDescriptor_(value, descriptor)
+            await future
+        finally:
+            del self._descriptor_write_futures[descriptor.handle()]
 
     @objc.python_method
     async def start_notifications(
         self, characteristic: CBCharacteristic, callback: Callable[[str, Any], Any]
-    ) -> bool:
+    ) -> None:
         c_handle = characteristic.handle()
         if c_handle in self._characteristic_notify_callbacks:
             raise ValueError("Characteristic notifications already started")
@@ -185,39 +202,47 @@ class PeripheralDelegate(NSObject):
         self._characteristic_notify_callbacks[c_handle] = callback
 
         future = self._event_loop.create_future()
-        self._characteristic_notify_change_futures[c_handle] = future
-        self.peripheral.setNotifyValue_forCharacteristic_(True, characteristic)
-        await future
 
-        return True
+        self._characteristic_notify_change_futures[c_handle] = future
+        try:
+            self.peripheral.setNotifyValue_forCharacteristic_(True, characteristic)
+            await future
+        finally:
+            del self._characteristic_notify_change_futures[c_handle]
 
     @objc.python_method
-    async def stop_notifications(self, characteristic: CBCharacteristic) -> bool:
+    async def stop_notifications(self, characteristic: CBCharacteristic) -> None:
         c_handle = characteristic.handle()
         if c_handle not in self._characteristic_notify_callbacks:
             raise ValueError("Characteristic notification never started")
 
         future = self._event_loop.create_future()
+
         self._characteristic_notify_change_futures[c_handle] = future
-        self.peripheral.setNotifyValue_forCharacteristic_(False, characteristic)
-        await future
+        try:
+            self.peripheral.setNotifyValue_forCharacteristic_(False, characteristic)
+            await future
+        finally:
+            del self._characteristic_notify_change_futures[c_handle]
 
         self._characteristic_notify_callbacks.pop(c_handle)
-
-        return True
 
     @objc.python_method
     async def read_rssi(self) -> NSNumber:
         future = self._event_loop.create_future()
+
         self._read_rssi_futures[self.peripheral.identifier()] = future
-        self.peripheral.readRSSI()
-        return await future
+        try:
+            self.peripheral.readRSSI()
+            return await future
+        finally:
+            del self._read_rssi_futures[self.peripheral.identifier()]
 
     # Protocol Functions
 
     @objc.python_method
     def did_discover_services(
-        self, peripheral: CBPeripheral, error: Optional[NSError]
+        self, peripheral: CBPeripheral, services: NSArray, error: Optional[NSError]
     ) -> None:
         future = self._services_discovered_future
         if error is not None:
@@ -225,7 +250,7 @@ class PeripheralDelegate(NSObject):
             future.set_exception(exception)
         else:
             logger.debug("Services discovered")
-            future.set_result(None)
+            future.set_result(services)
 
     def peripheral_didDiscoverServices_(
         self, peripheral: CBPeripheral, error: Optional[NSError]
@@ -234,12 +259,17 @@ class PeripheralDelegate(NSObject):
         self._event_loop.call_soon_threadsafe(
             self.did_discover_services,
             peripheral,
+            peripheral.services(),
             error,
         )
 
     @objc.python_method
     def did_discover_characteristics_for_service(
-        self, peripheral: CBPeripheral, service: CBService, error: Optional[NSError]
+        self,
+        peripheral: CBPeripheral,
+        service: CBService,
+        characteristics: NSArray,
+        error: Optional[NSError],
     ):
         future = self._service_characteristic_discovered_futures.get(
             service.startHandle()
@@ -256,7 +286,7 @@ class PeripheralDelegate(NSObject):
             future.set_exception(exception)
         else:
             logger.debug("Characteristics discovered")
-            future.set_result(None)
+            future.set_result(characteristics)
 
     def peripheral_didDiscoverCharacteristicsForService_error_(
         self, peripheral: CBPeripheral, service: CBService, error: Optional[NSError]
@@ -266,6 +296,7 @@ class PeripheralDelegate(NSObject):
             self.did_discover_characteristics_for_service,
             peripheral,
             service,
+            service.characteristics(),
             error,
         )
 
@@ -317,20 +348,23 @@ class PeripheralDelegate(NSObject):
     ):
         c_handle = characteristic.handle()
 
-        if error is None:
-            notify_callback = self._characteristic_notify_callbacks.get(c_handle)
-            if notify_callback:
-                notify_callback(c_handle, bytearray(value))
-
         future = self._characteristic_read_futures.get(c_handle)
+
+        # If there is no pending read request, then this must be a notification
+        # (the same delagate callback is used by both).
         if not future:
-            return  # only expected on read
+            if error is None:
+                notify_callback = self._characteristic_notify_callbacks.get(c_handle)
+                if notify_callback:
+                    notify_callback(c_handle, bytearray(value))
+            return
+
         if error is not None:
             exception = BleakError(f"Failed to read characteristic {c_handle}: {error}")
             future.set_exception(exception)
         else:
             logger.debug("Read characteristic value")
-            future.set_result(None)
+            future.set_result(value)
 
     def peripheral_didUpdateValueForCharacteristic_error_(
         self,
@@ -352,6 +386,7 @@ class PeripheralDelegate(NSObject):
         self,
         peripheral: CBPeripheral,
         descriptor: CBDescriptor,
+        value: NSObject,
         error: Optional[NSError],
     ):
         future = self._descriptor_read_futures.get(descriptor.handle())
@@ -365,7 +400,7 @@ class PeripheralDelegate(NSObject):
             future.set_exception(exception)
         else:
             logger.debug("Read descriptor value")
-            future.set_result(None)
+            future.set_result(value)
 
     def peripheral_didUpdateValueForDescriptor_error_(
         self,
@@ -378,6 +413,7 @@ class PeripheralDelegate(NSObject):
             self.did_update_value_for_descriptor,
             peripheral,
             descriptor,
+            descriptor.value(),
             error,
         )
 
@@ -388,7 +424,7 @@ class PeripheralDelegate(NSObject):
         characteristic: CBCharacteristic,
         error: Optional[NSError],
     ):
-        future = self._characteristic_write_futures.pop(characteristic.handle(), None)
+        future = self._characteristic_write_futures.get(characteristic.handle(), None)
         if not future:
             return  # event only expected on write with response
         if error is not None:
@@ -489,7 +525,7 @@ class PeripheralDelegate(NSObject):
     def did_read_rssi(
         self, peripheral: CBPeripheral, rssi: NSNumber, error: Optional[NSError]
     ) -> None:
-        future = self._read_rssi_futures.pop(peripheral.identifier(), None)
+        future = self._read_rssi_futures.get(peripheral.identifier(), None)
 
         if not future:
             logger.warning("Unexpected event did_read_rssi")

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -72,8 +72,14 @@ class PeripheralDelegate(NSObject):
 
         These can be used to handle any pending futures when a peripheral is disconnected.
         """
+        services_discovered_future = (
+            (self._services_discovered_future,)
+            if hasattr(self, "_services_discovered_future")
+            else ()
+        )
+
         return itertools.chain(
-            (self._services_discovered_future,),
+            services_discovered_future,
             self._service_characteristic_discovered_futures.values(),
             self._characteristic_descriptor_discover_futures.values(),
             self._characteristic_read_futures.values(),

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -234,7 +234,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
         use_cached=False,
-        **kwargs
+        **kwargs,
     ) -> bytearray:
         """Perform read operation on the specified GATT characteristic.
 
@@ -316,23 +316,14 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             raise BleakError("Characteristic {} was not found!".format(char_specifier))
 
         value = NSData.alloc().initWithBytes_length_(data, len(data))
-        success = await self._delegate.write_characteristic(
+        await self._delegate.write_characteristic(
             characteristic.obj,
             value,
             CBCharacteristicWriteWithResponse
             if response
             else CBCharacteristicWriteWithoutResponse,
         )
-        if success:
-            logger.debug(
-                "Write Characteristic {0} : {1}".format(characteristic.uuid, data)
-            )
-        else:
-            raise BleakError(
-                "Could not write value {0} to characteristic {1}: {2}".format(
-                    data, characteristic.uuid, success
-                )
-            )
+        logger.debug(f"Write Characteristic {characteristic.uuid} : {data}")
 
     async def write_gatt_descriptor(
         self, handle: int, data: Union[bytes, bytearray, memoryview]
@@ -349,21 +340,14 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             raise BleakError("Descriptor {} was not found!".format(handle))
 
         value = NSData.alloc().initWithBytes_length_(data, len(data))
-        success = await self._delegate.write_descriptor(descriptor.obj, value)
-        if success:
-            logger.debug("Write Descriptor {0} : {1}".format(handle, data))
-        else:
-            raise BleakError(
-                "Could not write value {0} to descriptor {1}: {2}".format(
-                    data, descriptor.uuid, success
-                )
-            )
+        await self._delegate.write_descriptor(descriptor.obj, value)
+        logger.debug("Write Descriptor {0} : {1}".format(handle, data))
 
     async def start_notify(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],
         callback: Callable[[int, bytearray], None],
-        **kwargs
+        **kwargs,
     ) -> None:
         """Activate notifications/indications on a characteristic.
 
@@ -398,15 +382,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         if not characteristic:
             raise BleakError("Characteristic {0} not found!".format(char_specifier))
 
-        success = await self._delegate.start_notifications(
-            characteristic.obj, bleak_callback
-        )
-        if not success:
-            raise BleakError(
-                "Could not start notify on {0}: {1}".format(
-                    characteristic.uuid, success
-                )
-            )
+        await self._delegate.start_notifications(characteristic.obj, bleak_callback)
 
     async def stop_notify(
         self, char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID]
@@ -427,11 +403,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         if not characteristic:
             raise BleakError("Characteristic {} not found!".format(char_specifier))
 
-        success = await self._delegate.stop_notifications(characteristic.obj)
-        if not success:
-            raise BleakError(
-                "Could not stop notify on {0}: {1}".format(characteristic.uuid, success)
-            )
+        await self._delegate.stop_notifications(characteristic.obj)
 
     async def get_rssi(self) -> int:
         """To get RSSI value in dBm of the connected Peripheral"""

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -44,7 +44,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         self._manager = CentralManagerDelegate.alloc().init()
         self._timeout: float = kwargs.get("timeout", 5.0)
         if objc.macos_available(12, 0) and not self._service_uuids:
-            logging.error(
+            logger.error(
                 "macOS 12 requires non-empty service_uuids kwarg, otherwise no advertisement data will be received"
             )
 

--- a/bleak/backends/p4android/defs.py
+++ b/bleak/backends/p4android/defs.py
@@ -20,6 +20,7 @@ BluetoothGattCharacteristic = autoclass("android.bluetooth.BluetoothGattCharacte
 BluetoothGattDescriptor = autoclass("android.bluetooth.BluetoothGattDescriptor")
 BluetoothProfile = autoclass("android.bluetooth.BluetoothProfile")
 PythonActivity = autoclass("org.kivy.android.PythonActivity")
+ParcelUuid = autoclass("android.os.ParcelUuid")
 activity = cast("android.app.Activity", PythonActivity.mActivity)
 context = cast("android.content.Context", activity.getApplicationContext())
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -68,12 +68,28 @@ AdvertisementDataFilter = Callable[
 
 
 class BaseBleakScanner(abc.ABC):
-    """Interface for Bleak Bluetooth LE Scanners"""
+    """
+    Interface for Bleak Bluetooth LE Scanners
+
+    Args:
+        **detection_callback (callable or coroutine):
+            Optional function that will be called each time a device is
+            discovered or advertising data has changed.
+        **service_uuids (List[str]):
+            Optional list of service UUIDs to filter on. Only advertisements
+            containing this advertising data will be received. Required on
+            macOS 12 and later.
+    """
 
     def __init__(self, *args, **kwargs):
         super(BaseBleakScanner, self).__init__()
         self._callback: Optional[AdvertisementDataCallback] = None
         self.register_detection_callback(kwargs.get("detection_callback"))
+        self._service_uuids: Optional[List[str]] = (
+            [u.lower() for u in kwargs["service_uuids"]]
+            if "service_uuids" in kwargs
+            else None
+        )
 
     async def __aenter__(self):
         await self.start()

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -13,8 +13,8 @@ from functools import wraps
 from typing import Callable, Any, List, Optional, Sequence, Union
 
 from bleak_winrt.windows.devices.bluetooth import (
+    BluetoothError,
     BluetoothLEDevice,
-    BluetoothConnectionStatus,
     BluetoothCacheMode,
     BluetoothAddressType,
 )
@@ -23,6 +23,8 @@ from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (
     GattCommunicationStatus,
     GattDescriptor,
     GattDeviceService,
+    GattSessionStatus,
+    GattSessionStatusChangedEventArgs,
     GattWriteOption,
     GattCharacteristicProperties,
     GattClientCharacteristicConfigurationDescriptorValue,
@@ -33,6 +35,7 @@ from bleak_winrt.windows.devices.enumeration import (
     DevicePairingResultStatus,
     DeviceUnpairingResultStatus,
 )
+from bleak_winrt.windows.foundation import EventRegistrationToken
 from bleak_winrt.windows.storage.streams import Buffer
 
 from bleak.backends.device import BLEDevice
@@ -126,8 +129,8 @@ class BleakClientWinRT(BaseBleakClient):
         else:
             self._device_info = None
         self._requester = None
-        self._connect_events: List[asyncio.Event] = []
-        self._disconnect_events: List[asyncio.Event] = []
+        self._session_active_events: List[asyncio.Event] = []
+        self._session_closed_events: List[asyncio.Event] = []
         self._session: GattSession = None
 
         self._address_type = (
@@ -137,7 +140,7 @@ class BleakClientWinRT(BaseBleakClient):
             else None
         )
 
-        self._connection_status_changed_token = None
+        self._session_status_changed_token: Optional[EventRegistrationToken] = None
 
     def __str__(self):
         return "BleakClientWinRT ({0})".format(self.address)
@@ -190,11 +193,11 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Called on disconnect event or on failure to connect.
         def handle_disconnect():
-            if self._connection_status_changed_token:
-                self._requester.remove_connection_status_changed(
-                    self._connection_status_changed_token
+            if self._session_status_changed_token:
+                self._session.remove_session_status_changed(
+                    self._session_status_changed_token
                 )
-                self._connection_status_changed_token = None
+                self._session_status_changed_token = None
 
             if self._requester:
                 self._requester.close()
@@ -204,54 +207,69 @@ class BleakClientWinRT(BaseBleakClient):
                 self._session.close()
                 self._session = None
 
-        def handle_connection_status_changed(
-            connection_status: BluetoothConnectionStatus,
+        def handle_session_status_changed(
+            args: GattSessionStatusChangedEventArgs,
         ):
-            if connection_status == BluetoothConnectionStatus.CONNECTED:
-                for e in self._connect_events:
+            if args.error != BluetoothError.SUCCESS:
+                logger.error(f"Unhandled GATT error {args.error}")
+
+            if args.status == GattSessionStatus.ACTIVE:
+                for e in self._session_active_events:
                     e.set()
 
-            elif connection_status == BluetoothConnectionStatus.DISCONNECTED:
+            elif args.status == GattSessionStatus.CLOSED:
                 if self._disconnected_callback:
                     self._disconnected_callback(self)
 
-                for e in self._disconnect_events:
+                for e in self._session_closed_events:
                     e.set()
 
                 handle_disconnect()
 
         loop = asyncio.get_running_loop()
 
-        def _ConnectionStatusChanged_Handler(sender, args):
+        # this is the WinRT event handler will be called on another thread
+        def session_status_changed_event_handler(
+            sender: GattSession, args: GattSessionStatusChangedEventArgs
+        ):
             logger.debug(
-                "_ConnectionStatusChanged_Handler: %d", sender.connection_status
+                "session_status_changed_event_handler: id: %s, error: %s, status: %s",
+                sender.device_id,
+                args.error,
+                args.status,
             )
-            loop.call_soon_threadsafe(
-                handle_connection_status_changed, sender.connection_status
-            )
-
-        self._connection_status_changed_token = (
-            self._requester.add_connection_status_changed(
-                _ConnectionStatusChanged_Handler
-            )
-        )
+            loop.call_soon_threadsafe(handle_session_status_changed, args)
 
         # Start a GATT Session to connect
         event = asyncio.Event()
-        self._connect_events.append(event)
+        self._session_active_events.append(event)
         try:
             self._session = await GattSession.from_device_id_async(
                 self._requester.bluetooth_device_id
             )
-            # This keeps the device connected until we dispose the session or
-            # until we set maintain_connection = False.
+
+            if not self._session.can_maintain_connection:
+                raise BleakError("device does not support GATT sessions")
+
+            self._session_status_changed_token = (
+                self._session.add_session_status_changed(
+                    session_status_changed_event_handler
+                )
+            )
+
+            # Windows does not support explicitly connecting to a device.
+            # Instead it has the concept of a GATT session that is owned
+            # by the calling program.
             self._session.maintain_connection = True
+            # This keeps the device connected until we set maintain_connection = False.
+
+            # wait for the session to become active
             await asyncio.wait_for(event.wait(), timeout=timeout)
         except BaseException:
             handle_disconnect()
             raise
         finally:
-            self._connect_events.remove(event)
+            self._session_active_events.remove(event)
 
         # Obtain services, which also leads to connection being established.
         await self.get_services()
@@ -280,18 +298,21 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Without this, disposing the BluetoothLEDevice won't disconnect it
         if self._session:
-            self._session.close()
+            self._session.maintain_connection = False
+            # calling self._session.close() here prevents any further GATT
+            # session status events, so we defer that until after the session
+            # is no longer active
 
-        # Dispose of the BluetoothLEDevice and see that the connection
-        # status is now Disconnected.
+        # Dispose of the BluetoothLEDevice and see that the session
+        # status is now closed.
         if self._requester:
             event = asyncio.Event()
-            self._disconnect_events.append(event)
+            self._session_closed_events.append(event)
             try:
                 self._requester.close()
                 await asyncio.wait_for(event.wait(), timeout=10)
             finally:
-                self._disconnect_events.remove(event)
+                self._session_closed_events.remove(event)
 
         return True
 
@@ -305,9 +326,8 @@ class BleakClientWinRT(BaseBleakClient):
         """
         return self._DeprecatedIsConnectedReturn(
             False
-            if self._requester is None
-            else self._requester.connection_status
-            == BluetoothConnectionStatus.CONNECTED
+            if self._session is None
+            else self._session.session_status == GattSessionStatus.ACTIVE
         )
 
     @property

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -125,7 +125,9 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Backend specific. WinRT objects.
         if isinstance(address_or_ble_device, BLEDevice):
-            self._device_info = address_or_ble_device.details.bluetooth_address
+            self._device_info = (
+                address_or_ble_device.address.details.adv.bluetooth_address
+            )
         else:
             self._device_info = None
         self._requester = None
@@ -166,7 +168,7 @@ class BleakClientWinRT(BaseBleakClient):
             )
 
             if device:
-                self._device_info = device.details.bluetooth_address
+                self._device_info = device.details.adv.bluetooth_address
             else:
                 raise BleakError(
                     "Device with address {0} was not found.".format(self.address)

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import pathlib
-from typing import List
+from typing import Dict, List, NamedTuple, Optional
 from uuid import UUID
 
 from bleak_winrt.windows.devices.bluetooth.advertisement import (
@@ -32,6 +32,24 @@ def _format_event_args(e):
         return e.bluetooth_address
 
 
+class _RawAdvData(NamedTuple):
+    """
+    Platform-specific advertisement data.
+
+    Windows does not combine advertising data with type SCAN_RSP with other
+    advertising data like other platforms, so se have to do it ourselves.
+    """
+
+    adv: BluetoothLEAdvertisementReceivedEventArgs
+    """
+    The advertisement data received from the BluetoothLEAdvertisementWatcher.Received event.
+    """
+    scan: Optional[BluetoothLEAdvertisementReceivedEventArgs]
+    """
+    The scan response for the same device as *adv*.
+    """
+
+
 class BleakScannerWinRT(BaseBleakScanner):
     """The native Windows Bleak BLE Scanner.
 
@@ -47,8 +65,7 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         self.watcher = None
         self._stopped_event = None
-        self._devices = {}
-        self._scan_responses = {}
+        self._discovered_devices: Dict[int, _RawAdvData] = {}
 
         if "scanning_mode" in kwargs and kwargs["scanning_mode"].lower() == "passive":
             self._scanning_mode = BluetoothLEScanningMode.PASSIVE
@@ -69,45 +86,68 @@ class BleakScannerWinRT(BaseBleakScanner):
         """Callback for AdvertisementWatcher.Received"""
         # TODO: Cannot check for if sender == self.watcher in winrt?
         logger.debug("Received {0}.".format(_format_event_args(event_args)))
+
+        # get the previous advertising data or start a new one
+        raw_data = self._discovered_devices.get(
+            event_args.bluetooth_address, _RawAdvData(event_args, None)
+        )
+
+        # update the advertsing data depending on the advertising data type
         if event_args.advertisement_type == BluetoothLEAdvertisementType.SCAN_RESPONSE:
-            if event_args.bluetooth_address not in self._scan_responses:
-                self._scan_responses[event_args.bluetooth_address] = event_args
+            raw_data = _RawAdvData(raw_data.adv, event_args)
         else:
-            if event_args.bluetooth_address not in self._devices:
-                self._devices[event_args.bluetooth_address] = event_args
+            raw_data = _RawAdvData(event_args, raw_data.scan)
+
+        self._discovered_devices[event_args.bluetooth_address] = raw_data
 
         if self._callback is None:
             return
 
         # Get a "BLEDevice" from parse_event args
-        device = self._parse_event_args(event_args)
+        device = self._parse_adv_data(raw_data)
+
+        # On Windows, we have to fake service UUID filtering. If we were to pass
+        # a BluetoothLEAdvertisementFilter to the BluetoothLEAdvertisementWatcher
+        # with the service UUIDs appropriately set, we would no longer receive
+        # scan response data (which commonly contains the local device name).
+        # So we have to do it like this instead.
+
+        if self._service_uuids:
+            for uuid in device.metadata["uuids"]:
+                if uuid in self._service_uuids:
+                    break
+            else:
+                # if there were no matching service uuids, the don't call the callback
+                return
+
+        service_data = {}
 
         # Decode service data
-        service_data = {}
-        # 0x16 is service data with 16-bit UUID
-        for section in event_args.advertisement.get_sections_by_type(0x16):
-            data = bytes(section.data)
-            service_data[
-                f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
-            ] = data[2:]
-        # 0x20 is service data with 32-bit UUID
-        for section in event_args.advertisement.get_sections_by_type(0x20):
-            data = bytes(section.data)
-            service_data[
-                f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
-            ] = data[4:]
-        # 0x21 is service data with 128-bit UUID
-        for section in event_args.advertisement.get_sections_by_type(0x21):
-            data = bytes(section.data)
-            service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
+        for args in filter(lambda d: d is not None, raw_data):
+            # 0x16 is service data with 16-bit UUID
+            for section in args.advertisement.get_sections_by_type(0x16):
+                data = bytes(section.data)
+                service_data[
+                    f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
+                ] = data[2:]
+            # 0x20 is service data with 32-bit UUID
+            for section in args.advertisement.get_sections_by_type(0x20):
+                data = bytes(section.data)
+                service_data[
+                    f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
+                ] = data[4:]
+            # 0x21 is service data with 128-bit UUID
+            for section in args.advertisement.get_sections_by_type(0x21):
+                data = bytes(section.data)
+                service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
 
         # Use the BLEDevice to populate all the fields for the advertisement data to return
         advertisement_data = AdvertisementData(
-            local_name=event_args.advertisement.local_name,
+            local_name=device.name,
             manufacturer_data=device.metadata["manufacturer_data"],
             service_data=service_data,
             service_uuids=device.metadata["uuids"],
-            platform_data=(sender, event_args),
+            platform_data=(sender, raw_data),
         )
 
         self._callback(device, advertisement_data)
@@ -115,12 +155,15 @@ class BleakScannerWinRT(BaseBleakScanner):
     def _stopped_handler(self, sender, e):
         logger.debug(
             "{0} devices found. Watcher status: {1}.".format(
-                len(self._devices), self.watcher.status
+                len(self._discovered_devices), self.watcher.status
             )
         )
         self._stopped_event.set()
 
     async def start(self):
+        # start with fresh list of discovered devices
+        self._discovered_devices.clear()
+
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.scanning_mode = self._scanning_mode
 
@@ -177,35 +220,27 @@ class BleakScannerWinRT(BaseBleakScanner):
 
     @property
     def discovered_devices(self) -> List[BLEDevice]:
-        found = []
-        for event_args in list(self._devices.values()):
-            new_device = self._parse_event_args(event_args)
-            if (
-                not new_device.name
-                and event_args.bluetooth_address in self._scan_responses
-            ):
-                new_device.name = self._scan_responses[
-                    event_args.bluetooth_address
-                ].advertisement.local_name
-            found.append(new_device)
-
-        return found
+        return [self._parse_adv_data(d) for d in self._discovered_devices.values()]
 
     @staticmethod
-    def _parse_event_args(event_args):
-        bdaddr = _format_bdaddr(event_args.bluetooth_address)
+    def _parse_adv_data(raw_data: _RawAdvData) -> BLEDevice:
+        """
+        Combines advertising data from regular advertisement data and scan response.
+        """
+        bdaddr = _format_bdaddr(raw_data.adv.bluetooth_address)
         uuids = []
-        try:
-            for u in event_args.advertisement.service_uuids:
-                uuids.append(str(u))
-        except NotImplementedError as e:
-            # Cannot get service uuids for this device...
-            pass
         data = {}
-        for m in event_args.advertisement.manufacturer_data:
-            data[m.company_id] = bytes(m.data)
-        local_name = event_args.advertisement.local_name
-        rssi = event_args.raw_signal_strength_in_d_bm
+        local_name = None
+
+        for args in filter(lambda d: d is not None, raw_data):
+            for u in args.advertisement.service_uuids:
+                uuids.append(str(u))
+            for m in args.advertisement.manufacturer_data:
+                data[m.company_id] = bytes(m.data)
+            if args.advertisement.local_name is not None:
+                local_name = args.advertisement.local_name
+            rssi = args.raw_signal_strength_in_d_bm
+
         return BLEDevice(
-            bdaddr, local_name, event_args, rssi, uuids=uuids, manufacturer_data=data
+            bdaddr, local_name, raw_data, rssi, uuids=uuids, manufacturer_data=data
         )

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -752,6 +752,13 @@ uuid128_dict = {
     "6e400001-b5a3-f393-e0a9-e50e24dcca9e": "Nordic UART Service",
     "6e400003-b5a3-f393-e0a9-e50e24dcca9e": "Nordic UART TX",
     "6e400002-b5a3-f393-e0a9-e50e24dcca9e": "Nordic UART RX",
+    # LEGO
+    "00001623-1212-efde-1623-785feabcd123": "LEGO Wireless Protocol v3 Hub Service",
+    "00001624-1212-efde-1623-785feabcd123": "LEGO Wireless Protocol v3 Hub Characteristic",
+    "00001625-1212-efde-1623-785feabcd123": "LEGO Wireless Protocol v3 Bootloader Service",
+    "00001626-1212-efde-1623-785feabcd123": "LEGO Wireless Protocol v3 Bootloader Characteristic",
+    "c5f50001-8280-46da-89f4-6d8051e4aeef": "Pybricks Service",
+    "c5f50002-8280-46da-89f4-6d8051e4aeef": "Pybricks Characteristic",
     # from nRF connect
     "be15bee0-6186-407e-8381-0bd89c4d8df4": "Anki Drive Vehicle Service READ",
     "be15bee1-6186-407e-8381-0bd89c4d8df4": "Anki Drive Vehicle Service WRITE",

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -9,20 +9,22 @@ Updated on 2020-10-11 by bernstern <bernie@allthenticate.net>
 """
 
 import asyncio
+import logging
+import sys
+
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
-import logging
 
-logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
-    print(device.address, "RSSI:", device.rssi, advertisement_data)
+    logger.info(f"{device.address} RSSI: {device.rssi}, {advertisement_data}")
 
 
-async def main():
-    scanner = BleakScanner()
+async def main(service_uuids):
+    scanner = BleakScanner(service_uuids=service_uuids)
     scanner.register_detection_callback(simple_callback)
 
     while True:
@@ -32,4 +34,9 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
+    service_uuids = sys.argv[1:]
+    asyncio.run(main(service_uuids))

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -15,6 +15,7 @@ import sys
 from bleak import BleakScanner
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
+from bleak.uuids import uuid16_dict, uuid128_dict
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,16 @@ def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
 
 
 async def main(service_uuids):
+    if len(service_uuids) > 0 and service_uuids[0] == "all":
+        # in Macos Monterey the service_uuids need to be specified.
+        # Instead of discovering valid uuids with a different tool
+        # you can add `all` as argument and it will add all defined
+        # uuid's from bleak/uuids as a starting point.
+        logger.info("Adding all known service uuids")
+        service_uuids.pop(0)
+        for item in uuid16_dict:
+            service_uuids.append("{0:04x}".format(item))
+        service_uuids.extend(uuid128_dict.keys())
     scanner = BleakScanner(service_uuids=service_uuids)
     scanner.register_detection_callback(simple_callback)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dbus-next>=0.2.2; sys_platform=="linux"
 pyobjc-core>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-CoreBluetooth>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-libdispatch>=7.0.1;sys_platform == 'darwin'
-bleak-winrt>=1.0.1; sys_platform == 'win32'
+bleak-winrt>=1.1.0; sys_platform == 'win32'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,5 +11,4 @@ Sphinx>=1.7.7
 sphinx-rtd-theme>=1.0.0
 PyYAML>=3.13
 pytest>=3.9.2
-pytest-runner>=4.2
 pytest-cov>=2.5.1

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         "Operating System :: Microsoft :: Windows :: Windows 10",
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Android",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,6 @@ setup(
         "Development Status :: 4 - Beta",
         "Framework :: AsyncIO",
         "Intended Audience :: Developers",
-        "Topic :: System :: Hardware :: Bluetooth",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: Microsoft :: Windows :: Windows 10",

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ REQUIRED = [
     'bleak-winrt>=1.0.1;platform_system=="Windows"',
 ]
 
-TEST_REQUIRED = ["pytest", "pytest-cov"]
-
 here = os.path.abspath(os.path.dirname(__file__))
 with io.open(os.path.join(here, "README.rst"), encoding="utf-8") as f:
     long_description = "\n" + f.read()
@@ -87,7 +85,6 @@ setup(
     entry_points={"console_scripts": ["bleak-lescan=bleak:cli"]},
     install_requires=REQUIRED,
     test_suite="tests",
-    tests_require=TEST_REQUIRED,
     include_package_data=True,
     license="MIT",
     project_urls={

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         "Development Status :: 4 - Beta",
         "Framework :: AsyncIO",
         "Intended Audience :: Developers",
-        "Topic :: Communications",
+        "Topic :: System :: Hardware :: Bluetooth",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: Microsoft :: Windows :: Windows 10",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIRED = [
     'pyobjc-framework-CoreBluetooth;platform_system=="Darwin"',
     'pyobjc-framework-libdispatch;platform_system=="Darwin"',
     # Windows reqs
-    'bleak-winrt>=1.0.1;platform_system=="Windows"',
+    'bleak-winrt>=1.1.0;platform_system=="Windows"',
 ]
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION

Added
-----

* Added ``service_uuids`` kwarg to  ``BleakScanner``. This can be used to work around issue of scanning not working on macOS 12. Fixes #230. Works around #635.
* Added UUIDs for LEGO Powered Up Smart Hubs.

Changed
-------

* Changed WinRT backend to use GATT session status instead of actual device connection status.
* Changed handling of scan response data on WinRT backend. Advertising data and scan response data is now combined in callbacks like other platforms.
* Updated ``bleak-winrt`` dependency to v1.1.0. Fixes #698.

Fixed
-----

* Fixed ``InvalidStateError`` in CoreBluetooth backend when read and notification of the same characteristic are used. Fixes #675.
* Fixed reading a characteristic on CoreBluetooth backend also triggers notification callback.
* Fixed in Linux, scanner callback not setting metadata parameters. Merged #715.
