### PR TITLE
winrt: fix AttributeError in BleakClient.__init__()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+
+* Fixed ``AttributeError`` when passing ``BLEDevice`` to ``BleakClient``
+  constructor on WinRT backend. Fixes #731.
+
 
 `0.14.0`_ (2022-01-10)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -125,9 +125,7 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Backend specific. WinRT objects.
         if isinstance(address_or_ble_device, BLEDevice):
-            self._device_info = (
-                address_or_ble_device.address.details.adv.bluetooth_address
-            )
+            self._device_info = address_or_ble_device.details.adv.bluetooth_address
         else:
             self._device_info = None
         self._requester = None


### PR DESCRIPTION
This fixes a regression caused by 3f26be6. When a `BLEDevice` is passed instead of a string, it tries to loop up a non-existent attribute.

Fixes: #731
