### PR TITLE
added remove_device function to BleakClient interface and implement it for WinRT backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 -----
 * ``AdvertisementData`` class now has an attribute ``tx_power``. Merged #987.
+* Added static ``remove_device`` function to ``BleakClient`` interface and implemented it for WinRT
 
 Changed
 -------

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import re
 from typing import Any, Dict
 
 from dbus_fast.constants import MessageType
@@ -7,8 +6,6 @@ from dbus_fast.message import Message
 from dbus_fast.signature import Variant
 
 from ...exc import BleakError, BleakDBusError
-
-_address_regex = re.compile("^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$")
 
 
 def assert_reply(reply: Message):
@@ -21,10 +18,6 @@ def assert_reply(reply: Message):
     if reply.message_type == MessageType.ERROR:
         raise BleakDBusError(reply.error_name, reply.body)
     assert reply.message_type == MessageType.METHOD_RETURN
-
-
-def validate_address(address):
-    return _address_regex.match(address) is not None
 
 
 def unpack_variants(dictionary: Dict[str, Variant]) -> Dict[str, Any]:

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -66,6 +66,20 @@ class BaseBleakClient(abc.ABC):
 
     # Connectivity methods
 
+    @staticmethod
+    @abc.abstractmethod
+    async def remove_device(
+        address_or_ble_device: Union[BLEDevice, str], **kwargs
+    ) -> bool:
+        """Remove the remote device object and its pairing information
+        Args:
+            address_or_ble_device (`BLEDevice` or str): The Bluetooth address of the BLE peripheral to remove or the `BLEDevice` object representing it.
+
+        Returns:
+            Boolean representing if device was present and removed.
+        """
+        raise NotImplementedError()
+
     def set_disconnected_callback(
         self, callback: Optional[Callable[["BaseBleakClient"], None]], **kwargs
     ) -> None:

--- a/bleak/utils.py
+++ b/bleak/utils.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import re
+
+_address_separators = [":", "-"]
+_address_regex = re.compile(
+    rf"^([0-9A-Fa-f]{{2}}[{''.join(_address_separators)}]){{5}}([0-9A-Fa-f]{{2}})$"
+)
+
+
+def validate_address(address: str) -> bool:
+    """Checks for validity of the given Bluetooth device address
+
+    Args:
+        address (str): Bluetooth device address to check
+
+    Returns:
+        bool: True if the given Bluetooth device address is valid
+    """
+    return _address_regex.match(address) is not None
+
+
+def address_to_int(address: str) -> int:
+    """Converts the Bluetooth device address string to its representing integer
+
+    Args:
+        address (str): Bluetooth device address to convert
+
+    Returns:
+        int: integer representation of the given Bluetooth device address
+    """
+    if not validate_address(address):
+        raise ValueError("The given Bluetooth device address is not valid.")
+
+    for char in _address_separators:
+        address = address.replace(char, "")
+
+    return int(address, base=16)


### PR DESCRIPTION
Hello,

this PR adds a remove_device function to be able to remove a device without the need of connecting to it before.
This was inspired by the remove_device function for the bluez backend from another pull request (https://github.com/hbldh/bleak/pull/640/files#diff-dca4aa1d374b221291b543a5d1296bbf912b43d1e2ebc51ed11c1eb153fbb89bR118)
As I have no possibility to test with the bluez backend at the moment I did not copy it from there.

Additionally I moved the validate_address function out of the bluez backend utils into a generic utils file to be able to use it in the WinRT backend as well.
