### PR TITLE
Handle the race in the BlueZ D-Bus backend where the device disconnects during the connection process

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 * Made BlueZ D-Bus signal callback logging lazy to improve performance.
-
+* Handle the race in the BlueZ D-Bus backend where the device disconnects during the connection process which presented as ``Failed to cancel connection``
 
 `0.15.0`_ (2022-07-29)
 ======================


### PR DESCRIPTION
Fixes
```
Logger: bleak.backends.bluezdbus.client
Source: components/switchbot/cover.py:94
First occurred: 10:36:23 (1 occurrences)
Last logged: 10:36:23
Failed to cancel connection (/org/bluez/hci0/dev_XX_XX_XX_XX_XX_XX): 'NoneType' object has no attribute 'call'
```