### PR TITLE
github: drop rc.2 from Python 3.11

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-rc.2']
+                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python 3.11 has been released so we no longer need the RC version.
