### PR TITLE
backends/winrt/client: retry getting services if services changed event occurs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 * On BlueZ, support creating additional instances running on a different event
   loops (i.e. multiple pytest-asyncio cases)
 * Fixed unhandled exception in ``max_pdu_size_changed_handler`` in WinRT backend. Fixes #1039.
+* Fixed stale services in WinRT backend causing ``WinError -2147483629``. Fixes #1061.
 
 `0.18.1`_ (2022-09-25)
 ======================


### PR DESCRIPTION
We can get an access denied error for services returned before a services changed event. This handles services changed events that are received while attempting to get services. Hopefully, this is the only time this event is received in most cases.

Fixes #1061.
