### PR TITLE
allow unpair without being connected on WinRT backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Changed
 -------
 * Relax ``async-timeout`` version to support different installations. Merged #1009.
+* ``unpair`` function of ``BleakClient`` in WinRT backend can be called without being connected to remove stored device information
 
 `0.17.0`_ (2022-09-12)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -73,6 +73,22 @@ _ACCESS_DENIED_SERVICES = list(
 #     protocol_error: typing.Optional[int]
 
 
+def _address_to_int(address: str) -> int:
+    """Converts the Bluetooth device address string to its representing integer
+
+    Args:
+        address (str): Bluetooth device address to convert
+
+    Returns:
+        int: integer representation of the given Bluetooth device address
+    """
+    _address_separators = [":", "-"]
+    for char in _address_separators:
+        address = address.replace(char, "")
+
+    return int(address, base=16)
+
+
 def _ensure_success(result: Any, attr: Optional[str], fail_msg: str) -> Any:
     """
     Ensures that *status* is ``GattCommunicationStatus.SUCCESS``, otherwise
@@ -182,6 +198,18 @@ class BleakClientWinRT(BaseBleakClient):
 
     # Connectivity methods
 
+    def _create_requester(self, bluetooth_address: int):
+        args = [
+            bluetooth_address,
+        ]
+        if self._address_type is not None:
+            args.append(
+                BluetoothAddressType.PUBLIC
+                if self._address_type == "public"
+                else BluetoothAddressType.RANDOM
+            )
+        return BluetoothLEDevice.from_bluetooth_address_async(*args)
+
     async def connect(self, **kwargs) -> bool:
         """Connect to the specified GATT server.
 
@@ -206,16 +234,7 @@ class BleakClientWinRT(BaseBleakClient):
 
         logger.debug("Connecting to BLE device @ %s", self.address)
 
-        args = [
-            self._device_info,
-        ]
-        if self._address_type is not None:
-            args.append(
-                BluetoothAddressType.PUBLIC
-                if self._address_type == "public"
-                else BluetoothAddressType.RANDOM
-            )
-        self._requester = await BluetoothLEDevice.from_bluetooth_address_async(*args)
+        self._requester = await self._create_requester(self._device_info)
 
         if self._requester is None:
             # https://github.com/microsoft/Windows-universal-samples/issues/1089#issuecomment-487586755
@@ -452,14 +471,17 @@ class BleakClientWinRT(BaseBleakClient):
             Boolean on whether the unparing was successful.
 
         """
-
-        # New local device information object created since the object from the requester isn't updated
-        device_information = await DeviceInformation.create_from_id_async(
-            self._requester.device_information.id
+        device = await self._create_requester(
+            self._device_info
+            if self._device_info is not None
+            else _address_to_int(self.address)
         )
-        if device_information.pairing.is_paired:
-            unpairing_result = await device_information.pairing.unpair_async()
 
+        if device is None:
+            raise BleakError(f"Device with address {self.address} was not found.")
+
+        try:
+            unpairing_result = await device.device_information.pairing.unpair_async()
             if unpairing_result.status not in (
                 DeviceUnpairingResultStatus.UNPAIRED,
                 DeviceUnpairingResultStatus.ALREADY_UNPAIRED,
@@ -467,12 +489,11 @@ class BleakClientWinRT(BaseBleakClient):
                 raise BleakError(
                     f"Could not unpair with device: {unpairing_result.status}"
                 )
+            logger.info("Unpaired with device.")
+        finally:
+            device.close()
 
-            else:
-                logger.info("Unpaired with device.")
-                return True
-
-        return not device_information.pairing.is_paired
+        return True
 
     # GATT services methods
 


### PR DESCRIPTION
This is a alternative approach to https://github.com/hbldh/bleak/pull/1002
Calling unpair when not connected should remove all device information from the OS.

This also relates to issue https://github.com/hbldh/bleak/issues/309