### PR TITLE
Adjust read timeout with corebluetooth to 10s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Changed
 * Add `py.typed` file so mypy discovers Bleak's type annotations
 * UUID descriptions updated to 2022-03-16 assigned numbers document
 * Replace use of deprecated ``asyncio.get_event_loop()`` in Android backend.
+* Adjust default timeout for read_gatt_char with CoreBluetooth to 10s
 
 
 `0.14.3`_ (2022-04-29)

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -131,7 +131,10 @@ class PeripheralDelegate(NSObject):
 
     @objc.python_method
     async def read_characteristic(
-        self, characteristic: CBCharacteristic, use_cached: bool = True
+        self,
+        characteristic: CBCharacteristic,
+        use_cached: bool = True,
+        timeout: int = 10,
     ) -> NSData:
         if characteristic.value() is not None and use_cached:
             return characteristic.value()
@@ -141,7 +144,7 @@ class PeripheralDelegate(NSObject):
         self._characteristic_read_futures[characteristic.handle()] = future
         try:
             self.peripheral.readValueForCharacteristic_(characteristic)
-            return await asyncio.wait_for(future, timeout=5)
+            return await asyncio.wait_for(future, timeout=timeout)
         finally:
             del self._characteristic_read_futures[characteristic.handle()]
 


### PR DESCRIPTION
Adjust read timeout with corebluetooth to 10s

5s would result in quite a few random failures with
HomeKit BLE devices because the device would have to
process a large dump of fragments which make it slow
to respond

Fixes https://github.com/Jc2k/aiohomekit/issues/111

Example of code that slows down the device with many
encrypted writes before waiting for a read
https://github.com/Jc2k/aiohomekit/blob/0e22b4e0a16d6b01da2e65bfce99fb01b4c1c7f3/aiohomekit/controller/ble/client.py#L117