### PR TITLE
Fixed use of wrong enum in unpair function of WinRT backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixed
 -----
 * Fixed wrong error message for BlueZ "Operation failed with ATT error". Merged #975.
 * Fixed possible ``AttributeError`` when enabling notifications for battery service in BlueZ backend. Merged #976.
+* Fixed use of wrong enum in unpair function of WinRT backend.
 
 Removed
 -------

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -482,8 +482,8 @@ class BleakClientWinRT(BaseBleakClient):
             unpairing_result = await device_information.pairing.unpair_async()
 
             if unpairing_result.status not in (
-                DevicePairingResultStatus.PAIRED,
-                DevicePairingResultStatus.ALREADY_PAIRED,
+                DeviceUnpairingResultStatus.UNPAIRED,
+                DeviceUnpairingResultStatus.ALREADY_UNPAIRED,
             ):
                 raise BleakError(
                     "Could not unpair with device: {0}: {1}".format(


### PR DESCRIPTION
Hello,

The wrong enum for checking the unpair result was used which caused an error when unpairing an already unpaired device as the values for ALREADY_UNPAIRED and ALREADY_PAIRED are not the same.