### PR TITLE
fix deprecated discover method

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -603,7 +603,7 @@ class BleakClient:
 
 
 # for backward compatibility
-def discover():
+def discover(*args, **kwargs):
     """
     .. deprecated:: 0.17.0
         This method will be removed in a future version of Bleak.
@@ -614,7 +614,7 @@ def discover():
         FutureWarning,
         stacklevel=2,
     )
-    return BleakScanner.discover()
+    return BleakScanner.discover(*args, **kwargs)
 
 
 def cli():


### PR DESCRIPTION
This was broken in 825df5dcdcdc234edcd7b33086056d7edc198916.

Fixes #1038.
