### PR TITLE
Adjust default timeout for ``read_gatt_char()`` with CoreBluetooth to 20s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixed
 * Handle the race in the BlueZ D-Bus backend where the device disconnects during
   the connection process which presented as ``Failed to cancel connection``. Merged #919.
 * Ensure the BlueZ D-Bus scanner can reconnect after DBus disconnection. Merged #920.
+* Adjust default timeout for ``read_gatt_char()`` with CoreBluetooth to 20s. Fixes #926.
 
 
 `0.15.0`_ (2022-07-29)

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -134,7 +134,7 @@ class PeripheralDelegate(NSObject):
         self,
         characteristic: CBCharacteristic,
         use_cached: bool = True,
-        timeout: int = 10,
+        timeout: int = 20,
     ) -> NSData:
         if characteristic.value() is not None and use_cached:
             return characteristic.value()


### PR DESCRIPTION

fixes #926
