### PR TITLE
github: fix virtual env python version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,9 +17,12 @@ jobs:
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}
-                uses: actions/setup-python@v2
+                uses: actions/setup-python@v4
+                id: py
                 with:
                     python-version: ${{ matrix.python-version }}
+            -   name: Create virtual environment
+                run: pipx run poetry env use '${{ steps.py.outputs.python-path }}'
             -   name: Install dependencies
                 run: pipx run poetry install --only main,test
             -   name: Test with pytest


### PR DESCRIPTION
Poetry seems to be picking up the wrong Python version when creating the virtual environment, so specify it explicitly using:

    poetry env use pythonX.Y
