### PR TITLE
winrt:: fix tx power compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Fixed
 * Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
 * BlueZ: Cancel the device discovery wait task if the device disconnects in
   between to avoid a timeout
+* Fixed ``AttributeError`` crash when scanning on Windows builds < 19041. Fixes #1094.
 
 `0.19.0`_ (2022-10-13)
 ======================

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -156,8 +156,16 @@ class BleakScannerWinRT(BaseBleakScanner):
             if args.advertisement.local_name:
                 local_name = args.advertisement.local_name
 
-            if args.transmit_power_level_in_d_bm is not None:
-                tx_power = raw_data.adv.transmit_power_level_in_d_bm
+            try:
+                if args.transmit_power_level_in_d_bm is not None:
+                    tx_power = args.transmit_power_level_in_d_bm
+            except AttributeError:
+                # the transmit_power_level_in_d_bm property was introduce in
+                # Windows build 19041 so we have a fallback for older versions
+                for section in args.advertisement.get_sections_by_type(
+                    AdvertisementDataType.TX_POWER_LEVEL
+                ):
+                    tx_power = bytes(section.data)[0]
 
             # Decode service data
             for section in args.advertisement.get_sections_by_type(


### PR DESCRIPTION
The transmit power property of the advertising data was added in Windows
build 19041, so we need a fallback for older versions of Windows.

Fixes hbldh/bleak#1094
