### PR TITLE
github: bump actions versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
                 os: [ubuntu-latest, windows-latest, macos-latest]
                 python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   name: Set up Python ${{ matrix.python-version }}
                 uses: actions/setup-python@v4
                 id: py

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -5,13 +5,13 @@ on: workflow_dispatch
 jobs:
     build_android:
         name: "Build Android"
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   name: Install dependencies
                 run: pip install buildozer cython
             -   name: Cache buildozer files
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 id: buildozer-cache
                 with:
                     path: |

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -11,9 +11,9 @@ jobs:
         name: "Format and lint"
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v3
             -   name: Set up Python
-                uses: actions/setup-python@v2
+                uses: actions/setup-python@v4
             -   name: Install development dependencies
                 run: pipx run poetry install --only docs,lint
             -   name: Check code formatting with black

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: pipx run poetry build
     - name: Publish


### PR DESCRIPTION
Older versions are showing deprecation warnings because they use nodejs v12.