### PR TITLE
Relax async-timeout version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* Relax ``async-timeout`` version to support different installations. Merged #1009.
+
 `0.17.0`_ (2022-09-12)
 ======================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-async-timeout = "^4.0.1"
+async-timeout = ">=3.0.0"
 typing-extensions = { version = "^4.2.0", python = "<3.8" }
 pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-async-timeout = ">=3.0.0"
+async-timeout = ">= 3.0.0, < 5"
 typing-extensions = { version = "^4.2.0", python = "<3.8" }
 pyobjc-core = { version = "^8.5", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5", markers = "platform_system=='Darwin'" }


### PR DESCRIPTION
Signatures of methods haven't changed since 3.0 for use cases in bleak.  Relaxing of the dependency will allow using prebuilt version of async-timeout on OpenWrt 21.03 which has version 3.0.1