### PR TITLE
Fix BleakClient leak on macOS

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 * Fixed reading the battery level returns a zero-filled bytearray on linux with bluez >= 5.48 Fixes #750
 * Fixed unpairing does not work on windows with winrt. Fixes #699
+* Fixed a leak of ``BleakClient`` instances in macOS. Fixes #762
 
 `0.14.2`_ (2022-01-26)
 ======================

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -355,7 +355,7 @@ class CentralManagerDelegate(NSObject):
 
         callback = self._disconnect_callbacks.get(peripheral.identifier())
         if callback is not None:
-            callback()
+            callback(error.code if error else None)
 
     def centralManager_didDisconnectPeripheral_error_(
         self,

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -92,7 +92,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 self._peripheral
             )
 
-        def disconnect_callback():
+        def disconnect_callback(error: Optional[int]):
             self.services = BleakGATTServiceCollection()
             # Ensure that `get_services` retrieves services again, rather
             # than using the cached object
@@ -109,7 +109,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                     # the future was already done
                     pass
 
-            if self._disconnected_callback:
+            if error and self._disconnected_callback:
                 self._disconnected_callback(self)
 
         manager = self._central_manager_delegate
@@ -126,7 +126,6 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         """Disconnect from the peripheral device"""
         if (
             self._peripheral is None
-            or self._peripheral.state() != CBPeripheralStateConnected
         ):
             return True
 


### PR DESCRIPTION
Please see https://github.com/hbldh/bleak/issues/762 which contains my "working out" for this problem.

Previously the disconnect handler was only called if the peripheral wasn't already disconnected. This is a problem when devices might disconnect before you are done with them.

It could lead to a leak where the handler was never disconnected and you could end up with duplicate disconnect callbacks for the same device.

The client objects themselves also leaked.

The existing code had the effect of masking a duplicate callback. corebluetooth seems to send a notification with no error when we disconnect the disconnect handler. So users previously only saw disconnect events caused by errors (the device going away).

Now that we disconnect from the handler we get an extra notification. To avoid an API break, we now only invoke the users callback if there was an error condition. This simulates the old behaviour.
