### PR TITLE
flake8: fix E402 and enable in CI

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -21,7 +21,7 @@ jobs:
             -   name: Lint with flake8
                 run: |
                     # stop the build if there are Python syntax errors or undefined names
-                    pipx run poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+                    pipx run poetry run flake8 . --count --select=E9,F63,F7,F82,E402 --show-source --statistics
                     # exit-zero treats all errors as warnings. Default line length of black is 88
                     pipx run poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
             -   name: Build docs

--- a/examples/kivy/main.py
+++ b/examples/kivy/main.py
@@ -1,3 +1,6 @@
+import asyncio
+import bleak
+
 from kivy.app import App
 
 # from kivy.core.window import Window
@@ -9,9 +12,6 @@ from kivy.logger import Logger
 import logging
 
 logging.Logger.manager.root = Logger
-
-import asyncio
-import bleak
 
 
 class ExampleApp(App):


### PR DESCRIPTION
This fixes all instances of flake8 E402 and enables CI to fail on future instances of this error.
