### PR TITLE
bluez: Create a bluez manager instance per-event-loop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Added
 -----
 * Added support for Python 3.11.
 
+Fixed
+-----
+* On BlueZ, support creating additional instances running on a different event
+  loops (i.e. multiple pytest-asyncio cases)
+
 `0.18.1`_ (2022-09-25)
 ======================
 

--- a/docs/backends/linux.rst
+++ b/docs/backends/linux.rst
@@ -3,12 +3,10 @@
 Linux backend
 =============
 
-The Linux backend of Bleak is written using the
-`TxDBus <https://github.com/cocagne/txdbus>`_
-package. It is written for
-`Twisted <https://twistedmatrix.com/trac/>`_, but by using the
-`twisted.internet.asyncioreactor <https://twistedmatrix.com/documents/current/api/twisted.internet.asyncioreactor.html>`_
-one can use it with `asyncio`.
+The Linux backend of Bleak communicates with `BlueZ <http://www.bluez.org/>`_
+over DBus. Communication uses the `dbus-fast
+<https://github.com/Bluetooth-Devices/dbus-fast>`_ package for async access to
+DBus messaging.
 
 
 Special handling for ``write_gatt_char``
@@ -33,6 +31,15 @@ return the cached services without waiting for them to be resolved again. This
 is useful when you know services have not changed, and you want to use the
 services immediately, but don't want to wait for them to be resolved again.
 
+Parallel Access
+---------------
+
+Each Bleak object should be created and used from a single `asyncio event
+loop`_. Simple asyncio programs will only have a single event loop. It's also
+possible to use Bleak with multiple event loops, even at the same time, but
+individual Bleak objects should not be shared between event loops. Otherwise,
+RuntimeErrors similar to ``[...] got Future <Future pending> attached to a
+different loop`` will be thrown.
 
 API
 ---
@@ -48,3 +55,5 @@ Client
 
 .. automodule:: bleak.backends.bluezdbus.client
     :members:
+
+.. _`asyncio event loop`: https://docs.python.org/3/library/asyncio-eventloop.html


### PR DESCRIPTION
Alternative to #1031. Avoids "got Future <Future pending> attached to a different loop" if Bleak instances with BlueZ backend are constructed in context of more than one event loop (for example, in default configuration of [pytest-asyncio](https://pypi.org/project/pytest-asyncio/)).

Also enables parallel access to Bleak instances from multiple event loops, provided the same Bleak object is not shared between two event loops. Each backend manager instance establishes an independent dbus connection with a unique dbus address.

Some quick code that demonstrates using Bleak in parallel from multiple threads (and therefore multiple event loops):
<details>

```python
import asyncio
import logging
from logging import getLogger, getLevelName, Formatter, StreamHandler
import threading
import time

from bleak import BleakScanner

log = getLogger()
log.setLevel(getLevelName('INFO'))
log_formatter = Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s [%(threadName)s] ")
console_handler = StreamHandler()
console_handler.setFormatter(log_formatter)
log.addHandler(console_handler)

def scanner_callback(device, adv_data):
    log.info(f"Callback Loop {id(asyncio.get_running_loop())} device {device}")

async def scan_coro():
    log.info(f"Scanning Loop {id(asyncio.get_running_loop())}")
    async with BleakScanner(scanner_callback):
        await asyncio.sleep(2)
    log.info("Coro done")

def run_scanner():
    log.info("Running thread")
    asyncio.run(scan_coro(), debug=True)
    log.info("Thread done")

threads = [ threading.Thread(target=run_scanner),
            threading.Thread(target=run_scanner),
            threading.Thread(target=run_scanner), ]

for t in threads:
    t.start()
    # note need to stagger starting scanning as BlueZ seems to drop responses to StartDiscovery if they happen at
    # the same time (seems to be a BlueZ limitation or bug, not anything Bleak is doing).
    time.sleep(0.4) 

[t.join() for t in threads]
```

</details>

There is also a simple pytest-asyncio case in PR #1031 that fails without this patch and passes with this patch.