### PR TITLE
backends/winrt/characteristic: remove unused import

### DIFF
--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -8,7 +8,6 @@ from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.descriptor import BleakGATTDescriptor
-from bleak.backends.winrt.descriptor import BleakGATTDescriptorWinRT
 
 
 _GattCharacteristicsPropertiesMap = {


### PR DESCRIPTION
This was missed in #989.
