### PR TITLE
Fix race with _disconnect_monitor event in BlueZ

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ Fixed
 * Fixed use of wrong enum in unpair function of WinRT backend.
 * Fixed inconsistent return types for ``properties`` and ``descriptors`` properties of ``BleakGATTCharacteristic``.
 * Handle device being removed before GetManagedObjects returns in BlueZ backend. Fixes #996.
+* Fixes a race in the BlueZ D-Bus backend where the disconnect monitor would be removed before it could be awaited.
 
 Removed
 -------

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -179,7 +179,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
                 # Create a task that runs until the device is disconnected.
                 self._disconnect_monitor_event = asyncio.Event()
-                asyncio.ensure_future(self._disconnect_monitor())
+                asyncio.ensure_future(
+                    self._disconnect_monitor(self._disconnect_monitor_event)
+                )
 
                 #
                 # We will try to use the cache if it exists and `dangerous_use_bleak_cache`
@@ -226,7 +228,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
             self._cleanup_all()
             raise
 
-    async def _disconnect_monitor(self) -> None:
+    async def _disconnect_monitor(
+        self, disconnect_monitor_event: asyncio.Event
+    ) -> None:
         # This task runs until the device is disconnected. If the task is
         # cancelled, it probably means that the event loop crashed so we
         # try to disconnected the device. Otherwise BlueZ will keep the device
@@ -237,7 +241,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # task will still be running and asyncio complains if a loop with running
         # tasks is stopped.
         try:
-            await self._disconnect_monitor_event.wait()
+            await disconnect_monitor_event.wait()
         except asyncio.CancelledError:
             try:
                 # by using send() instead of call(), we ensure that the message


### PR DESCRIPTION
If the device disconnects right away for any reason, the on_connected_changed callback fires and clears the disconnect_monitor_event which results in the following exception:

```
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/client.py", line 182, in connect
    asyncio.ensure_future(self._disconnect_monitor())
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 615, in ensure_future
    return _ensure_future(coro_or_future, loop=loop)
  File "/usr/local/lib/python3.10/asyncio/tasks.py", line 636, in _ensure_future
    return loop.create_task(coro_or_future)
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/bleak/backends/bluezdbus/client.py", line 240, in _disconnect_monitor
    await self._disconnect_monitor_event.wait()
AttributeError: NoneType object has no attribute wait
```

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.7+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
