### PR TITLE
Release/0.19.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11.0-rc.2']
+                python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         steps:
             -   uses: actions/checkout@v2
             -   name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 * Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
+* BlueZ: Cancel the device discovery wait task if the device disconnects in
+  between to avoid a timeout
 
 `0.19.0`_ (2022-10-13)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,13 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+`0.19.1`_ (2022-10-29)
+======================
+
 Fixed
 -----
 * Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
-* BlueZ: Cancel the device discovery wait task if the device disconnects in
-  between to avoid a timeout
+* Fixed service discovery blocking forever if device disconnects in BlueZ backend. Merged #1092.
 * Fixed ``AttributeError`` crash when scanning on Windows builds < 19041. Fixes #1094.
 
 `0.19.0`_ (2022-10-13)
@@ -848,7 +850,8 @@ Fixed
 * Bleak created.
 
 
-.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.19.0...develop
+.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.19.1...develop
+.. _0.19.1: https://github.com/hbldh/bleak/compare/v0.19.0...v0.19.1
 .. _0.19.0: https://github.com/hbldh/bleak/compare/v0.18.1...v0.19.0
 .. _0.18.1: https://github.com/hbldh/bleak/compare/v0.18.0...v0.18.1
 .. _0.18.0: https://github.com/hbldh/bleak/compare/v0.17.0...v0.18.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
+
 `0.19.0`_ (2022-10-13)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Fixed
 * Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
 * BlueZ: Cancel the device discovery wait task if the device disconnects in
   between to avoid a timeout
+* Fixed ``AttributeError`` crash when scanning on Windows builds < 19041. Fixes #1094.
 
 `0.19.0`_ (2022-10-13)
 ======================

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -570,7 +570,7 @@ class BlueZManager:
                 logger.debug("Using cached services for %s", device_path)
                 return services
 
-        await self._wait_for_services_disovery(device_path)
+        await self._wait_for_services_discovery(device_path)
 
         services = BleakGATTServiceCollection()
 
@@ -648,11 +648,11 @@ class BlueZManager:
         except KeyError:
             return False
 
-    async def _wait_for_services_disovery(self, device_path: str) -> None:
-        """Wait for the device services to be discovered.
+    async def _wait_for_services_discovery(self, device_path: str) -> None:
+        """
+        Waits for the device services to be discovered.
 
         If a disconnect happens before the completion a BleakError exception is raised.
-
         """
         services_discovered_wait_task = asyncio.create_task(
             self._wait_condition(device_path, "ServicesResolved", True)

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -256,7 +256,7 @@ class BleakScannerP4Android(BaseBleakScanner):
             service_data=service_data,
             service_uuids=service_uuids,
             tx_power=tx_power,
-            rssi=native_device.getRssi(),
+            rssi=result.getRssi(),
             platform_data=(result,),
         )
 

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -156,8 +156,16 @@ class BleakScannerWinRT(BaseBleakScanner):
             if args.advertisement.local_name:
                 local_name = args.advertisement.local_name
 
-            if args.transmit_power_level_in_d_bm is not None:
-                tx_power = raw_data.adv.transmit_power_level_in_d_bm
+            try:
+                if args.transmit_power_level_in_d_bm is not None:
+                    tx_power = args.transmit_power_level_in_d_bm
+            except AttributeError:
+                # the transmit_power_level_in_d_bm property was introduce in
+                # Windows build 19041 so we have a fallback for older versions
+                for section in args.advertisement.get_sections_by_type(
+                    AdvertisementDataType.TX_POWER_LEVEL
+                ):
+                    tx_power = bytes(section.data)[0]
 
             # Decode service data
             for section in args.advertisement.get_sections_by_type(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bleak"
-version = "0.19.0"
+version = "0.20.0a1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 authors = ["Henrik Blidh <henrik.blidh@nedomkull.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bleak"
-version = "0.20.0a1"
+version = "0.19.1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 authors = ["Henrik Blidh <henrik.blidh@nedomkull.com>"]
 license = "MIT"


### PR DESCRIPTION

Fixed
-----
* Fixed crash in Android backend introduced in v0.19.0. Fixes #1085.
* Fixed service discovery blocking forever if device disconnects in BlueZ backend. Merged #1092.
* Fixed ``AttributeError`` crash when scanning on Windows builds < 19041. Fixes #1094.
