### PR TITLE
Avoid reusing the MessageBus in the manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 * Made BlueZ D-Bus signal callback logging lazy to improve performance.
+* Ensure the BlueZ D-Bus scanner can reconnect after DBus disconnection.
 
 
 `0.15.0`_ (2022-07-29)

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -17,6 +17,7 @@ from typing import (
     Iterable,
     List,
     NamedTuple,
+    Optional,
     Set,
     Tuple,
     cast,
@@ -266,7 +267,7 @@ class BlueZManager:
     """
 
     def __init__(self):
-        self._bus = MessageBus(bus_type=BusType.SYSTEM)
+        self._bus: Optional[MessageBus] = None
         self._bus_lock = asyncio.Lock()
 
         # dict of object path: dict of interface name: dict of property name: property value
@@ -284,22 +285,26 @@ class BlueZManager:
         connected, no action is performed.
         """
         async with self._bus_lock:
-            if self._bus.connected:
+            if self._bus and self._bus.connected:
                 return
 
-            await self._bus.connect()
+            # We need to create a new MessageBus each time as
+            # dbus-next will destory the underlying file descriptors
+            # when the previous one is closed in its finalizer.
+            bus = MessageBus(bus_type=BusType.SYSTEM)
+            await bus.connect()
 
             try:
                 # Add signal listeners
 
-                self._bus.add_message_handler(self._parse_msg)
+                bus.add_message_handler(self._parse_msg)
 
                 rules = MatchRules(
                     interface=defs.OBJECT_MANAGER_INTERFACE,
                     member="InterfacesAdded",
                     arg0path="/org/bluez/",
                 )
-                reply = await add_match(self._bus, rules)
+                reply = await add_match(bus, rules)
                 assert_reply(reply)
 
                 rules = MatchRules(
@@ -307,7 +312,7 @@ class BlueZManager:
                     member="InterfacesRemoved",
                     arg0path="/org/bluez/",
                 )
-                reply = await add_match(self._bus, rules)
+                reply = await add_match(bus, rules)
                 assert_reply(reply)
 
                 rules = MatchRules(
@@ -315,13 +320,13 @@ class BlueZManager:
                     member="PropertiesChanged",
                     path_namespace="/org/bluez",
                 )
-                reply = await add_match(self._bus, rules)
+                reply = await add_match(bus, rules)
                 assert_reply(reply)
 
                 # get existing objects after adding signal handlers to avoid
                 # race condition
 
-                reply = await self._bus.call(
+                reply = await bus.call(
                     Message(
                         destination=defs.BLUEZ_SERVICE,
                         path="/",
@@ -341,8 +346,11 @@ class BlueZManager:
 
             except BaseException:
                 # if setup failed, disconnect
-                await self._bus.disconnect()
+                bus.disconnect()
                 raise
+
+            # Everything is setup, so save the bus
+            self._bus = bus
 
     async def active_scan(
         self,


### PR DESCRIPTION
When the dbus socket gets disconnected from dbus, we cannot
reuse the connection because dbus-next finalize will remove
the underlying fds

Fixes
```
2022-08-02 09:29:00.722 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Bluetooth for bluetooth
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 357, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 253, in async_setup_entry
    await manager.async_start(
  File "/usr/src/homeassistant/homeassistant/components/bluetooth/__init__.py", line 343, in async_start
    await self.scanner.start()  # type: ignore[no-untyped-call]
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/scanner.py", line 128, in start
    manager = await get_global_bluez_manager()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 808, in get_global_bluez_manager
    await instance.async_init()
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 290, in async_init
    await self._bus.connect()
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 149, in connect
    await self._authenticate()
  File "/usr/local/lib/python3.10/site-packages/dbus_next/aio/message_bus.py", line 380, in _authenticate
    await self._loop.sock_sendall(self._sock, b0)
  File "/usr/local/lib/python3.10/asyncio/selector_events.py", line 441, in sock_sendall
    n = sock.send(data)
BrokenPipeError: [Errno 32] Broken pipe
```
