### PR TITLE
__init__: fix noqa line

### DIFF
--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -19,10 +19,6 @@ jobs:
             -   name: Check code formatting with black
                 run: pipx run poetry run black . --check --diff
             -   name: Lint with flake8
-                run: |
-                    # stop the build if there are Python syntax errors or undefined names
-                    pipx run poetry run flake8 . --count --select=E9,F63,F7,F82,E402 --show-source --statistics
-                    # exit-zero treats all errors as warnings. Default line length of black is 88
-                    pipx run poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+                run: pipx run poetry run flake8 . --count --show-source --statistics
             -   name: Build docs
                 run: READTHEDOCS=True pipx run poetry run make -C docs html

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -29,31 +29,31 @@ if bool(os.environ.get("BLEAK_LOGGING", False)):
 if _on_rtd:
     pass
 elif os.environ.get("P4A_BOOTSTRAP") is not None:
-    from bleak.backends.p4android.scanner import (
+    from bleak.backends.p4android.scanner import (  # noqa: F401
         BleakScannerP4Android as BleakScanner,
-    )  # noqa: F401
-    from bleak.backends.p4android.client import (
+    )
+    from bleak.backends.p4android.client import (  # noqa: F401
         BleakClientP4Android as BleakClient,
-    )  # noqa: F401
+    )
 elif platform.system() == "Linux":
-    from bleak.backends.bluezdbus.scanner import (
+    from bleak.backends.bluezdbus.scanner import (  # noqa: F401
         BleakScannerBlueZDBus as BleakScanner,
-    )  # noqa: F401
-    from bleak.backends.bluezdbus.client import (
+    )
+    from bleak.backends.bluezdbus.client import (  # noqa: F401
         BleakClientBlueZDBus as BleakClient,
-    )  # noqa: F401
+    )
 elif platform.system() == "Darwin":
     try:
         from CoreBluetooth import CBPeripheral  # noqa: F401
     except Exception as ex:
         raise BleakError("Bleak requires the CoreBluetooth Framework") from ex
 
-    from bleak.backends.corebluetooth.scanner import (
+    from bleak.backends.corebluetooth.scanner import (  # noqa: F401
         BleakScannerCoreBluetooth as BleakScanner,
-    )  # noqa: F401
-    from bleak.backends.corebluetooth.client import (
+    )
+    from bleak.backends.corebluetooth.client import (  # noqa: F401
         BleakClientCoreBluetooth as BleakClient,
-    )  # noqa: F401
+    )
 
 elif platform.system() == "Windows":
     # Requires Windows 10 Creators update at least, i.e. Window 10.0.16299
@@ -70,12 +70,12 @@ elif platform.system() == "Windows":
             "Requires at least Windows 10 version 0.16299 (Fall Creators Update)."
         )
 
-    from bleak.backends.winrt.scanner import (
+    from bleak.backends.winrt.scanner import (  # noqa: F401
         BleakScannerWinRT as BleakScanner,
-    )  # noqa: F401
-    from bleak.backends.winrt.client import (
+    )
+    from bleak.backends.winrt.client import (  # noqa: F401
         BleakClientWinRT as BleakClient,
-    )  # noqa: F401
+    )
 
 else:
     raise BleakError(f"Unsupported platform: {platform.system()}")


### PR DESCRIPTION
The `# noqa: F401` directives were on the wrong line and not picked up by flake8. This moves them to correct line and also allows us to use the main flake8 config in CI since all errors are now fixed.
