### PR TITLE
Handle device being removed before GetManagedObjects returns

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed
 * Fixed possible ``AttributeError`` when enabling notifications for battery service in BlueZ backend. Merged #976.
 * Fixed use of wrong enum in unpair function of WinRT backend.
 * Fixed inconsistent return types for ``properties`` and ``descriptors`` properties of ``BleakGATTCharacteristic``.
+* Handle device being removed before GetManagedObjects returns in BlueZ backend. Fixes #996.
 
 Removed
 -------

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -706,7 +706,10 @@ class BlueZManager:
             obj_path, interfaces = message.body
 
             for interface in interfaces:
-                del self._properties[obj_path][interface]
+                try:
+                    del self._properties[obj_path][interface]
+                except KeyError:
+                    pass
 
                 if interface == defs.DEVICE_INTERFACE:
                     self._services_cache.pop(obj_path, None)


### PR DESCRIPTION
Fixes #996

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/dbus_fast/message_bus.py", line 736, in _process_message
    result = handler(msg)
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/manager.py", line 710, in _parse_msg
    del self._properties[obj_path][interface]
KeyError: '/org/bluez/hci0/dev_00_06_80_08_D2_95'
```