### PR TITLE
Switch from dbus_next to dbus_fast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Changed
 * The BlueZ D-Bus backend implements a services cache between connections to significancy improve reconnect performance.
   To use the cache, call ``connect`` and ``get_services`` with the ``dangerous_use_bleak_cache``
   argument to avoid services being resolved again.
+* The BlueZ D-Bus backend now uses `dbus-fast` instead of `dbus-next` which significancy improves performance.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Changed
 * The BlueZ D-Bus backend implements a services cache between connections to significancy improve reconnect performance.
   To use the cache, call ``connect`` and ``get_services`` with the ``dangerous_use_bleak_cache``
   argument to avoid services being resolved again.
-* The BlueZ D-Bus backend now uses `dbus-fast` instead of `dbus-next` which significantly improves performance.
+* The BlueZ D-Bus backend now uses ``dbus-fast`` instead of ``dbus-next`` which significantly improves performance.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Changed
 * The BlueZ D-Bus backend implements a services cache between connections to significancy improve reconnect performance.
   To use the cache, call ``connect`` and ``get_services`` with the ``dangerous_use_bleak_cache``
   argument to avoid services being resolved again.
-* The BlueZ D-Bus backend now uses `dbus-fast` instead of `dbus-next` which significancy improves performance.
+* The BlueZ D-Bus backend now uses `dbus-fast` instead of `dbus-next` which significantly improves performance.
 
 Fixed
 -----

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -9,7 +9,7 @@ monitor api <https://github.com/bluez/bluez/blob/master/doc/advertisement-monito
 import logging
 from typing import Iterable, NamedTuple, Tuple, Union, no_type_check
 
-from dbus_next.service import ServiceInterface, dbus_property, method, PropertyAccess
+from dbus_fast.service import ServiceInterface, dbus_property, method, PropertyAccess
 
 from . import defs
 from ...assigned_numbers import AdvertisementDataType
@@ -58,7 +58,7 @@ class AdvertisementMonitor(ServiceInterface):
                 List of or patterns that will be returned by the ``Patterns`` property.
         """
         super().__init__(defs.ADVERTISEMENT_MONITOR_INTERFACE)
-        # dbus_next marshaling requires list instead of tuple
+        # dbus_fast marshaling requires list instead of tuple
         self._or_patterns = [list(p) for p in or_patterns]
 
     @method()

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -263,9 +263,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # Try to disconnect the System Bus.
         try:
             self._bus.disconnect()
-
-            # work around https://github.com/altdesktop/python-dbus-next/issues/112
-            self._bus._sock.close()
         except Exception as e:
             logger.error(
                 f"Attempt to disconnect system bus failed ({self._device_path}): {e}"

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -12,10 +12,10 @@ from uuid import UUID
 
 import async_timeout
 
-from dbus_next.aio import MessageBus
-from dbus_next.constants import BusType, ErrorType
-from dbus_next.message import Message
-from dbus_next.signature import Variant
+from dbus_fast.aio import MessageBus
+from dbus_fast.constants import BusType, ErrorType
+from dbus_fast.message import Message
+from dbus_fast.signature import Variant
 
 from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -22,8 +22,8 @@ from typing import (
     cast,
 )
 
-from dbus_next import BusType, Message, MessageType, Variant
-from dbus_next.aio.message_bus import MessageBus
+from dbus_fast import BusType, Message, MessageType, Variant
+from dbus_fast.aio.message_bus import MessageBus
 
 from ...exc import BleakError
 from ..service import BleakGATTServiceCollection
@@ -633,7 +633,7 @@ class BlueZManager:
 
     def _parse_msg(self, message: Message):
         """
-        Handles callbacks from dbus_next.
+        Handles callbacks from dbus_fast.
         """
 
         if message.message_type != MessageType.SIGNAL:

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -3,7 +3,7 @@ import sys
 from typing import Callable, Coroutine, Dict, List, Optional
 from warnings import warn
 
-from dbus_next import Variant
+from dbus_fast import Variant
 
 if sys.version_info[:2] < (3, 8):
     from typing_extensions import Literal, TypedDict

--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -3,10 +3,10 @@
 import re
 from typing import Any, Coroutine, Dict, Optional
 
-from dbus_next.aio.message_bus import MessageBus
-from dbus_next.errors import InvalidObjectPathError
-from dbus_next.message import Message
-from dbus_next.validators import (
+from dbus_fast.aio.message_bus import MessageBus
+from dbus_fast.errors import InvalidObjectPathError
+from dbus_fast.message import Message
+from dbus_fast.validators import (
     assert_interface_name_valid,
     assert_member_name_valid,
     assert_object_path_valid,

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -2,9 +2,9 @@
 import re
 from typing import Any, Dict
 
-from dbus_next.constants import MessageType
-from dbus_next.message import Message
-from dbus_next.signature import Variant
+from dbus_fast.constants import MessageType
+from dbus_fast.message import Message
+from dbus_fast.signature import Variant
 
 from ...exc import BleakError, BleakDBusError
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,7 +112,7 @@ autodoc_mock_imports = [
     "async_timeout",
     "bleak_winrt",
     "CoreBluetooth",
-    "dbus_next",
+    "dbus_fast",
     "Foundation",
     "jnius",
     "libdispatch",

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,7 +136,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "dbus-fast"
-version = "1.1.7"
+version = "1.1.9"
 description = "A faster version of dbus-next"
 category = "main"
 optional = false
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "66ecf7291762b12bc4e6a4a16c22607e95d6bc9224c05c6a4284f8eb662caf3a"
+content-hash = "236b615fa8b086f5fabf3640e12de440ed681559e7ba61d4a3b9ae4d848f4697"
 
 [metadata.files]
 alabaster = [
@@ -762,8 +762,8 @@ coverage = [
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
 dbus-fast = [
-    {file = "dbus-fast-1.1.7.tar.gz", hash = "sha256:3668f3ff07b964a38f2c2acbe265e9f22063f155e3df9444cd44ffa654cb9964"},
-    {file = "dbus_fast-1.1.7-py3-none-any.whl", hash = "sha256:7684d3df480dd193e84be28f5567fb6dd67f78a2a968d241afb64fb78b48995a"},
+    {file = "dbus-fast-1.1.9.tar.gz", hash = "sha256:482a7e8e2b89b0831fd0c3b805d06adcbc454ccabed0bc684a02486b00707330"},
+    {file = "dbus_fast-1.1.9-py3-none-any.whl", hash = "sha256:c4b8c351ffedc8ba4bdb4ba3cb2336662cf8ab5975bea35f030988fd2008beb7"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "c97c4c7e1f77323261c5b5a9aadea27ada06f777dc35c64ae953152ce36b1cab"
+content-hash = "32a71adb406735bf106873faf0cae924210e005efac5a5b5f6244584e264a6e4"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,7 +136,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "dbus-fast"
-version = "1.3.0"
+version = "1.4.0"
 description = "A faster version of dbus-next"
 category = "main"
 optional = false
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "103d83de029619199dac72c79dc3ac7a8532cc314c12615ab907521f3c069a80"
+content-hash = "c97c4c7e1f77323261c5b5a9aadea27ada06f777dc35c64ae953152ce36b1cab"
 
 [metadata.files]
 alabaster = [
@@ -762,8 +762,8 @@ coverage = [
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
 dbus-fast = [
-    {file = "dbus-fast-1.3.0.tar.gz", hash = "sha256:1c73d58721170e415b5ee9d255f8e8d58d8de23672e21811625315171eaa08f5"},
-    {file = "dbus_fast-1.3.0-py3-none-any.whl", hash = "sha256:61a0e78cf2aa53a7b3be8ffcc2c17ff5a3ff09af6cff3f5059fa6c8b0e358a1d"},
+    {file = "dbus-fast-1.4.0.tar.gz", hash = "sha256:292fec563d27f39bdc46d0a7d03320ff2d77f5f336bd8f564fe186946a213764"},
+    {file = "dbus_fast-1.4.0-py3-none-any.whl", hash = "sha256:3fea12c425587bb2b552e60e40bfcda2d3b94e77a8b2a30ec07c5bbc187bc984"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,7 +136,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "dbus-fast"
-version = "1.2.0"
+version = "1.3.0"
 description = "A faster version of dbus-next"
 category = "main"
 optional = false
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e0f405e08de801d630564445bf73e3ded41fb4240f305ef35268d5248ea47ffb"
+content-hash = "103d83de029619199dac72c79dc3ac7a8532cc314c12615ab907521f3c069a80"
 
 [metadata.files]
 alabaster = [
@@ -762,8 +762,8 @@ coverage = [
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
 dbus-fast = [
-    {file = "dbus-fast-1.2.0.tar.gz", hash = "sha256:2b4bf6b10a42f391eacfe714ea44e9d92b75381a7313848e6b230d0cdee4e130"},
-    {file = "dbus_fast-1.2.0-py3-none-any.whl", hash = "sha256:d0e470c25a6ea22e9f6a9d6636025ed461db2d31d9e96def74a7d58f245aefdd"},
+    {file = "dbus-fast-1.3.0.tar.gz", hash = "sha256:1c73d58721170e415b5ee9d255f8e8d58d8de23672e21811625315171eaa08f5"},
+    {file = "dbus_fast-1.3.0-py3-none-any.whl", hash = "sha256:61a0e78cf2aa53a7b3be8ffcc2c17ff5a3ff09af6cff3f5059fa6c8b0e358a1d"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -75,7 +75,7 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "bleak-winrt"
-version = "1.1.1"
+version = "1.2.0"
 description = "Python WinRT bindings for Bleak"
 category = "main"
 optional = false
@@ -83,7 +83,7 @@ python-versions = "*"
 
 [[package]]
 name = "certifi"
-version = "2022.6.15"
+version = "2022.6.15.1"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "dev"
 optional = false
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "32a71adb406735bf106873faf0cae924210e005efac5a5b5f6244584e264a6e4"
+content-hash = "9f197cee707510b33951a1c160d32e68ec86ceda7c82897971d39295d55f9ee3"
 
 [metadata.files]
 alabaster = [
@@ -683,19 +683,21 @@ black = [
     {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
 ]
 bleak-winrt = [
-    {file = "bleak-winrt-1.1.1.tar.gz", hash = "sha256:3e7765f98d71b5229d95bd3b197931994dead40f3144e7186de7b8f664e26df0"},
-    {file = "bleak_winrt-1.1.1-cp310-cp310-win32.whl", hash = "sha256:f1ab6641cfdadce69126b459c5d30f1a934384bc0c37632393163eea3c94d7a8"},
-    {file = "bleak_winrt-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:79a87c7fcc99838bf7f71765e855a74a80e085c4aedde14d0931d56a9f87be77"},
-    {file = "bleak_winrt-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:1cf652fe38822216c093d4322b9899f54bff3169c4fc48ee8dd10bc1938ec59c"},
-    {file = "bleak_winrt-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:09b64b9b768dfa3abab16e67f7e0d476a0e9d86da2975a2487e033ce2be96663"},
-    {file = "bleak_winrt-1.1.1-cp38-cp38-win32.whl", hash = "sha256:1c4a9ee0c3195d07a3fd8f994953075443563c2c5c8e608cd09f3d0eaac540ed"},
-    {file = "bleak_winrt-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e75b8d5aad3169bd528be9ccbacb775fb0d07f1714ca93b1efa6687c47a1b755"},
-    {file = "bleak_winrt-1.1.1-cp39-cp39-win32.whl", hash = "sha256:e0da28651f8e83aaaea4113d084880f1fafae75c29c2a70429ae1f0b8681dc52"},
-    {file = "bleak_winrt-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:7481aed7d17e8c2aa2bf9e3786206e382f710f516e00887d825df1b7a4c613d5"},
+    {file = "bleak-winrt-1.2.0.tar.gz", hash = "sha256:0577d070251b9354fc6c45ffac57e39341ebb08ead014b1bdbd43e211d2ce1d6"},
+    {file = "bleak_winrt-1.2.0-cp310-cp310-win32.whl", hash = "sha256:a2ae3054d6843ae0cfd3b94c83293a1dfd5804393977dd69bde91cb5099fc47c"},
+    {file = "bleak_winrt-1.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:677df51dc825c6657b3ae94f00bd09b8ab88422b40d6a7bdbf7972a63bc44e9a"},
+    {file = "bleak_winrt-1.2.0-cp311-cp311-win32.whl", hash = "sha256:9449cdb942f22c9892bc1ada99e2ccce9bea8a8af1493e81fefb6de2cb3a7b80"},
+    {file = "bleak_winrt-1.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:98c1b5a6a6c431ac7f76aa4285b752fe14a1c626bd8a1dfa56f66173ff120bee"},
+    {file = "bleak_winrt-1.2.0-cp37-cp37m-win32.whl", hash = "sha256:623ac511696e1f58d83cb9c431e32f613395f2199b3db7f125a3d872cab968a4"},
+    {file = "bleak_winrt-1.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:13ab06dec55469cf51a2c187be7b630a7a2922e1ea9ac1998135974a7239b1e3"},
+    {file = "bleak_winrt-1.2.0-cp38-cp38-win32.whl", hash = "sha256:5a36ff8cd53068c01a795a75d2c13054ddc5f99ce6de62c1a97cd343fc4d0727"},
+    {file = "bleak_winrt-1.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:810c00726653a962256b7acd8edf81ab9e4a3c66e936a342ce4aec7dbd3a7263"},
+    {file = "bleak_winrt-1.2.0-cp39-cp39-win32.whl", hash = "sha256:dd740047a08925bde54bec357391fcee595d7b8ca0c74c87170a5cbc3f97aa0a"},
+    {file = "bleak_winrt-1.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:63130c11acfe75c504a79c01f9919e87f009f5e742bfc7b7a5c2a9c72bf591a7"},
 ]
 certifi = [
-    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
-    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+    {file = "certifi-2022.6.15.1-py3-none-any.whl", hash = "sha256:43dadad18a7f168740e66944e4fa82c6611848ff9056ad910f8f7a3e46ab89e0"},
+    {file = "certifi-2022.6.15.1.tar.gz", hash = "sha256:cffdcd380919da6137f76633531a5817e3a9f268575c128249fb637e4f9e73fb"},
 ]
 charset-normalizer = [
     {file = "charset-normalizer-2.1.1.tar.gz", hash = "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1780977ec34a25bcda3f680fd4b67d65c918eb59ed1f1a649808f2034aadc223"
+content-hash = "66ecf7291762b12bc4e6a4a16c22607e95d6bc9224c05c6a4284f8eb662caf3a"
 
 [metadata.files]
 alabaster = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -136,7 +136,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "dbus-fast"
-version = "1.1.9"
+version = "1.2.0"
 description = "A faster version of dbus-next"
 category = "main"
 optional = false
@@ -634,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "236b615fa8b086f5fabf3640e12de440ed681559e7ba61d4a3b9ae4d848f4697"
+content-hash = "e0f405e08de801d630564445bf73e3ded41fb4240f305ef35268d5248ea47ffb"
 
 [metadata.files]
 alabaster = [
@@ -762,8 +762,8 @@ coverage = [
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
 dbus-fast = [
-    {file = "dbus-fast-1.1.9.tar.gz", hash = "sha256:482a7e8e2b89b0831fd0c3b805d06adcbc454ccabed0bc684a02486b00707330"},
-    {file = "dbus_fast-1.1.9-py3-none-any.whl", hash = "sha256:c4b8c351ffedc8ba4bdb4ba3cb2336662cf8ab5975bea35f030988fd2008beb7"},
+    {file = "dbus-fast-1.2.0.tar.gz", hash = "sha256:2b4bf6b10a42f391eacfe714ea44e9d92b75381a7313848e6b230d0cdee4e130"},
+    {file = "dbus_fast-1.2.0-py3-none-any.whl", hash = "sha256:d0e470c25a6ea22e9f6a9d6636025ed461db2d31d9e96def74a7d58f245aefdd"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -135,12 +135,15 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
-name = "dbus-next"
-version = "0.2.3"
-description = "A zero-dependency DBus library for Python with asyncio support"
+name = "dbus-fast"
+version = "1.1.7"
+description = "A faster version of dbus-next"
 category = "main"
 optional = false
-python-versions = ">=3.6.0"
+python-versions = ">=3.7,<4.0"
+
+[package.extras]
+docs = ["Sphinx[docs] (>=5.1.1,<6.0.0)", "myst-parser[docs] (>=0.18.0,<0.19.0)", "sphinx-rtd-theme[docs] (>=1.0.0,<2.0.0)", "sphinxcontrib-asyncio[docs] (>=0.3.0,<0.4.0)", "sphinxcontrib-fulltoc[docs] (>=1.2.0,<2.0.0)"]
 
 [[package]]
 name = "docutils"
@@ -631,7 +634,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2472b729df55efa6f17ebc22ee78d6ea2a65118e072d8d5d8b82ec8f13f27127"
+content-hash = "1780977ec34a25bcda3f680fd4b67d65c918eb59ed1f1a649808f2034aadc223"
 
 [metadata.files]
 alabaster = [
@@ -758,9 +761,9 @@ coverage = [
     {file = "coverage-6.4.4-pp36.pp37.pp38-none-any.whl", hash = "sha256:f67cf9f406cf0d2f08a3515ce2db5b82625a7257f88aad87904674def6ddaec1"},
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
 ]
-dbus-next = [
-    {file = "dbus_next-0.2.3-py3-none-any.whl", hash = "sha256:58948f9aff9db08316734c0be2a120f6dc502124d9642f55e90ac82ffb16a18b"},
-    {file = "dbus_next-0.2.3.tar.gz", hash = "sha256:f4eae26909332ada528c0a3549dda8d4f088f9b365153952a408e28023a626a5"},
+dbus-fast = [
+    {file = "dbus-fast-1.1.7.tar.gz", hash = "sha256:3668f3ff07b964a38f2c2acbe265e9f22063f155e3df9444cd44ffa654cb9964"},
+    {file = "dbus_fast-1.1.7-py3-none-any.whl", hash = "sha256:7684d3df480dd193e84be28f5567fb6dd67f78a2a968d241afb64fb78b48995a"},
 ]
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
-dbus-fast = {version = ">=1.1.7", markers = "platform_system == \"Linux\""}
+dbus-fast = {version = ">=1.1.9", markers = "platform_system == \"Linux\""}
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
-dbus-fast = ">=1.1.7"
+dbus-fast = {version = ">=1.1.7", markers = "platform_system == \"Linux\""}
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
-dbus-fast = {version = ">=1.2.0", markers = "platform_system == \"Linux\""}
+dbus-fast = {version = ">=1.3.0", markers = "platform_system == \"Linux\""}
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
-dbus-fast = {version = ">=1.4.0", markers = "platform_system == \"Linux\""}
+dbus-fast = { version = "^1.4.0", markers = "platform_system == 'Linux'" }
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 python = "^3.7"
 async-timeout = "^4.0.1"
 typing-extensions = { version = "^4.2.0", python = "<3.8" }
-dbus-next = { version = "^0.2.2", markers = "platform_system=='Linux'" }
 pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
+dbus-fast = ">=1.1.7"
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
-dbus-fast = {version = ">=1.1.9", markers = "platform_system == \"Linux\""}
+dbus-fast = {version = ">=1.2.0", markers = "platform_system == \"Linux\""}
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-libdispatch = { version = "^8.5", markers = "platform_system=='Darwin'" }
 bleak-winrt = { version = "^1.1.1", markers = "platform_system=='Windows'" }
-dbus-fast = {version = ">=1.3.0", markers = "platform_system == \"Linux\""}
+dbus-fast = {version = ">=1.4.0", markers = "platform_system == \"Linux\""}
 
 [tool.poetry.group.docs.dependencies]
 Sphinx = { version = "^5.1.1", python = ">=3.8" }


### PR DESCRIPTION
Removes workaround since `.disconnect()` now closes the socket and fixes the leak.

