### PR TITLE
Fix disconnect in the global BlueZ manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 * Made BlueZ D-Bus signal callback logging lazy to improve performance.
-
+* The global BlueZ manager now disconnects correctly on exception.
 
 `0.15.0`_ (2022-07-29)
 ======================

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -341,7 +341,7 @@ class BlueZManager:
 
             except BaseException:
                 # if setup failed, disconnect
-                await self._bus.disconnect()
+                self._bus.disconnect()
                 raise
 
     async def active_scan(


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 357, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 253, in async_setup_entry
    await manager.async_start(
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 343, in async_start
    await self.scanner.start()  # type: ignore[no-untyped-call]
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/scanner.py", line 128, in start
    manager = await get_global_bluez_manager()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 808, in get_global_bluez_manager
    await instance.async_init()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 344, in async_init
    await self._bus.disconnect()
TypeError: object NoneType can't be used in 'await' expression

```
