### PR TITLE
winrt/client: handle exception in max_pdu_size_changed_handler

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Fixed
 -----
 * On BlueZ, support creating additional instances running on a different event
   loops (i.e. multiple pytest-asyncio cases)
+* Fixed unhandled exception in ``max_pdu_size_changed_handler`` in WinRT backend. Fixes #1039.
 
 `0.18.1`_ (2022-09-25)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -304,7 +304,15 @@ class BleakClientWinRT(BaseBleakClient):
             loop.call_soon_threadsafe(handle_session_status_changed, args)
 
         def max_pdu_size_changed_handler(sender: GattSession, args):
-            logger.debug("max_pdu_size_changed_handler: %d", sender.max_pdu_size)
+            try:
+                max_pdu_size = sender.max_pdu_size
+            except OSError:
+                # There is a race condition where this event was already
+                # queued when the GattSession object was closed. In that
+                # case, we get a Windows error which we can just ignore.
+                return
+
+            logger.debug("max_pdu_size_changed_handler: %d", max_pdu_size)
 
         # Start a GATT Session to connect
         event = asyncio.Event()


### PR DESCRIPTION
This catches a possible OSError when max_pdu_size_changed_handler is called after the GATT session ends. It can safely be ignored.

Fixes #1039.
