### PR TITLE
backends/scanner: fix tx_power missing in __repr__ when 0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Fixed ``tx_power`` not included in ``AdvertisementData.__repr__`` when 0.
+
 `0.17.0`_ (2022-09-12)
 ======================
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -58,7 +58,7 @@ class AdvertisementData:
             kwargs.append(f"service_data={repr(self.service_data)}")
         if self.service_uuids:
             kwargs.append(f"service_uuids={repr(self.service_uuids)}")
-        if self.tx_power:
+        if self.tx_power is not None:
             kwargs.append(f"tx_power={repr(self.tx_power)}")
         return f"AdvertisementData({', '.join(kwargs)})"
 


### PR DESCRIPTION
0 is a valid value for `tx_power`, so we can't use a falsy check and need to check for None instead.
