### PR TITLE
docs: add async keyword to function

### DIFF
--- a/docs/api/scanner.rst
+++ b/docs/api/scanner.rst
@@ -29,7 +29,7 @@ and stop scanning is to use it in an ``async with`` statement::
     import asyncio
     from bleak import BleakScanner
 
-    def main():
+    async def main():
         stop_event = asyncio.Event()
 
         # TODO: add something that calls stop_event.set()


### PR DESCRIPTION
The example only works for me when adding the async to the main() function, otherwise i get this error:

```
    async with BleakScanner(callback) as scanner:
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: 'async with' outside async function
```