### PR TITLE
docs: warn against bleak.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,7 @@ Connect to a Bluetooth device and read its model number:
 
     asyncio.run(main(address))
 
+DO NOT NAME YOUR SCRIPT `bleak.py`! It will cause a circular import error.
 
 See examples folder for more code, for instance example code for connecting to a
 `TI SensorTag CC2650 <http://www.ti.com/ww/en/wireless_connectivity/sensortag/>`_

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -22,6 +22,8 @@ To discover Bluetooth devices that can be connected to:
 
     asyncio.run(main())
 
+.. warning:: Do not name your script `bleak.py`! It will cause a circular import error.
+
 This will scan for 5 seconds and then produce a printed list of detected devices::
 
     24:71:89:CC:09:05: CC2650 SensorTag

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -4,6 +4,17 @@ Troubleshooting
 
 When things don't seem to be working right, here are some things to try.
 
+---------------
+Common Mistakes
+---------------
+
+Many people name their first script ```bleak.py``. This causes the script to
+crash with an ``ImportError`` similar to::
+
+    ImportError: cannot import name 'BleakClient' from partially initialized module 'bleak' (most likely due to a circular import) (bleak.py)`
+
+To fix the error, change the name of the script to something other than ``bleak.py``.
+
 
 --------------
 Enable Logging

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,8 @@ or one can do it without the context manager like this:
 
     asyncio.run(main(address))
 
+.. warning:: Do not name your script `bleak.py`! It will cause a circular import error.
+
 Make sure you always get to call the disconnect method for a client before discarding it;
 the Bluetooth stack on the OS might need to be cleared of residual data which is cached in the
 ``BleakClient``.


### PR DESCRIPTION
We frequently get bug reports about circular import errors. This is due to naming your script `bleak.py`. So put warnings  everywhere so hopefully people won't miss it.

Fixes: #729
Fixes: #704
Fixes: #515
