### PR TITLE
Release/v0.15.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Fixed
 * The global BlueZ manager now disconnects correctly on exception. Merged #918.
 * Handle the race in the BlueZ D-Bus backend where the device disconnects during
   the connection process which presented as ``Failed to cancel connection``. Merged #919.
+* Ensure the BlueZ D-Bus scanner can reconnect after DBus disconnection. Merged #920.
+
 
 `0.15.0`_ (2022-07-29)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* The global BlueZ manager now disconnects correctly on exception. Merged #918.
+
 `0.15.0`_ (2022-07-29)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -723,7 +723,7 @@ Fixed
 
 
 .. _Unreleased: https://github.com/hbldh/bleak/compare/v0.15.1...develop
-.. _0.15.1: https://github.com/hbldh/bleak/compare/v0.14.3...v0.15.1
+.. _0.15.1: https://github.com/hbldh/bleak/compare/v0.15.0...v0.15.1
 .. _0.15.0: https://github.com/hbldh/bleak/compare/v0.14.3...v0.15.0
 .. _0.14.3: https://github.com/hbldh/bleak/compare/v0.14.2...v0.14.3
 .. _0.14.2: https://github.com/hbldh/bleak/compare/v0.14.1...v0.14.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,9 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+`0.15.1`_ (2022-08-03)
+======================
+
 Fixed
 -----
 * The global BlueZ manager now disconnects correctly on exception. Merged #918.
@@ -719,7 +722,8 @@ Fixed
 * Bleak created.
 
 
-.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.15.0...develop
+.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.15.1...develop
+.. _0.15.1: https://github.com/hbldh/bleak/compare/v0.14.3...v0.15.1
 .. _0.15.0: https://github.com/hbldh/bleak/compare/v0.14.3...v0.15.0
 .. _0.14.3: https://github.com/hbldh/bleak/compare/v0.14.2...v0.14.3
 .. _0.14.2: https://github.com/hbldh/bleak/compare/v0.14.1...v0.14.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 * The global BlueZ manager now disconnects correctly on exception. Merged #918.
+* Handle the race in the BlueZ D-Bus backend where the device disconnects during
+  the connection process which presented as ``Failed to cancel connection``. Merged #919.
 
 `0.15.0`_ (2022-07-29)
 ======================

--- a/bleak/__version__.py
+++ b/bleak/__version__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -341,7 +341,7 @@ class BlueZManager:
 
             except BaseException:
                 # if setup failed, disconnect
-                await self._bus.disconnect()
+                self._bus.disconnect()
                 raise
 
     async def active_scan(


### PR DESCRIPTION

Fixed
-----
* The global BlueZ manager now disconnects correctly on exception. Merged #918.
* Handle the race in the BlueZ D-Bus backend where the device disconnects during
  the connection process which presented as ``Failed to cancel connection``. Merged #919.
* Ensure the BlueZ D-Bus scanner can reconnect after DBus disconnection. Merged #920.
