### PR TITLE
backends/winrt/client: extend disconnect timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* Extended disconnect timeout to 120 seconds in WinRT backend. Fixes #807.
+
+
 `0.16.0`_ (2022-08-31)
 ======================
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -366,7 +366,9 @@ class BleakClientWinRT(BaseBleakClient):
             self._session_closed_events.append(event)
             try:
                 self._requester.close()
-                async with async_timeout.timeout(10):
+                # sometimes it can take over one minute before Windows decides
+                # to end the GATT session/disconnect the device
+                async with async_timeout.timeout(120):
                     await event.wait()
             finally:
                 self._session_closed_events.remove(event)


### PR DESCRIPTION
This changes the disconnect timeout on the WinRT backend to 120s.

Sometimes it can take up to a minute for Windows to actually close
the GATT session/disconnect the device. This behavior is also seen
in other apps, like WebBluetooth in Chrome. Furthermore, the device
remains connected even after the app is closed, so clearly this is
an issue with the Windows Bluetooth stack and not something that
can be fixed in userspace code.

Fixes #807.
