### PR TITLE
Bluez advertisement watcher/passive scanning

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,8 @@ Contributors
 * Bernie Conrad <bernie@allthenticate.net>
 * Jonathan Soto <jsotogaviard@alum.mit.edu>
 * Kyle J. Williams <kyle@kjwill.tech>
+
+Sponsors
+--------
+
+* Nabu Casa <https://www.nabucasa.com/>

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 * UUID descriptions updated to 2022-03-16 assigned numbers document
 * Replace use of deprecated ``asyncio.get_event_loop()`` in Android backend.
 * ``BleakScanner()`` args ``detection_callback`` and ``service_uuids`` are no longer keyword-only.
+* ``BleakScanner()`` arg ``scanning_mode`` is no longer Windows-only and is no longer keyword-only.
 
 
 `0.14.3`_ (2022-04-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Added
+-----
+
+* Added new ``assigned_numbers`` module and ``AdvertisementDataType`` enum.
+
 Changed
 -------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 
 * Added new ``assigned_numbers`` module and ``AdvertisementDataType`` enum.
 * Added new ``bluez`` kwarg to ``BleakScanner`` in BlueZ backend.
+* Added support for passive scanning in the BlueZ backend. Fixes #606.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 -----
 
 * Added new ``assigned_numbers`` module and ``AdvertisementDataType`` enum.
+* Added new ``bluez`` kwarg to ``BleakScanner`` in BlueZ backend.
 
 Changed
 -------
@@ -24,6 +25,7 @@ Changed
 * ``BleakScanner()`` args ``detection_callback`` and ``service_uuids`` are no longer keyword-only.
 * ``BleakScanner()`` arg ``scanning_mode`` is no longer Windows-only and is no longer keyword-only.
 * All ``BleakScanner()`` instances in BlueZ backend now use common D-Bus object manager.
+* Deprecated ``filters`` kwarg in ``BleakScanner`` in BlueZ backend.
 
 
 `0.14.3`_ (2022-04-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changed
 * Replace use of deprecated ``asyncio.get_event_loop()`` in Android backend.
 * ``BleakScanner()`` args ``detection_callback`` and ``service_uuids`` are no longer keyword-only.
 * ``BleakScanner()`` arg ``scanning_mode`` is no longer Windows-only and is no longer keyword-only.
+* All ``BleakScanner()`` instances in BlueZ backend now use common D-Bus object manager.
 
 
 `0.14.3`_ (2022-04-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 * Add `py.typed` file so mypy discovers Bleak's type annotations
 * UUID descriptions updated to 2022-03-16 assigned numbers document
 * Replace use of deprecated ``asyncio.get_event_loop()`` in Android backend.
+* ``BleakScanner()`` args ``detection_callback`` and ``service_uuids`` are no longer keyword-only.
 
 
 `0.14.3`_ (2022-04-29)

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+typing-extensions = ">=4.2.0"
 dbus-next = {version = ">=0.2.2", sys_platform = "== 'linux'"}
 pyobjc-core = {version = ">=7.0.1", sys_platform = "== 'darwin'"}
 pyobjc-framework-CoreBluetooth = {version = ">=7.0.1", sys_platform = "== 'darwin'"}

--- a/bleak/assigned_numbers.py
+++ b/bleak/assigned_numbers.py
@@ -1,0 +1,37 @@
+"""
+Bluetooth Assigned Numbers
+--------------------------
+
+This module contains useful assigned numbers from the Bluetooth spec.
+
+See <https://www.bluetooth.com/specifications/assigned-numbers/>.
+"""
+
+
+from enum import IntEnum
+
+
+class AdvertisementDataType(IntEnum):
+    """
+    Generic Access Profile advertisement data types.
+
+    `Source <https://btprodspecificationrefs.blob.core.windows.net/assigned-numbers/Assigned%20Number%20Types/Generic%20Access%20Profile.pdf>`.
+    """
+
+    FLAGS = 0x01
+    INCOMPLETE_LIST_SERVICE_UUID16 = 0x02
+    COMPLETE_LIST_SERVICE_UUID16 = 0x03
+    INCOMPLETE_LIST_SERVICE_UUID32 = 0x04
+    COMPLETE_LIST_SERVICE_UUID32 = 0x05
+    INCOMPLETE_LIST_SERVICE_UUID128 = 0x06
+    COMPLETE_LIST_SERVICE_UUID128 = 0x07
+    SHORTENED_LOCAL_NAME = 0x08
+    COMPLETE_LOCAL_NAME = 0x09
+    TX_POWER_LEVEL = 0x0A
+    CLASS_OF_DEVICE = 0x0D
+
+    SERVICE_DATA_UUID16 = 0x16
+    SERVICE_DATA_UUID32 = 0x20
+    SERVICE_DATA_UUID128 = 0x21
+
+    MANUFACTURER_SPECIFIC_DATA = 0xFF

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -1,0 +1,124 @@
+"""
+Advertisement Monitor
+--------------------
+
+This module contains types associated with the BlueZ D-Bus `advertisement
+monitor api <https://github.com/bluez/bluez/blob/master/doc/advertisement-monitor-api.txt>`.
+"""
+
+import logging
+from typing import Callable, Iterable, NamedTuple, Set, Tuple, Union, no_type_check
+
+from dbus_next.service import ServiceInterface, dbus_property, method, PropertyAccess
+
+from . import defs
+from ...assigned_numbers import AdvertisementDataType
+
+
+logger = logging.getLogger(__name__)
+
+
+class OrPattern(NamedTuple):
+    """
+    BlueZ advertisement monitor or-pattern.
+
+    https://github.com/bluez/bluez/blob/master/doc/advertisement-monitor-api.txt
+    """
+
+    start_position: int
+    ad_data_type: AdvertisementDataType
+    content_of_pattern: bytes
+
+
+# Windows has a similar structure, so we allow generic tuple for cross-platform compatibility
+OrPatternLike = Union[OrPattern, Tuple[int, AdvertisementDataType, bytes]]
+
+
+class AdvertisementMonitor(ServiceInterface):
+    """
+    Implementation of the org.bluez.AdvertisementMonitor1 D-Bus interface.
+    """
+
+    def __init__(
+        self,
+        or_patterns: Iterable[OrPatternLike],
+        on_device_found: Callable[[str], None],
+    ):
+        """
+        Args:
+            or_patterns:
+                List of or patterns that will be returned by the ``Patterns`` property.
+            on_device_found:
+                Callback that will be called with the D-Bus device object path
+                when an advertisement is received.
+        """
+        super().__init__(defs.ADVERTISEMENT_MONITOR_INTERFACE)
+        # dbus_next marshaling requires list instead of tuple
+        self._or_patterns = [list(p) for p in or_patterns]
+        self._on_device_found = on_device_found
+        self._seen_devices: Set[str] = set()
+
+    @method()
+    def Release(self):
+        logger.debug("Release")
+
+    @method()
+    def Activate(self):
+        logger.debug("Activate")
+
+    # REVISIT: mypy is broke, so we have to add redundant @no_type_check
+    # https://github.com/python/mypy/issues/6583
+
+    @method()
+    @no_type_check
+    def DeviceFound(self, device: "o"):  # noqa: F821
+        logger.debug("DeviceFound %s", device)
+
+        # REVISIT: this will not catch advertisement data that changes like
+        # active scanning does
+
+        # only call callback once per device to avoid flood of callbacks
+        if device not in self._seen_devices:
+            self._seen_devices.add(device)
+            self._on_device_found(device)
+
+    @method()
+    @no_type_check
+    def DeviceLost(self, device: "o"):  # noqa: F821
+        logger.debug("DeviceLost %s", device)
+
+    @dbus_property(PropertyAccess.READ)
+    @no_type_check
+    def Type(self) -> "s":  # noqa: F821
+        # this is currently the only type supported in BlueZ
+        return "or_patterns"
+
+    @dbus_property(PropertyAccess.READ, disabled=True)
+    @no_type_check
+    def RSSILowThreshold(self) -> "n":  # noqa: F821
+        ...
+
+    @dbus_property(PropertyAccess.READ, disabled=True)
+    @no_type_check
+    def RSSIHighThreshold(self) -> "n":  # noqa: F821
+        ...
+
+    @dbus_property(PropertyAccess.READ, disabled=True)
+    @no_type_check
+    def RSSILowTimeout(self) -> "q":  # noqa: F821
+        ...
+
+    @dbus_property(PropertyAccess.READ, disabled=True)
+    @no_type_check
+    def RSSIHighTimeout(self) -> "q":  # noqa: F821
+        ...
+
+    @dbus_property(PropertyAccess.READ, disabled=True)
+    @no_type_check
+    def RSSISamplingPeriod(self) -> "q":  # noqa: F821
+        ...
+
+    @dbus_property(PropertyAccess.READ)
+    @no_type_check
+    def Patterns(self) -> "a(yyay)":  # noqa: F821
+        return self._or_patterns

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -7,6 +7,8 @@ PROPERTIES_INTERFACE = "org.freedesktop.DBus.Properties"
 # Bluez specific DBUS
 BLUEZ_SERVICE = "org.bluez"
 ADAPTER_INTERFACE = "org.bluez.Adapter1"
+ADVERTISEMENT_MONITOR_INTERFACE = "org.bluez.AdvertisementMonitor1"
+ADVERTISEMENT_MONITOR_MANAGER_INTERFACE = "org.bluez.AdvertisementMonitorManager1"
 DEVICE_INTERFACE = "org.bluez.Device1"
 BATTERY_INTERFACE = "org.bluez.Battery1"
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -1,0 +1,462 @@
+"""
+BlueZ D-Bus manager module
+--------------------------
+
+This contains code for the global BlueZ D-Bus object manager.
+"""
+
+import asyncio
+import logging
+from typing import Any, Callable, Coroutine, Dict, List, NamedTuple, Set, Tuple, cast
+
+from dbus_next import BusType, Message, MessageType, Variant
+from dbus_next.aio.message_bus import MessageBus
+from typing_extensions import TypedDict, Literal
+
+from . import defs
+from .signals import MatchRules, add_match
+from .utils import assert_reply, unpack_variants
+
+logger = logging.getLogger(__name__)
+
+
+# D-Bus properties for interfaces
+# https://github.com/bluez/bluez/blob/master/doc/adapter-api.txt
+
+
+class Adapter1(TypedDict):
+    Address: str
+    Name: str
+    Alias: str
+    Class: int
+    Powered: bool
+    Discoverable: bool
+    Pairable: bool
+    PairableTimeout: int
+    DiscoverableTimeout: int
+    Discovering: int
+    UUIDs: List[str]
+    Modalias: str
+    Roles: List[str]
+    ExperimentalFeatures: List[str]
+
+
+# https://github.com/bluez/bluez/blob/master/doc/advertisement-monitor-api.txt
+
+
+class AdvertisementMonitor1(TypedDict):
+    Type: str
+    RSSILowThreshold: int
+    RSSIHighThreshold: int
+    RSSILowTimeout: int
+    RSSIHighTimeout: int
+    RSSISamplingPeriod: int
+    Patterns: List[Tuple[int, int, bytes]]
+
+
+class AdvertisementMonitorManager1(TypedDict):
+    SupportedMonitorTypes: List[str]
+    SupportedFeatures: List[str]
+
+
+# https://github.com/bluez/bluez/blob/master/doc/battery-api.txt
+
+
+class Battery1(TypedDict):
+    SupportedMonitorTypes: List[str]
+    SupportedFeatures: List[str]
+
+
+# https://github.com/bluez/bluez/blob/master/doc/device-api.txt
+
+
+class Device1(TypedDict):
+    Address: str
+    AddressType: str
+    Name: str
+    Icon: str
+    Class: int
+    Appearance: int
+    UUIDs: List[str]
+    Paired: bool
+    Bonded: bool
+    Connected: bool
+    Trusted: bool
+    Blocked: bool
+    WakeAllowed: bool
+    Alias: str
+    Adapter: str
+    LegacyPairing: bool
+    Modalias: str
+    RSSI: int
+    TxPower: int
+    ManufacturerData: Dict[int, bytes]
+    ServiceData: Dict[str, bytes]
+    ServicesResolved: bool
+    AdvertisingFlags: bytes
+    AdvertisingData: Dict[int, bytes]
+
+
+# https://github.com/bluez/bluez/blob/master/doc/gatt-api.txt
+
+
+class GattService1(TypedDict):
+    UUID: str
+    Primary: bool
+    Device: str
+    Includes: List[str]
+    # Handle is server-only and not available in Bleak
+
+
+class GattCharacteristic1(TypedDict):
+    UUID: str
+    Service: str
+    Value: bytes
+    WriteAcquired: bool
+    NotifyAcquired: bool
+    Notifying: bool
+    Flags: List[
+        Literal[
+            "broadcast",
+            "read",
+            "write-without-response",
+            "write",
+            "notify",
+            "indicate",
+            "authenticated-signed-writes",
+            "extended-properties",
+            "reliable-write",
+            "writable-auxiliaries",
+            "encrypt-read",
+            "encrypt-write",
+            # "encrypt-notify" and "encrypt-indicate" are server-only
+            "encrypt-authenticated-read",
+            "encrypt-authenticated-write",
+            # "encrypt-authenticated-notify", "encrypt-authenticated-indicate",
+            # "secure-read", "secure-write", "secure-notify", "secure-indicate"
+            # are server-only
+            "authorize",
+        ]
+    ]
+    MTU: int
+    # Handle is server-only and not available in Bleak
+
+
+class GattDescriptor1(TypedDict):
+    UUID: str
+    Characteristic: str
+    Value: bytes
+    Flags: List[
+        Literal[
+            "read",
+            "write",
+            "encrypt-read",
+            "encrypt-write",
+            "encrypt-authenticated-read",
+            "encrypt-authenticated-write",
+            # "secure-read" and "secure-write" are server-only and not available in Bleak
+            "authorize",
+        ]
+    ]
+    # Handle is server-only and not available in Bleak
+
+
+AdvertisementCallback = Callable[[str, Device1], None]
+"""
+A callback that is called when advertisement data is received.
+
+Args:
+    arg0: The D-Bus object path of the device.
+    arg1: The D-Bus properties of the device object.
+"""
+
+
+class CallbackAndState(NamedTuple):
+    """
+    Encapsulates an :data:`AdvertisementCallback` and some state.
+    """
+
+    callback: AdvertisementCallback
+    """
+    The callback.
+    """
+
+    adapter_path: str
+    """
+    The D-Bus object path of the adapter associated with the callback.
+    """
+
+    seen_devices: Set[str]
+    """
+    Set of device D-Bus object paths that have been "seen" already by this callback.
+    """
+
+
+# set of org.bluez.Device1 property names that come from advertising data
+_ADVERTISING_DATA_PROPERTIES = {
+    "AdvertisingData",
+    "AdvertisingFlags",
+    "ManufacturerData",
+    "Name",
+    "ServiceData",
+    "UUIDs",
+}
+
+
+class BlueZManager:
+    """
+    BlueZ D-Bus object manager.
+
+    Use :func:`bleak.backends.bluezdbus.get_global_bluez_manager` to get the global instance.
+    """
+
+    def __init__(self):
+        self._bus = MessageBus(bus_type=BusType.SYSTEM)
+        self._bus_lock = asyncio.Lock()
+
+        # dict of object path: dict of interface name: dict of property name: property value
+        self._properties: Dict[str, Dict[str, Dict[str, Any]]] = {}
+
+        self._advertisement_callbacks: List[CallbackAndState] = []
+
+    async def async_init(self):
+        """
+        Connects to the D-Bus message bus and begins monitoring signals.
+
+        It is safe to call this method multiple times. If the bus is already
+        connected, no action is performed.
+        """
+        async with self._bus_lock:
+            if self._bus.connected:
+                return
+
+            await self._bus.connect()
+
+            try:
+                # Add signal listeners
+
+                self._bus.add_message_handler(self._parse_msg)
+
+                rules = MatchRules(
+                    interface=defs.OBJECT_MANAGER_INTERFACE,
+                    member="InterfacesAdded",
+                    arg0path="/org/bluez/",
+                )
+                reply = await add_match(self._bus, rules)
+                assert_reply(reply)
+
+                rules = MatchRules(
+                    interface=defs.OBJECT_MANAGER_INTERFACE,
+                    member="InterfacesRemoved",
+                    arg0path="/org/bluez/",
+                )
+                reply = await add_match(self._bus, rules)
+                assert_reply(reply)
+
+                rules = MatchRules(
+                    interface=defs.PROPERTIES_INTERFACE,
+                    member="PropertiesChanged",
+                    path_namespace="/org/bluez",
+                )
+                reply = await add_match(self._bus, rules)
+                assert_reply(reply)
+
+                # get existing objects after adding signal handlers to avoid
+                # race condition
+
+                reply = await self._bus.call(
+                    Message(
+                        destination=defs.BLUEZ_SERVICE,
+                        path="/",
+                        member="GetManagedObjects",
+                        interface=defs.OBJECT_MANAGER_INTERFACE,
+                    )
+                )
+                assert_reply(reply)
+
+                # dictionary is replaced in case AddInterfaces was received first
+                self._properties = {
+                    path: unpack_variants(interfaces)
+                    for path, interfaces in reply.body[0].items()
+                }
+
+                logger.debug(f"initial properties: {self._properties}")
+
+            except BaseException:
+                # if setup failed, disconnect
+                await self._bus.disconnect()
+                raise
+
+    async def active_scan(
+        self,
+        adapter_path: str,
+        filters: Dict[str, Variant],
+        callback: AdvertisementCallback,
+    ) -> Callable[[], Coroutine]:
+        """
+        Configures the advertisement data filters and starts scanning.
+
+        Args:
+            adapter_path: The D-Bus object path of the adapter to use for scanning.
+            filters: A dictionary of filters to pass to ``SetDiscoveryFilter``.
+            callback: A callable that will be called when new advertisement data is received.
+
+        Returns:
+            An async function that is used to stop scanning and remove the filters.
+        """
+        async with self._bus_lock:
+            callback_and_state = CallbackAndState(callback, adapter_path, set())
+            self._advertisement_callbacks.append(callback_and_state)
+
+            try:
+                # Apply the filters
+                reply = await self._bus.call(
+                    Message(
+                        destination=defs.BLUEZ_SERVICE,
+                        path=adapter_path,
+                        interface=defs.ADAPTER_INTERFACE,
+                        member="SetDiscoveryFilter",
+                        signature="a{sv}",
+                        body=[filters],
+                    )
+                )
+                assert_reply(reply)
+
+                # Start scanning
+                reply = await self._bus.call(
+                    Message(
+                        destination=defs.BLUEZ_SERVICE,
+                        path=adapter_path,
+                        interface=defs.ADAPTER_INTERFACE,
+                        member="StartDiscovery",
+                    )
+                )
+                assert_reply(reply)
+
+                async def stop() -> None:
+                    async with self._bus_lock:
+                        reply = await self._bus.call(
+                            Message(
+                                destination=defs.BLUEZ_SERVICE,
+                                path=adapter_path,
+                                interface=defs.ADAPTER_INTERFACE,
+                                member="StopDiscovery",
+                            )
+                        )
+                        assert_reply(reply)
+
+                        # remove the filters
+                        reply = await self._bus.call(
+                            Message(
+                                destination=defs.BLUEZ_SERVICE,
+                                path=adapter_path,
+                                interface=defs.ADAPTER_INTERFACE,
+                                member="SetDiscoveryFilter",
+                                signature="a{sv}",
+                                body=[{}],
+                            )
+                        )
+                        assert_reply(reply)
+
+                        self._advertisement_callbacks.remove(callback_and_state)
+
+                return stop
+            except BaseException:
+                # if starting scanning failed, don't leak the callback
+                self._advertisement_callbacks.remove(callback_and_state)
+                raise
+
+    def _parse_msg(self, message: Message):
+        """
+        Handles callbacks from dbus_next.
+        """
+
+        if message.message_type != MessageType.SIGNAL:
+            return
+
+        logger.debug(
+            f"received D-Bus signal: {message.interface}.{message.member} ({message.path}): {message.body}"
+        )
+
+        # type hints
+        obj_path: str
+        interfaces_and_props: Dict[str, Dict[str, Variant]]
+        interfaces: List[str]
+        interface: str
+        changed: Dict[str, Variant]
+        invalidated: List[str]
+
+        if message.member == "InterfacesAdded":
+            obj_path, interfaces_and_props = message.body
+
+            for interface, props in interfaces_and_props.items():
+                self._properties.setdefault(obj_path, {})[interface] = unpack_variants(
+                    props
+                )
+        elif message.member == "InterfacesRemoved":
+            obj_path, interfaces = message.body
+
+            for interface in interfaces:
+                del self._properties[obj_path][interface]
+        elif message.member == "PropertiesChanged":
+            assert message.path is not None
+
+            interface, changed, invalidated = message.body
+
+            try:
+                self_interface = self._properties[message.path][interface]
+            except KeyError:
+                # This can happen during initialization. The "PropertyChanged"
+                # handler is attached before "GetManagedObjects" is called
+                # and so self._properties may not yet be populated.
+                # This is not a problem. We just discard the property value
+                # since "GetManagedObjects" will return a newer value.
+                pass
+            else:
+                self_interface.update(unpack_variants(changed))
+
+                if interface == defs.DEVICE_INTERFACE:
+                    for (
+                        callback,
+                        adapter_path,
+                        seen_devices,
+                    ) in self._advertisement_callbacks:
+                        # filter messages from other adapters
+                        if not message.path.startswith(adapter_path):
+                            continue
+
+                        first_time_seen = False
+
+                        if message.path not in seen_devices:
+                            first_time_seen = True
+                            seen_devices.add(message.path)
+
+                        # Only do advertising data callback if this is the first time the
+                        # device has been seen or if an advertising data property changed.
+                        # Otherwise we get a flood of callbacks from RSSI changing.
+                        if (
+                            first_time_seen
+                            or not _ADVERTISING_DATA_PROPERTIES.isdisjoint(
+                                changed.keys()
+                            )
+                        ):
+                            # TODO: this should be deep copy, not shallow
+                            callback(message.path, cast(Device1, self_interface.copy()))
+
+                for name in invalidated:
+                    del self_interface[name]
+
+
+async def get_global_bluez_manager() -> BlueZManager:
+    """
+    Gets the initialized global BlueZ manager instance.
+    """
+
+    if not hasattr(get_global_bluez_manager, "instance"):
+        setattr(get_global_bluez_manager, "instance", BlueZManager())
+
+    instance: BlueZManager = getattr(get_global_bluez_manager, "instance")
+
+    await instance.async_init()
+
+    return instance

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -5,6 +5,7 @@ from dbus_next.aio import MessageBus
 from dbus_next.constants import BusType, MessageType
 from dbus_next.message import Message
 from dbus_next.signature import Variant
+from typing_extensions import Literal
 
 from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.signals import MatchRules, add_match, remove_match
@@ -65,6 +66,8 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             Optional list of service UUIDs to filter on. Only advertisements
             containing this advertising data will be received. Specifying this
             also enables scanning while the screen is off on Android.
+        scanning_mode:
+            Set to ``"passive"`` to avoid the ``"active"`` scanning mode.
         **adapter (str):
             Bluetooth adapter to use for discovery.
         **filters (dict):
@@ -75,9 +78,14 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         self,
         detection_callback: Optional[AdvertisementDataCallback] = None,
         service_uuids: Optional[List[str]] = None,
+        scanning_mode: Literal["active", "passive"] = "active",
         **kwargs,
     ):
         super(BleakScannerBlueZDBus, self).__init__(detection_callback, service_uuids)
+
+        if scanning_mode == "passive":
+            raise NotImplementedError
+
         # kwarg "device" is for backwards compatibility
         self._adapter = kwargs.get("adapter", kwargs.get("device", "hci0"))
 

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -14,7 +14,11 @@ from bleak.backends.bluezdbus.utils import (
     validate_address,
 )
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import BaseBleakScanner, AdvertisementData
+from bleak.backends.scanner import (
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+    AdvertisementData,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,10 +58,10 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
     <https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/adapter-api.txt?h=5.48&id=0d1e3b9c5754022c779da129025d493a198d49cf>`_
 
     Args:
-        **detection_callback (callable or coroutine):
+        detection_callback:
             Optional function that will be called each time a device is
             discovered or advertising data has changed.
-        **service_uuids (List[str]):
+        service_uuids:
             Optional list of service UUIDs to filter on. Only advertisements
             containing this advertising data will be received. Specifying this
             also enables scanning while the screen is off on Android.
@@ -67,8 +71,13 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             A dict of filters to be applied on discovery.
     """
 
-    def __init__(self, **kwargs):
-        super(BleakScannerBlueZDBus, self).__init__(**kwargs)
+    def __init__(
+        self,
+        detection_callback: Optional[AdvertisementDataCallback] = None,
+        service_uuids: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        super(BleakScannerBlueZDBus, self).__init__(detection_callback, service_uuids)
         # kwarg "device" is for backwards compatibility
         self._adapter = kwargs.get("adapter", kwargs.get("device", "hci0"))
 

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -1,54 +1,14 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Callable, Coroutine, Dict, List, Optional
 
-from dbus_next.aio import MessageBus
-from dbus_next.constants import BusType, MessageType
-from dbus_next.message import Message
-from dbus_next.signature import Variant
+from dbus_next import Variant
 from typing_extensions import Literal
 
-from bleak.backends.bluezdbus import defs
-from bleak.backends.bluezdbus.signals import MatchRules, add_match, remove_match
-from bleak.backends.bluezdbus.utils import (
-    assert_reply,
-    unpack_variants,
-    validate_address,
-)
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import (
-    AdvertisementDataCallback,
-    BaseBleakScanner,
-    AdvertisementData,
-)
+from ..device import BLEDevice
+from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
+from .manager import Device1, get_global_bluez_manager
 
 logger = logging.getLogger(__name__)
-
-# set of org.bluez.Device1 property names that come from advertising data
-_ADVERTISING_DATA_PROPERTIES = {
-    "AdvertisingData",
-    "AdvertisingFlags",
-    "ManufacturerData",
-    "Name",
-    "ServiceData",
-    "UUIDs",
-}
-
-
-def _device_info(path, props):
-    try:
-        name = props.get("Alias", "Unknown")
-        address = props.get("Address", None)
-        if address is None:
-            try:
-                address = path[-17:].replace("_", ":")
-                if not validate_address(address):
-                    address = None
-            except Exception:
-                address = None
-        rssi = props.get("RSSI", "?")
-        return name, address, rssi, path
-    except Exception:
-        return None, None, None, None
 
 
 class BleakScannerBlueZDBus(BaseBleakScanner):
@@ -88,123 +48,41 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         # kwarg "device" is for backwards compatibility
         self._adapter = kwargs.get("adapter", kwargs.get("device", "hci0"))
-
-        self._bus: Optional[MessageBus] = None
-        self._cached_devices: Dict[str, Variant] = {}
-        self._devices: Dict[str, Dict[str, Any]] = {}
-        self._rules: List[MatchRules] = []
         self._adapter_path: str = f"/org/bluez/{self._adapter}"
 
+        # map of d-bus object path to d-bus object properties
+        self._devices: Dict[str, Device1] = {}
+
+        # callback from manager for stopping scanning if it has been started
+        self._stop: Optional[Callable[[], Coroutine]] = None
+
         # Discovery filters
+
         self._filters: Dict[str, Variant] = {}
+
+        self._filters["Transport"] = Variant("s", "le")
+        self._filters["DuplicateData"] = Variant("b", False)
+
         if self._service_uuids:
             self._filters["UUIDs"] = Variant("as", self._service_uuids)
+
         self.set_scanning_filter(**kwargs)
 
     async def start(self):
-        self._bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        manager = await get_global_bluez_manager()
 
         self._devices.clear()
-        self._cached_devices.clear()
 
-        # Add signal listeners
-
-        self._bus.add_message_handler(self._parse_msg)
-
-        rules = MatchRules(
-            interface=defs.OBJECT_MANAGER_INTERFACE,
-            member="InterfacesAdded",
-            arg0path=f"{self._adapter_path}/",
+        self._stop = await manager.active_scan(
+            self._adapter_path, self._filters, self._handle_advertising_data
         )
-        reply = await add_match(self._bus, rules)
-        assert_reply(reply)
-        self._rules.append(rules)
-
-        rules = MatchRules(
-            interface=defs.OBJECT_MANAGER_INTERFACE,
-            member="InterfacesRemoved",
-            arg0path=f"{self._adapter_path}/",
-        )
-        reply = await add_match(self._bus, rules)
-        assert_reply(reply)
-        self._rules.append(rules)
-
-        rules = MatchRules(
-            interface=defs.PROPERTIES_INTERFACE,
-            member="PropertiesChanged",
-            path_namespace=self._adapter_path,
-        )
-        reply = await add_match(self._bus, rules)
-        assert_reply(reply)
-        self._rules.append(rules)
-
-        # Find the HCI device to use for scanning and get cached device properties
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path="/",
-                member="GetManagedObjects",
-                interface=defs.OBJECT_MANAGER_INTERFACE,
-            )
-        )
-        assert_reply(reply)
-
-        # get only the device interface
-        self._cached_devices = {
-            path: unpack_variants(interfaces[defs.DEVICE_INTERFACE])
-            for path, interfaces in reply.body[0].items()
-            if defs.DEVICE_INTERFACE in interfaces
-        }
-
-        logger.debug(f"cached devices: {self._cached_devices}")
-
-        # Apply the filters
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path=self._adapter_path,
-                interface=defs.ADAPTER_INTERFACE,
-                member="SetDiscoveryFilter",
-                signature="a{sv}",
-                body=[self._filters],
-            )
-        )
-        assert_reply(reply)
-
-        # Start scanning
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path=self._adapter_path,
-                interface=defs.ADAPTER_INTERFACE,
-                member="StartDiscovery",
-            )
-        )
-        assert_reply(reply)
 
     async def stop(self):
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path=self._adapter_path,
-                interface=defs.ADAPTER_INTERFACE,
-                member="StopDiscovery",
-            )
-        )
-        assert_reply(reply)
+        if self._stop:
+            # avoid reentrancy
+            stop, self._stop = self._stop, None
 
-        for rule in self._rules:
-            await remove_match(self._bus, rule)
-        self._rules.clear()
-        self._bus.remove_message_handler(self._parse_msg)
-
-        # Try to disconnect the System Bus.
-        try:
-            self._bus.disconnect()
-        except Exception as e:
-            logger.error("Attempt to disconnect system bus failed: {0}".format(e))
-
-        self._bus = None
+            await stop()
 
     def set_scanning_filter(self, **kwargs):
         """Sets OS level scanning filters for the BleakScanner.
@@ -237,9 +115,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             else:
                 logger.warning("Filter '%s' is not currently supported." % k)
 
-        if "Transport" not in self._filters:
-            self._filters["Transport"] = Variant("s", "le")
-
     @property
     def discovered_devices(self) -> List[BLEDevice]:
         # Reduce output.
@@ -250,15 +125,13 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
                     "Disregarding %s since no properties could be obtained." % path
                 )
                 continue
-            name, address, _, path = _device_info(path, props)
-            if address is None:
-                continue
+
             uuids = props.get("UUIDs", [])
             manufacturer_data = props.get("ManufacturerData", {})
             discovered_devices.append(
                 BLEDevice(
-                    address,
-                    name,
+                    props["Address"],
+                    props["Alias"],
                     {"path": path, "props": props},
                     props.get("RSSI", 0),
                     uuids=uuids,
@@ -269,16 +142,19 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
     # Helper methods
 
-    def _invoke_callback(self, path: str, message: Message) -> None:
-        """Invokes the advertising data callback.
+    def _handle_advertising_data(self, path: str, props: Device1) -> None:
+        """
+        Handles advertising data received from the BlueZ manager instance.
 
         Args:
-            message: The D-Bus message that triggered the callback.
+            path: The D-Bus object path of the device.
+            props: The D-Bus object properties of the device.
         """
+
+        self._devices[path] = props
+
         if self._callback is None:
             return
-
-        props = self._devices[path]
 
         # Get all the information wanted to pack in the advertisement data
         _local_name = props.get("Name")
@@ -294,7 +170,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             manufacturer_data=_manufacturer_data,
             service_data=_service_data,
             service_uuids=_service_uuids,
-            platform_data=(props, message),
+            platform_data=props,
         )
 
         device = BLEDevice(
@@ -307,76 +183,3 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         )
 
         self._callback(device, advertisement_data)
-
-    def _parse_msg(self, message: Message):
-        if message.message_type != MessageType.SIGNAL:
-            return
-
-        logger.debug(
-            "received D-Bus signal: {0}.{1} ({2}): {3}".format(
-                message.interface, message.member, message.path, message.body
-            )
-        )
-
-        if message.member == "InterfacesAdded":
-            # if a new device is discovered while we are scanning, add it to
-            # the discovered devices list
-
-            obj_path: str
-            interfaces_and_props: Dict[str, Dict[str, Variant]]
-            obj_path, interfaces_and_props = message.body
-            device_props = unpack_variants(
-                interfaces_and_props.get(defs.DEVICE_INTERFACE, {})
-            )
-            if device_props:
-                self._devices[obj_path] = device_props
-                self._invoke_callback(obj_path, message)
-        elif message.member == "InterfacesRemoved":
-            # if a device disappears while we are scanning, remove it from the
-            # discovered devices list
-
-            obj_path: str
-            interfaces: List[str]
-            obj_path, interfaces = message.body
-
-            if defs.DEVICE_INTERFACE in interfaces:
-                # Using pop to avoid KeyError if obj_path does not exist
-                self._devices.pop(obj_path, None)
-        elif message.member == "PropertiesChanged":
-            # Property change events basically mean that new advertising data
-            # was received or the RSSI changed. Either way, it lets us know
-            # that the device is active and we can add it to the discovered
-            # devices list.
-
-            interface: str
-            changed: Dict[str, Variant]
-            invalidated: List[str]
-            interface, changed, invalidated = message.body
-
-            if interface != defs.DEVICE_INTERFACE:
-                return
-
-            first_time_seen = False
-
-            if message.path not in self._devices:
-                if message.path not in self._cached_devices:
-                    # This can happen when we start scanning. The "PropertyChanged"
-                    # handler is attached before "GetManagedObjects" is called
-                    # and so self._cached_devices is not assigned yet.
-                    # This is not a problem. We just discard the property value
-                    # since "GetManagedObjects" will return a newer value.
-                    return
-
-                first_time_seen = True
-                self._devices[message.path] = self._cached_devices[message.path]
-
-            changed = unpack_variants(changed)
-            self._devices[message.path].update(changed)
-
-            # Only do advertising data callback if this is the first time the
-            # device has been seen or if an advertising data property changed.
-            # Otherwise we get a flood of callbacks from RSSI changing.
-            if first_time_seen or not _ADVERTISING_DATA_PROPERTIES.isdisjoint(
-                changed.keys()
-            ):
-                self._invoke_callback(message.path, message)

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -6,8 +6,7 @@ from dbus_next.constants import MessageType
 from dbus_next.message import Message
 from dbus_next.signature import Variant
 
-from bleak import BleakError
-from bleak.exc import BleakDBusError
+from ...exc import BleakError, BleakDBusError
 
 _address_regex = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
 

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import objc
 from Foundation import NSArray, NSUUID, NSBundle
 from CoreBluetooth import CBPeripheral
+from typing_extensions import Literal
 
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
@@ -13,6 +14,7 @@ from bleak.backends.scanner import (
     BaseBleakScanner,
     AdvertisementData,
 )
+from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,10 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
             Optional list of service UUIDs to filter on. Only advertisements
             containing this advertising data will be received. Required on
             macOS >= 12.0, < 12.3 (unless you create an app with ``py2app``).
+        scanning_mode:
+            Set to ``"passive"`` to avoid the ``"active"`` scanning mode. Not
+            supported on macOS! Will raise :class:`BleakError` if set to
+            ``"passive"``
         **timeout (float):
              The scanning timeout to be used, in case of missing
             ``stopScan_`` method.
@@ -45,11 +51,16 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         self,
         detection_callback: Optional[AdvertisementDataCallback] = None,
         service_uuids: Optional[List[str]] = None,
+        scanning_mode: Literal["active", "passive"] = "active",
         **kwargs
     ):
         super(BleakScannerCoreBluetooth, self).__init__(
             detection_callback, service_uuids
         )
+
+        if scanning_mode == "passive":
+            raise BleakError("macOS does not support passive scanning")
+
         self._identifiers: Optional[Dict[NSUUID, Dict[str, Any]]] = None
         self._manager = CentralManagerDelegate.alloc().init()
         self._timeout: float = kwargs.get("timeout", 5.0)

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -8,7 +8,11 @@ from CoreBluetooth import CBPeripheral
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import BaseBleakScanner, AdvertisementData
+from bleak.backends.scanner import (
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+    AdvertisementData,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -25,19 +29,27 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
     this for the BLEDevice address on macOS.
 
     Args:
-        **timeout (double): The scanning timeout to be used, in case of missing
-          ``stopScan_`` method.
-        **detection_callback (callable or coroutine):
+        detection_callback:
             Optional function that will be called each time a device is
             discovered or advertising data has changed.
-        **service_uuids (List[str]):
+        service_uuids:
             Optional list of service UUIDs to filter on. Only advertisements
             containing this advertising data will be received. Required on
-            macOS 12 and later (unless you create an app with ``py2app``).
+            macOS >= 12.0, < 12.3 (unless you create an app with ``py2app``).
+        **timeout (float):
+             The scanning timeout to be used, in case of missing
+            ``stopScan_`` method.
     """
 
-    def __init__(self, **kwargs):
-        super(BleakScannerCoreBluetooth, self).__init__(**kwargs)
+    def __init__(
+        self,
+        detection_callback: Optional[AdvertisementDataCallback] = None,
+        service_uuids: Optional[List[str]] = None,
+        **kwargs
+    ):
+        super(BleakScannerCoreBluetooth, self).__init__(
+            detection_callback, service_uuids
+        )
         self._identifiers: Optional[Dict[NSUUID, Dict[str, Any]]] = None
         self._manager = CentralManagerDelegate.alloc().init()
         self._timeout: float = kwargs.get("timeout", 5.0)

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -2,10 +2,14 @@
 
 import asyncio
 import logging
-from typing import List
+from typing import List, Optional
 import warnings
 
-from bleak.backends.scanner import BaseBleakScanner, AdvertisementData
+from bleak.backends.scanner import (
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+    AdvertisementData,
+)
 from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
 
@@ -24,10 +28,10 @@ class BleakScannerP4Android(BaseBleakScanner):
     The python-for-android Bleak BLE Scanner.
 
     Args:
-        **detection_callback (callable or coroutine):
+        detection_callback:
             Optional function that will be called each time a device is
             discovered or advertising data has changed.
-        **service_uuids (List[str]):
+        service_uuids:
             Optional list of service UUIDs to filter on. Only advertisements
             containing this advertising data will be received. Specifying this
             also enables scanning while the screen is off on Android.
@@ -35,8 +39,13 @@ class BleakScannerP4Android(BaseBleakScanner):
 
     __scanner = None
 
-    def __init__(self, **kwargs):
-        super(BleakScannerP4Android, self).__init__(**kwargs)
+    def __init__(
+        self,
+        detection_callback: Optional[AdvertisementDataCallback] = None,
+        service_uuids: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        super(BleakScannerP4Android, self).__init__(detection_callback, service_uuids)
 
         self._devices = {}
         self.__adapter = None

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -72,23 +72,24 @@ class BaseBleakScanner(abc.ABC):
     Interface for Bleak Bluetooth LE Scanners
 
     Args:
-        **detection_callback (callable or coroutine):
+        detection_callback:
             Optional function that will be called each time a device is
             discovered or advertising data has changed.
-        **service_uuids (List[str]):
+        service_uuids:
             Optional list of service UUIDs to filter on. Only advertisements
-            containing this advertising data will be received. Required on
-            macOS 12 and later.
+            containing this advertising data will be received.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self,
+        detection_callback: Optional[AdvertisementDataCallback],
+        service_uuids: Optional[List[str]],
+    ):
         super(BaseBleakScanner, self).__init__()
         self._callback: Optional[AdvertisementDataCallback] = None
-        self.register_detection_callback(kwargs.get("detection_callback"))
+        self.register_detection_callback(detection_callback)
         self._service_uuids: Optional[List[str]] = (
-            [u.lower() for u in kwargs["service_uuids"]]
-            if "service_uuids" in kwargs
-            else None
+            [u.lower() for u in service_uuids] if service_uuids is not None else None
         )
 
     async def __aenter__(self):

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -11,12 +11,9 @@ from bleak_winrt.windows.devices.bluetooth.advertisement import (
 )
 from typing_extensions import Literal
 
-from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import (
-    AdvertisementDataCallback,
-    BaseBleakScanner,
-    AdvertisementData,
-)
+from ..device import BLEDevice
+from ..scanner import AdvertisementDataCallback, BaseBleakScanner, AdvertisementData
+from ...assigned_numbers import AdvertisementDataType
 
 
 logger = logging.getLogger(__name__)
@@ -141,20 +138,23 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         # Decode service data
         for args in filter(lambda d: d is not None, raw_data):
-            # 0x16 is service data with 16-bit UUID
-            for section in args.advertisement.get_sections_by_type(0x16):
+            for section in args.advertisement.get_sections_by_type(
+                AdvertisementDataType.SERVICE_DATA_UUID16
+            ):
                 data = bytes(section.data)
                 service_data[
                     f"0000{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
                 ] = data[2:]
-            # 0x20 is service data with 32-bit UUID
-            for section in args.advertisement.get_sections_by_type(0x20):
+            for section in args.advertisement.get_sections_by_type(
+                AdvertisementDataType.SERVICE_DATA_UUID32
+            ):
                 data = bytes(section.data)
                 service_data[
                     f"{data[3]:02x}{data[2]:02x}{data[1]:02x}{data[0]:02x}-0000-1000-8000-00805f9b34fb"
                 ] = data[4:]
-            # 0x21 is service data with 128-bit UUID
-            for section in args.advertisement.get_sections_by_type(0x21):
+            for section in args.advertisement.get_sections_by_type(
+                AdvertisementDataType.SERVICE_DATA_UUID128
+            ):
                 data = bytes(section.data)
                 service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
 

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -11,7 +11,11 @@ from bleak_winrt.windows.devices.bluetooth.advertisement import (
 )
 
 from bleak.backends.device import BLEDevice
-from bleak.backends.scanner import BaseBleakScanner, AdvertisementData
+from bleak.backends.scanner import (
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+    AdvertisementData,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -53,13 +57,25 @@ class BleakScannerWinRT(BaseBleakScanner):
 
     Implemented using `Python/WinRT <https://github.com/Microsoft/xlang/tree/master/src/package/pywinrt/projection/>`_.
 
-    Keyword Args:
-        scanning mode (str): Set to "Passive" to avoid the "Active" scanning mode.
+    Args:
+        detection_callback:
+            Optional function that will be called each time a device is
+            discovered or advertising data has changed.
+        service_uuids:
+            Optional list of service UUIDs to filter on. Only advertisements
+            containing this advertising data will be received.
+        **scanning_mode (str):
+            Set to "Passive" to avoid the "Active" scanning mode.
 
     """
 
-    def __init__(self, **kwargs):
-        super(BleakScannerWinRT, self).__init__(**kwargs)
+    def __init__(
+        self,
+        detection_callback: Optional[AdvertisementDataCallback] = None,
+        service_uuids: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        super(BleakScannerWinRT, self).__init__(detection_callback, service_uuids)
 
         self.watcher = None
         self._stopped_event = None

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -9,6 +9,7 @@ from bleak_winrt.windows.devices.bluetooth.advertisement import (
     BluetoothLEAdvertisementReceivedEventArgs,
     BluetoothLEAdvertisementType,
 )
+from typing_extensions import Literal
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import (
@@ -64,8 +65,8 @@ class BleakScannerWinRT(BaseBleakScanner):
         service_uuids:
             Optional list of service UUIDs to filter on. Only advertisements
             containing this advertising data will be received.
-        **scanning_mode (str):
-            Set to "Passive" to avoid the "Active" scanning mode.
+        scanning_mode:
+            Set to ``"passive"`` to avoid the ``"active"`` scanning mode.
 
     """
 
@@ -73,6 +74,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         self,
         detection_callback: Optional[AdvertisementDataCallback] = None,
         service_uuids: Optional[List[str]] = None,
+        scanning_mode: Literal["active", "passive"] = "active",
         **kwargs,
     ):
         super(BleakScannerWinRT, self).__init__(detection_callback, service_uuids)
@@ -81,7 +83,8 @@ class BleakScannerWinRT(BaseBleakScanner):
         self._stopped_event = None
         self._discovered_devices: Dict[int, _RawAdvData] = {}
 
-        if "scanning_mode" in kwargs and kwargs["scanning_mode"].lower() == "passive":
+        # case insensitivity is for backwards compatibility on Windows only
+        if scanning_mode.lower() == "passive":
             self._scanning_mode = BluetoothLEScanningMode.PASSIVE
         else:
             self._scanning_mode = BluetoothLEScanningMode.ACTIVE

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -66,8 +66,7 @@ or separately, calling ``start`` and ``stop`` methods on the scanner manually:
         print(device.address, "RSSI:", device.rssi, advertisement_data)
 
     async def main():
-        scanner = BleakScanner()
-        scanner.register_detection_callback(detection_callback)
+        scanner = BleakScanner(detection_callback)
         await scanner.start()
         await asyncio.sleep(5.0)
         await scanner.stop()

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -24,8 +24,7 @@ def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
 
 
 async def main(service_uuids):
-    scanner = BleakScanner(service_uuids=service_uuids)
-    scanner.register_detection_callback(simple_callback)
+    scanner = BleakScanner(simple_callback, service_uuids)
 
     while True:
         print("(re)starting scanner")

--- a/examples/mtu_size.py
+++ b/examples/mtu_size.py
@@ -18,7 +18,7 @@ async def main():
         # can use advertising data to filter here
         queue.put_nowait(device)
 
-    async with BleakScanner(detection_callback=callback):
+    async with BleakScanner(callback):
         # get the first matching device
         device = await queue.get()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+typing-extensions>=4.2.0
 dbus-next>=0.2.2; sys_platform=="linux"
 pyobjc-core>=7.0.1;sys_platform == 'darwin'
 pyobjc-framework-CoreBluetooth>=7.0.1;sys_platform == 'darwin'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,3 +12,4 @@ sphinx-rtd-theme>=1.0.0
 PyYAML>=3.13
 pytest>=3.9.2
 pytest-cov>=2.5.1
+typing-extensions>=4.2.0

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ EMAIL = "henrik.blidh@nedomkull.com"
 AUTHOR = "Henrik Blidh"
 
 REQUIRED = [
+    "typing-extensions>=4.2.0",
     # Linux reqs
     'dbus-next;platform_system=="Linux"',
     # macOS reqs


### PR DESCRIPTION
This implements passive scanning in the BlueZ backend using the experimental [advertisement monitor api](https://github.com/bluez/bluez/blob/master/doc/advertisement-monitor-api.txt).

Fixes #606.

This PR also includes some improvements to the argument handling of the `BleakScanner` constructor that lays the groundwork for the new args required by this new feature. It also includes a new global BlueZ state manager which, in addition to making the passive scanning feature trivial to implement, will be useful in fixing other long-standing BlueZ issues.

There are a number of technical restrictions for using the BlueZ advertisement monitor api (I've tried to make useful error messages to guide users). The following should probably be added to the docs:

System requirements are BlueZ >= 5.56 and Linux kernel >= 5.10.

To enable experimental features in BlueZ on an OS that uses systemd, run the following command:

    sudo systemctl edit bluetooth.service

... then add the following (first `ExecStart=` is not a typo and must not be omitted  - refer to `man systemd.exec`) ...

```
[Service]
ExecStart=
ExecStart=/usr/lib/bluetooth/bluetoothd --experimental
```

Then save and close the file and then run the following commands:

    sudo systemctl dameon-reload
    sudo systemctl restart bluetooth.service


Due to technical restrictions in the current BlueZ implementation, filters are required, so this cannot be used to discover all devices. Filters are supplied via the backend-specific `bluez` keyword argument.

Here is a modified version of the `detection_callback.py` example to show how this works:

```python
import asyncio
import logging
import sys

from bleak import BleakScanner
from bleak.assigned_numbers import AdvertisementDataType
from bleak.backends.bluezdbus.advertisement_monitor import OrPattern
from bleak.backends.bluezdbus.scanner import BlueZArgs
from bleak.backends.device import BLEDevice
from bleak.backends.scanner import AdvertisementData

logger = logging.getLogger(__name__)


def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
    logger.info(f"{device.address} RSSI: {device.rssi}, {advertisement_data}")


async def main(service_uuids):
    scanner = BleakScanner(
        simple_callback,
        service_uuids,
        # select passive scanning
        scanning_mode="passive",
        # at least one or_pattern is required, otherwise BlueZ will (silently) reject the advertisement monitor
        # (bleak will check for the condition and raise an exception since BlueZ is silent on the matter)
        bluez=BlueZArgs(
            or_patterns=[
                OrPattern(0, AdvertisementDataType.FLAGS, b"\x06"),
                OrPattern(0, AdvertisementDataType.FLAGS, b"\x1a"),
            ]
        ),
    )

    while True:
        print("(re)starting scanner")
        await scanner.start()
        await asyncio.sleep(5.0)
        await scanner.stop()


if __name__ == "__main__":
    logging.basicConfig(
        level=logging.INFO,
        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
    )
    service_uuids = sys.argv[1:]
    asyncio.run(main(service_uuids))
```
