### PR TITLE
remove explicit inheritance from object

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Changed
 -------
 * Switch to using async_timeout instead of asyncio.wait_for for performance.
 
+Removed
+-------
+* Removed explicit inheritance from object in class declarations.
+
 `0.15.1`_ (2022-08-03)
 ======================
 

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -9,7 +9,7 @@ Created on 2018-04-23 by hbldh <henrik.blidh@nedomkull.com>
 from ._manufacturers import MANUFACTURERS
 
 
-class BLEDevice(object):
+class BLEDevice:
     """A simple wrapper class representing a BLE server detected during
     a `discover` call.
 

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -81,7 +81,7 @@ class BleakGATTService(abc.ABC):
             return None
 
 
-class BleakGATTServiceCollection(object):
+class BleakGATTServiceCollection:
     """Simple data container for storing the peripheral's service complement."""
 
     def __init__(self):


### PR DESCRIPTION
In Python 3, we don't need to explicitly inherit from object.
