### PR TITLE
exc: fix BlueZ ATT error messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Fixed wrong error message for BlueZ "Operation failed with ATT error".
+
+
 `0.16.0`_ (2022-08-31)
 ======================
 

--- a/bleak/exc.py
+++ b/bleak/exc.py
@@ -31,7 +31,7 @@ class BleakDBusError(BleakError):
             details = self.args[1]
             # Some error descriptions can be further parsed to be even more helpful
             if "ATT error: 0x" in details:
-                more_detail = CONTROLLER_ERROR_CODES.get(
+                more_detail = PROTOCOL_ERROR_CODES.get(
                     int(details.rsplit("x")[1], 16), "Unknown code"
                 )
                 details += f" ({more_detail})"


### PR DESCRIPTION
We are decoding the ATT error message number to a string. This was
using the wrong lookup table for the messages.

`PROTOCOL_ERROR_CODES` matches `BT_ATT_ERROR_*` in the BlueZ source.
