### PR TITLE
winrt: fix name is 'Unknown'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Changed
 
 * Updated ``bleak-winrt`` dependency to v1.1.1. Fixes #741.
 
+Fixed
+-----
+
+* Fixed ``name`` is ``'Unknown'`` in WinRT backend. Fixes #736.
+
 
 `0.14.1`_ (2022-01-12)
 ======================

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -237,7 +237,8 @@ class BleakScannerWinRT(BaseBleakScanner):
                 uuids.append(str(u))
             for m in args.advertisement.manufacturer_data:
                 data[m.company_id] = bytes(m.data)
-            if args.advertisement.local_name is not None:
+            # local name is empty string rather than None if not present
+            if args.advertisement.local_name:
                 local_name = args.advertisement.local_name
             rssi = args.raw_signal_strength_in_d_bm
 


### PR DESCRIPTION
Commit 3f26be60c "winrt: combine adv data and scan rsp data" incorrectly assumed that `local_name` would return None instead of '' when no name was present in the advertising data. This changes the test to not strictly check for None.

Fixes: https://github.com/hbldh/bleak/issues/736
