### PR TITLE
backends/bluezdbus/manager: Cancel the discovery on disconnect to avoid a timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 * Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
+* BlueZ: Cancel the device discovery wait task if the device disconnects in
+  between to avoid a timeout
 
 `0.19.0`_ (2022-10-13)
 ======================


### PR DESCRIPTION
If a device disconnects while waiting for the services to be discovered, the manager will wait forever.
This commit fixes that by introducing a context to the _wait_condition method with an exception on disconnect.
