### PR TITLE
BlueZ: fix not disconnecting if get_services() throws during connect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 Fixed
 -----
 * Made BlueZ D-Bus signal callback logging lazy to improve performance.
+* Fixed possible bad connection state in BlueZ backend. Fixes #951.
 
 Changed
 -------

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -167,8 +167,19 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 assert_reply(reply)
 
                 self._is_connected = True
+
+                # Create a task that runs until the device is disconnected.
+                self._disconnect_monitor_event = asyncio.Event()
+                asyncio.ensure_future(self._disconnect_monitor())
+
+                await self.get_services()
+
+                return True
             except BaseException:
-                # calling Disconnect cancels any pending connect request
+                # Calling Disconnect cancels any pending connect request. Also,
+                # if connection was successful but get_services() raises (e.g.
+                # because task was cancelled), the we still need to disconnect
+                # before passing on the exception.
                 if self._bus:
                     # If disconnected callback already fired, this will be a no-op
                     # since self._bus will be None and the _cleanup_all call will
@@ -196,15 +207,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
                         )
 
                 raise
-
-            # Create a task that runs until the device is disconnected.
-            self._disconnect_monitor_event = asyncio.Event()
-            asyncio.ensure_future(self._disconnect_monitor())
-
-            # Get all services. This means making the actual connection.
-            await self.get_services()
-
-            return True
         except BaseException:
             self._cleanup_all()
             raise


### PR DESCRIPTION
It is possible for get_services() to raise an exception, e.g. if external code cancels the task. If this happens, we need to be sure
that the device disconnects so the BlueZClient is in a consistent state (if the connect() method raises and exception, is is expected that the device will not be connected).

To fix this, we can just move the call to get_services() inside of the existing try block that will disconnect on any exception, then reraise the exception.

Fixes #951.
