### PR TITLE
BleakClient: fix missing mtu_size property

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -329,6 +329,19 @@ class BleakClient:
         """
         return self._backend.address
 
+    @property
+    def mtu_size(self) -> int:
+        """
+        Gets the negotiated MTU size in bytes for the active connection.
+
+        Consider using :attr:`bleak.backends.characteristic.BleakGATTCharacteristic.max_write_without_response_size` instead.
+
+        .. warning:: The BlueZ backend will always return 23 (the minimum MTU size).
+            See the ``mtu_size.py`` example for a way to hack around this.
+
+        """
+        return self._backend.mtu_size
+
     def __str__(self):
         return f"{self.__class__.__name__}, {self.address}"
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -49,6 +49,12 @@ class BaseBleakClient(abc.ABC):
         self._timeout = kwargs.get("timeout", 10.0)
         self._disconnected_callback = kwargs.get("disconnected_callback")
 
+    @property
+    @abc.abstractmethod
+    def mtu_size(self) -> int:
+        """Gets the negotiated MTU."""
+        raise NotImplementedError
+
     # Connectivity methods
 
     def set_disconnected_callback(

--- a/docs/api/client.rst
+++ b/docs/api/client.rst
@@ -49,6 +49,8 @@ Device information
 
 .. autoproperty:: bleak.BleakClient.address
 
+.. autoproperty:: bleak.BleakClient.mtu_size
+
 
 ----------------------
 GATT Client Operations


### PR DESCRIPTION
This was missed in #982 since BaseBleakClient didn't have an abstract property for this.

This adds the base abstract property to the backends, fixes the missing property in BleakClient client and adds it to the documentation.

cc @bdraco 