### PR TITLE
Add py.typed file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+
+* Add `py.typed` file so mypy discovers Bleak's type annotations
+
 
 `0.14.3`_ (2022-04-29)
 ======================

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE
 include README.rst
+include bleak/py.typed
 
 recursive-include tests *
 recursive-exclude * __pycache__


### PR DESCRIPTION
This is needed for mypy to read the type signatures defined in the project, ref https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

There's also a note about needing `zip_safe=False`, but I'm not to familiar with setuptools so I didn't want to add that unless it's strictly required.

<!--

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.7+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!


-->