### PR TITLE
bluez: Implement unpair() method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 * Added ``rssi`` attribute to ``AdvertisementData``.
 * Added ``BleakScanner.discovered_devices_and_advertisement_data`` property.
 * Added ``return_adv`` argument to ``BleakScanner.discover`` method.
+* Added ``BleakClient.unpair()`` implementation for BlueZ backend.
 
 Changed
 -------


### PR DESCRIPTION
Operates by calling RemoveDevice on the Adapter object, which can be done regardless of the device's connection status.

If the device is connected then calling this method will cause Bluez to disconnect. Calling this method will also cause Bluez to delete any bonding information and GATT attribute cache.

As noted in the previous version of this function, there doesn't seem to be a more direct way to unpair a device in Bluez. It's possible to set the Trusted parameter (readwrite) on a Device object, but not the Paired parameter.
