### PR TITLE
backends\winrt set data to bytes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ Contributors
 * Bernie Conrad <bernie@allthenticate.net>
 * Jonathan Soto <jsotogaviard@alum.mit.edu>
 * Kyle J. Williams <kyle@kjwill.tech>
+* Artucuno <artucunov@gmail.com>
 
 Sponsors
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixed
 Changed
 -------
 * Switch to using async_timeout instead of asyncio.wait_for for performance.
+* Changed line 668 in bleak\bleak\backends\winrt - sets data to bytes
 
 `0.15.1`_ (2022-08-03)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -665,7 +665,7 @@ class BleakClientWinRT(BaseBleakClient):
         buf = Buffer(len(data))
         buf.length = buf.capacity
         with memoryview(buf) as mv:
-            mv[:] = data
+            mv[:] = bytes(data)
         _ensure_success(
             await characteristic.obj.write_value_with_result_async(buf, response),
             None,


### PR DESCRIPTION
Fixing an issue experienced on Windows.

`a bytes-like object is required, not 'list'`

Found using this repo: https://github.com/al5681/Sphero_Bolt_Multiplatform_Python_Bleak/pull/3