### PR TITLE
winrt: update bleak-winrt to v1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+
+* Updated ``bleak-winrt`` dependency to v1.1.1. Fixes #741.
+
 
 `0.14.1`_ (2022-01-12)
 ======================

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ dbus-next = {version = ">=0.2.2", sys_platform = "== 'linux'"}
 pyobjc-core = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-CoreBluetooth = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-libdispatch = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
-bleak-winrt = {version = ">=1.1.0", sys_platform = "== 'win32'"}
+bleak-winrt = {version = ">=1.1.1", sys_platform = "== 'win32'"}
 
 [dev-packages]
 pytest = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dbus-next>=0.2.2; sys_platform=="linux"
 pyobjc-core>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-CoreBluetooth>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-libdispatch>=7.0.1;sys_platform == 'darwin'
-bleak-winrt>=1.1.0; sys_platform == 'win32'
+bleak-winrt>=1.1.1; sys_platform == 'win32'

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ REQUIRED = [
     'pyobjc-framework-CoreBluetooth;platform_system=="Darwin"',
     'pyobjc-framework-libdispatch;platform_system=="Darwin"',
     # Windows reqs
-    'bleak-winrt>=1.1.0;platform_system=="Windows"',
+    'bleak-winrt>=1.1.1;platform_system=="Windows"',
 ]
 
 here = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
v1.1.0 was not statically linked against the MSVC runtime and would require users to manually install it to avoid an `ImportError`.

Fixes: https://github.com/hbldh/bleak/issues/741
