### PR TITLE
backends/bluezdbus/manager: replace startswith in hot path

### DIFF
--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -837,10 +837,9 @@ class BlueZManager:
         """
         for (callback, adapter_path) in self._advertisement_callbacks:
             # filter messages from other adapters
-            if not device_path.startswith(adapter_path):
+            if adapter_path != device["Adapter"]:
                 continue
 
-            # TODO: this should be deep copy, not shallow
             callback(device_path, device.copy())
 
 


### PR DESCRIPTION
Receiving advertisements is a hot path in the code. We can improve performance by avoiding using startswith. In this case we conveniently already have the adapter path available as a D-Bus property, so we can use that instead.

Also drop comment while we are touching this since deep copy wouldn't actually make much of a difference since the dictionary value should be treated as immutable already.
