### PR TITLE
backends: fix implicit scanning when connecting

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -86,13 +86,13 @@ class BleakScanner:
         backend: Optional[BaseBleakScanner] = None,
         **kwargs,
     ):
-        if backend is None:
-            PlatformBleakScanner = get_platform_scanner_backend_type()
-            self._backend = PlatformBleakScanner(
-                detection_callback, service_uuids, scanning_mode, bluez=bluez, **kwargs
-            )
-        else:
-            self._backend = backend
+        PlatformBleakScanner = (
+            get_platform_scanner_backend_type() if backend is None else backend
+        )
+
+        self._backend = PlatformBleakScanner(
+            detection_callback, service_uuids, scanning_mode, bluez=bluez, **kwargs
+        )
 
     async def __aenter__(self):
         await self._backend.start()
@@ -305,17 +305,17 @@ class BleakClient:
         backend: Optional[BaseBleakClient] = None,
         **kwargs,
     ):
-        if backend is None:
-            PlatformBleakClient = get_platform_client_backend_type()
-            self._backend = PlatformBleakClient(
-                device_or_address,
-                disconnected_callback=disconnected_callback,
-                timeout=timeout,
-                winrt=winrt,
-                **kwargs,
-            )
-        else:
-            self._backend = backend
+        PlatformBleakClient = (
+            get_platform_client_backend_type() if backend is None else backend
+        )
+
+        self._backend = PlatformBleakClient(
+            device_or_address,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+            winrt=winrt,
+            **kwargs,
+        )
 
     # device info
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -16,6 +16,7 @@ from dbus_fast.constants import BusType, ErrorType
 from dbus_fast.message import Message
 from dbus_fast.signature import Variant
 
+from ... import BleakScanner
 from ...exc import BleakDBusError, BleakError
 from ..client import BaseBleakClient
 from ..device import BLEDevice
@@ -102,8 +103,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # Find the desired device before trying to connect.
         timeout = kwargs.get("timeout", self._timeout)
         if self._device_path is None:
-            device = await BleakScannerBlueZDBus.find_device_by_address(
-                self.address, timeout=timeout, adapter=self._adapter
+            device = await BleakScanner.find_device_by_address(
+                self.address,
+                timeout=timeout,
+                adapter=self._adapter,
+                backend=BleakScannerBlueZDBus,
             )
 
             if device:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -17,6 +17,7 @@ from CoreBluetooth import (
 )
 from Foundation import NSArray, NSData
 
+from ... import BleakScanner
 from ...exc import BleakError
 from ..characteristic import BleakGATTCharacteristic
 from ..client import BaseBleakClient
@@ -72,8 +73,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         """
         timeout = kwargs.get("timeout", self._timeout)
         if self._peripheral is None:
-            device = await BleakScannerCoreBluetooth.find_device_by_address(
-                self.address, timeout=timeout
+            device = await BleakScanner.find_device_by_address(
+                self.address, timeout=timeout, backend=BleakScannerCoreBluetooth
             )
 
             if device:

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -48,6 +48,7 @@ from bleak_winrt.windows.devices.enumeration import (
 from bleak_winrt.windows.foundation import EventRegistrationToken
 from bleak_winrt.windows.storage.streams import Buffer
 
+from ... import BleakScanner
 from ...exc import PROTOCOL_ERROR_CODES, BleakError
 from ..characteristic import BleakGATTCharacteristic
 from ..client import BaseBleakClient
@@ -221,8 +222,8 @@ class BleakClientWinRT(BaseBleakClient):
         # Try to find the desired device.
         timeout = kwargs.get("timeout", self._timeout)
         if self._device_info is None:
-            device = await BleakScannerWinRT.find_device_by_address(
-                self.address, timeout=timeout
+            device = await BleakScanner.find_device_by_address(
+                self.address, timeout=timeout, backend=BleakScannerWinRT
             )
 
             if device:


### PR DESCRIPTION
0150ef3 broke implicit scanning because some methods were moved from the backends to the new top-level class.

This fixes the issue by using the new backends kwarg of the scanner to pass the matching scanner backend to the client. This also revealed a bug in the backend kwarg implementation that is now fixed.
