### PR TITLE
Fix documentation of raised error

### DIFF
--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -46,7 +46,7 @@ def assert_bus_name_valid(type: str):
     :type name: str
 
     :raises:
-        - :class:`InvalidBusNameError` - If this is not a valid message type.
+        - :class:`InvalidMessageTypeError` - If this is not a valid message type.
     """
     if not is_message_type_valid(type):
         raise InvalidMessageTypeError(type)


### PR DESCRIPTION
Simple fix in documentation of method describing the error that could be raised.
