### PR TITLE
Fix for method named to use to determine MTU Size

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -564,7 +564,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """Get ATT MTU size for active connection"""
         if self._mtu_size is None:
             warnings.warn(
-                "Using default MTU value. Call _assign_mtu() or set _mtu_size first to avoid this warning."
+                "Using default MTU value. Call _acquire_mtu() or set _mtu_size first to avoid this warning."
             )
             return 23
 


### PR DESCRIPTION
Fix for method named to use to determine MTU Size as provided in warning for BlueZ backend.

There is actually no `_assign_mtu()` method at all in Bleak, while there is an `_acquire_mtu()` method that is supposed to determine the MTU Size on the BlueZ backend.