### PR TITLE
backends/corebluetooth: better error message for unauthorized

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 -----
 * Added support for Python 3.11.
+* Added better error message for Bluetooth not authorized on macOS.
 
 `0.18.1`_ (2022-09-25)
 ======================

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -84,6 +84,9 @@ class CentralManagerDelegate(NSObject):
         if self.central_manager.state() == CBManagerStateUnsupported:
             raise BleakError("BLE is unsupported")
 
+        if self.central_manager.state() == CBManagerStateUnauthorized:
+            raise BleakError("BLE is not authorized - check macOS privacy settings")
+
         if self.central_manager.state() != CBManagerStatePoweredOn:
             raise BleakError("Bluetooth device is turned off")
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -43,6 +43,11 @@ the *Privacy* settings in the macOS *System Preferences*.
 
 .. image:: images/macos-privacy-bluetooth.png
 
+If the app is already in the list but the checkbox for Bluetooth is disabled,
+you will get the a ``BleakError``: "BLE is not authorized - check macOS privacy settings".
+instead of crashing with ``SIGABRT``, in which case you need to check the box
+to allow Bluetooth for the app that is running Python.
+
 
 No devices found when scanning on macOS 12
 ==========================================


### PR DESCRIPTION
If Bleak is run in a terminal app on macOS that has the permission for Bluetooth disabled, the CentralManager state will return unauthorized.

Previously, this raised the same error as when Bluetooth is not powered which is misleading. This adds a new error message for the unauthorized case.

Issue: https://github.com/hbldh/bleak/discussions/1016
