### PR TITLE
Skip logging CoreBlueooth scanner error if running as .app

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ replace = __version__ = "{new_version}"
 universal = 1
 
 [flake8]
-exclude = docs,.venv,*.pyi,.buildozer
+exclude = docs,.venv,*.pyi,.buildozer,build,dist,.eggs
 ignore = E203,E501,W503
 
 [aliases]


### PR DESCRIPTION
Based on further insights from https://github.com/hbldh/bleak/issues/720, we should be able to suppress this error if bleak is being used within a .app.