### PR TITLE
backends/p4android/scanner: fix crash when getting rssi

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
+
 `0.19.0`_ (2022-10-13)
 ======================
 

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -256,7 +256,7 @@ class BleakScannerP4Android(BaseBleakScanner):
             service_data=service_data,
             service_uuids=service_uuids,
             tx_power=tx_power,
-            rssi=native_device.getRssi(),
+            rssi=result.getRssi(),
             platform_data=(result,),
         )
 


### PR DESCRIPTION
In #1047, the call to getRssi() was broken by using the wrong object.

This fixes the mistake.

Fixes #1085.
