### PR TITLE
backends/characteristic: fix inconsistent property types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 * Fixed wrong error message for BlueZ "Operation failed with ATT error". Merged #975.
 * Fixed possible ``AttributeError`` when enabling notifications for battery service in BlueZ backend. Merged #976.
 * Fixed use of wrong enum in unpair function of WinRT backend.
+* Fixed inconsistent return types for ``properties`` and ``descriptors`` properties of ``BleakGATTCharacteristic``.
 
 Removed
 -------

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -68,7 +68,7 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         return self.obj.get("UUID")
 
     @property
-    def properties(self) -> List:
+    def properties(self) -> List[str]:
         """Properties of this characteristic
 
         Returns the characteristics `Flags` present in the DBus API.
@@ -76,7 +76,7 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         return self.obj["Flags"]
 
     @property
-    def descriptors(self) -> List:
+    def descriptors(self) -> List[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         return self.__descriptors
 

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -90,7 +90,7 @@ class BleakGATTCharacteristic(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def descriptors(self) -> List:
+    def descriptors(self) -> List[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         raise NotImplementedError()
 

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -12,6 +12,7 @@ from CoreBluetooth import CBCharacteristic
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class CBCharacteristicProperties(Enum):
@@ -93,13 +94,11 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
         return self.__props
 
     @property
-    def descriptors(self) -> List[BleakGATTDescriptorCoreBluetooth]:
+    def descriptors(self) -> List[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         return self.__descriptors
 
-    def get_descriptor(
-        self, specifier
-    ) -> Union[BleakGATTDescriptorCoreBluetooth, None]:
+    def get_descriptor(self, specifier) -> Union[BleakGATTDescriptor, None]:
         """Get a descriptor by handle (int) or UUID (str or uuid.UUID)"""
         try:
             if isinstance(specifier, int):
@@ -111,7 +110,7 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
         except StopIteration:
             return None
 
-    def add_descriptor(self, descriptor: BleakGATTDescriptorCoreBluetooth):
+    def add_descriptor(self, descriptor: BleakGATTDescriptor):
         """Add a :py:class:`~BleakGATTDescriptor` to the characteristic.
 
         Should not be used by end user, but rather by `bleak` itself.

--- a/bleak/backends/p4android/characteristic.py
+++ b/bleak/backends/p4android/characteristic.py
@@ -56,12 +56,12 @@ class BleakGATTCharacteristicP4Android(BleakGATTCharacteristic):
         return self.__uuid
 
     @property
-    def properties(self) -> List:
+    def properties(self) -> List[str]:
         """Properties of this characteristic"""
         return self.__properties
 
     @property
-    def descriptors(self) -> List:
+    def descriptors(self) -> List[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         return self.__descriptors
 

--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -108,13 +108,13 @@ class BleakGATTCharacteristicWinRT(BleakGATTCharacteristic):
         return self.__props
 
     @property
-    def descriptors(self) -> List[BleakGATTDescriptorWinRT]:
-        """List of descriptors for this service"""
+    def descriptors(self) -> List[BleakGATTDescriptor]:
+        """List of descriptors for this characteristic"""
         return self.__descriptors
 
     def get_descriptor(
         self, specifier: Union[int, str, UUID]
-    ) -> Union[BleakGATTDescriptorWinRT, None]:
+    ) -> Union[BleakGATTDescriptor, None]:
         """Get a descriptor by handle (int) or UUID (str or uuid.UUID)"""
         try:
             if isinstance(specifier, int):


### PR DESCRIPTION
The `properties` and `descriptors` properties had inconsistent return types between backends. This makes them consistent in all backends.
