### PR TITLE
bluezdbus/manager: add adapter check and error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Added
 * Added option to use cached services, characteristics and descriptors in WinRT backend. Fixes #686.
 * Added ``PendingDeprecationWarning`` to use of ``address_type`` as keyword argument. It will be moved into the
   ``win`` keyword instead according to #623.
+* Added better error message when adapter is not present in BlueZ backend. Fixes #889.
 
 Changed
 -------

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -309,6 +309,12 @@ class BlueZManager:
             An async function that is used to stop scanning and remove the filters.
         """
         async with self._bus_lock:
+            # If the adapter doesn't exist, then the message calls below would
+            # fail with "method not found". This provides a more informative
+            # error message.
+            if adapter_path not in self._properties:
+                raise BleakError(f"adapter '{adapter_path.split('/')[-1]}' not found")
+
             callback_and_state = CallbackAndState(callback, adapter_path, set())
             self._advertisement_callbacks.append(callback_and_state)
 
@@ -388,6 +394,12 @@ class BlueZManager:
             An async function that is used to stop scanning and remove the filters.
         """
         async with self._bus_lock:
+            # If the adapter doesn't exist, then the message calls below would
+            # fail with "method not found". This provides a more informative
+            # error message.
+            if adapter_path not in self._properties:
+                raise BleakError(f"adapter '{adapter_path.split('/')[-1]}' not found")
+
             callback_and_state = CallbackAndState(callback, adapter_path, set())
             self._advertisement_callbacks.append(callback_and_state)
 


### PR DESCRIPTION
This adds a better error message when an adapter is missing on the BlueZ backend. Instead of getting a D-Bus method not found error, it will actually say what the real problem is - the adapter is not present.

Fixes #889.