### PR TITLE
[bluezdbus] Handle errors checking bluetoothctl version

### DIFF
--- a/bleak/backends/bluezdbus/__init__.py
+++ b/bleak/backends/bluezdbus/__init__.py
@@ -14,8 +14,12 @@ def check_bluez_version(major: int, minor: int) -> bool:
     """
     # lazy-get the version and store it so we only have to run subprocess once
     if not hasattr(check_bluez_version, "version"):
-        p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
-        out, _ = p.communicate()
+        try:
+            p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
+            out, _ = p.communicate()
+        except OSError as err:
+            raise BleakError(f"Error determining BlueZ version: {err}") from err
+
         s = re.search(b"(\\d+).(\\d+)", out.strip(b"'"))
 
         if not s:


### PR DESCRIPTION
Pull Request Guidelines for Bleak
---------------------------------

`subprocess.Popen` can raise `OSError` ([docs](https://docs.python.org/3/library/subprocess.html#exceptions)). This catches these errors and re-raises them as BleakError.

Stack trace from [Home Assistant issue tracker](https://github.com/home-assistant/core/issues/75706):
```
Logger: homeassistant.loader
Source: components/bluetooth/__init__.py:12
First occurred: 3:11:57 PM (1 occurrences)
Last logged: 3:11:57 PM

Unexpected exception importing component homeassistant.components.bluetooth
Traceback (most recent call last):
  File "/home/amiller/Git/Hass/src/homeassistant/loader.py", line 638, in get_component
    cache[self.domain] = importlib.import_module(self.pkg_path)
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/amiller/Git/Hass/src/homeassistant/components/bluetooth/__init__.py", line 12, in <module>
    from bleak import BleakError
  File "/home/amiller/Git/Hass/src/venv/lib64/python3.9/site-packages/bleak/__init__.py", line 41, in <module>
    if not _on_ci and not check_bluez_version(5, 43):
  File "/home/amiller/Git/Hass/src/venv/lib64/python3.9/site-packages/bleak/backends/bluezdbus/__init__.py", line 17, in check_bluez_version
    p = subprocess.Popen(["bluetoothctl", "--version"], stdout=subprocess.PIPE)
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'bluetoothctl'
```