### PR TITLE
Make callback logging lazy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Made BlueZ D-Bus signal callback logging lazy to improve performance.
+
+
 `0.15.0`_ (2022-07-29)
 ======================
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -669,7 +669,11 @@ class BlueZManager:
             return
 
         logger.debug(
-            f"received D-Bus signal: {message.interface}.{message.member} ({message.path}): {message.body}"
+            "received D-Bus signal: %s.%s (%s): %s",
+            message.interface,
+            message.member,
+            message.path,
+            message.body,
         )
 
         # type hints


### PR DESCRIPTION
Fixes logging-format-interpolation (W1202)

Fixes `__repr__` being called and thrown away
<img width="730" alt="Screen Shot 2022-07-31 at 4 06 25 PM" src="https://user-images.githubusercontent.com/663432/182058719-03cff18a-38a7-491e-8eab-402dd908df50.png">

