### PR TITLE
backends/winrt/client: fix crash in max_pdu_size_changed_handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -34,6 +34,7 @@ Fixed
 * Fixed use of wrong enum in unpair function of WinRT backend.
 * Fixed inconsistent return types for ``properties`` and ``descriptors`` properties of ``BleakGATTCharacteristic``.
 * Handle device being removed before GetManagedObjects returns in BlueZ backend. Fixes #996.
+* Fixed crash in ``max_pdu_size_changed_handler`` in WinRT backend. Fixes #998.
 
 Removed
 -------

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -279,7 +279,7 @@ class BleakClientWinRT(BaseBleakClient):
             loop.call_soon_threadsafe(handle_session_status_changed, args)
 
         def max_pdu_size_changed_handler(sender: GattSession, args):
-            logger.debug("max_pdu_size_changed_handler: %d", self._session.max_pdu_size)
+            logger.debug("max_pdu_size_changed_handler: %d", sender.max_pdu_size)
 
         # Start a GATT Session to connect
         event = asyncio.Event()


### PR DESCRIPTION
It is possible that `self._session` is set to `None` when `max_pdu_size_changed_handler` is called. So we can use the `sender` arg instead to avoid a possible `AttributeError`.

Fixes #998.
