### PR TITLE
Pairing agent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,17 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Added
+-----
+* Added ``BleakClient.close()`` method.
+
+
 Changed
 -------
 * Dropped ``async-timeout`` dependency on Python >= 3.11.
 * Deprecated ``BLEDevice.rssi`` and ``BLEDevice.metadata``. Fixes #1025.
 * ``BLEDevice`` now uses ``__slots__`` to reduce memory usage.
+* BlueZ no longer closes D-Bus socket on disconnect of ``BleakClient``.
 
 
 `0.19.4`_ (2022-11-06)
@@ -41,6 +47,7 @@ Fixed
 * Fixed crash when getting services in WinRT backend in Python 3.11. Fixes #1112.
 * Fixed cache mode when retrying get services in WinRT backend. Merged #1102.
 * Fixed ``KeyError`` crash in BlueZ backend when removing non-existent property. Fixes #1107.
+
 
 `0.19.1`_ (2022-10-29)
 ======================

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -38,6 +38,7 @@ if sys.version_info[:2] < (3, 8):
 else:
     from typing import Literal
 
+from .agent import BaseBleakAgentCallbacks
 from .backends.characteristic import BleakGATTCharacteristic
 from .backends.client import BaseBleakClient, get_platform_client_backend_type
 from .backends.device import BLEDevice
@@ -493,7 +494,9 @@ class BleakClient:
         """
         return await self._backend.disconnect()
 
-    async def pair(self, *args, **kwargs) -> bool:
+    async def pair(
+        self, callbacks: Optional[BaseBleakAgentCallbacks] = None, **kwargs
+    ) -> bool:
         """
         Pair with the specified GATT server.
 
@@ -502,11 +505,22 @@ class BleakClient:
         that a characteristic that requires authentication is read or written.
         This method may have backend-specific additional keyword arguments.
 
+        Args:
+            callbacks:
+                Optional callbacks for confirming or requesting pin. This is
+                only supported on Linux and Windows. If omitted, the OS will
+                handle the pairing request.
+
         Returns:
             Always returns ``True`` for backwards compatibility.
 
+        Raises:
+            BleakPairingCancelledError:
+                if pairing was canceled before it completed (device disconnected, etc.)
+            BleakPairingFailedError:
+                if pairing failed (rejected, wrong pin, etc.)
         """
-        return await self._backend.pair(*args, **kwargs)
+        return await self._backend.pair(callbacks, **kwargs)
 
     async def unpair(self) -> bool:
         """

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -438,6 +438,17 @@ class BleakClient:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.disconnect()
+        self.close()
+
+    def __del__(self):
+        # Remember kids: __del__is NOT guaranteed to run EVER!
+        # Use the context manager or call close explicitly.
+        # This is only here for people with long running programs that didn't
+        # follow that advice so that they don't run out of file descriptors.
+        self.close()
+
+    def close(self):
+        self._backend.close()
 
     # Connectivity methods
 

--- a/bleak/agent.py
+++ b/bleak/agent.py
@@ -1,0 +1,52 @@
+import abc
+from typing import Optional
+
+from .backends.device import BLEDevice
+
+
+class BaseBleakAgentCallbacks(abc.ABC):
+    @abc.abstractmethod
+    async def confirm(self, device: BLEDevice) -> bool:
+        """
+        Implementers should prompt the user to confirm or reject the pairing
+        request.
+
+        Returns:
+            ``True`` to accept the pairing request or ``False`` to reject it.
+        """
+
+    @abc.abstractmethod
+    async def confirm_pin(self, device: BLEDevice, pin: str) -> bool:
+        """
+        Implementers should display the pin code to the user and prompt the
+        user to validate the pin code and confirm or reject the pairing request.
+
+        Args:
+            pin: The pin code to be confirmed.
+
+        Returns:
+            ``True`` to accept the pairing request or ``False`` to reject it.
+        """
+
+    @abc.abstractmethod
+    async def display_pin(self, device: BLEDevice, pin: str) -> None:
+        """
+        Implementers should display the pin code to the user.
+
+        This method should block indefinitely until it canceled (i.e.
+        ``await asyncio.Event().wait()``).
+
+        Args:
+            pin: The pin code to be confirmed.
+        """
+
+    @abc.abstractmethod
+    async def request_pin(self, device: BLEDevice) -> Optional[str]:
+        """
+        Implementers should prompt the user to enter a pin code to accept the
+        pairing request or to reject the paring request.
+
+        Returns:
+            A string containing the pin code to accept the pairing request or
+            ``None`` to reject it.
+        """

--- a/bleak/backends/bluezdbus/agent.py
+++ b/bleak/backends/bluezdbus/agent.py
@@ -1,0 +1,171 @@
+"""
+Agent
+-----
+
+This module contains types associated with the BlueZ D-Bus `agent api
+<https://github.com/bluez/bluez/blob/master/doc/agent-api.txt>`.
+"""
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Set, no_type_check
+
+from dbus_fast import DBusError, Message
+from dbus_fast.aio import MessageBus
+from dbus_fast.service import ServiceInterface, method
+
+from bleak.backends.device import BLEDevice
+
+from ...agent import BaseBleakAgentCallbacks
+from . import defs
+from .manager import get_global_bluez_manager
+from .utils import assert_reply
+
+logger = logging.getLogger(__name__)
+
+
+class Agent(ServiceInterface):
+    """
+    Implementation of the org.bluez.Agent1 D-Bus interface.
+    """
+
+    def __init__(self, callbacks: BaseBleakAgentCallbacks):
+        """
+        Args:
+        """
+        super().__init__(defs.AGENT_INTERFACE)
+        self._callbacks = callbacks
+        self._tasks: Set[asyncio.Task] = set()
+
+    async def _create_ble_device(self, device_path: str) -> BLEDevice:
+        manager = await get_global_bluez_manager()
+        props = manager.get_device_props(device_path)
+        return BLEDevice(
+            props["Address"], props["Alias"], {"path": device_path, "props": props}
+        )
+
+    @method()
+    def Release(self):
+        logger.debug("Release")
+
+    # REVISIT: mypy is broke, so we have to add redundant @no_type_check
+    # https://github.com/python/mypy/issues/6583
+
+    @method()
+    @no_type_check
+    async def RequestPinCode(self, device: "o") -> "s":  # noqa: F821
+        logger.debug("RequestPinCode %s", device)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def DisplayPinCode(self, device: "o", pincode: "s"):  # noqa: F821
+        logger.debug("DisplayPinCode %s %s", device, pincode)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def RequestPasskey(self, device: "o") -> "u":  # noqa: F821
+        logger.debug("RequestPasskey %s", device)
+
+        ble_device = await self._create_ble_device(device)
+
+        task = asyncio.create_task(self._callbacks.request_pin(ble_device))
+        self._tasks.add(task)
+
+        try:
+            pin = await task
+        except asyncio.CancelledError:
+            raise DBusError("org.bluez.Error.Canceled", "task canceled")
+        finally:
+            self._tasks.remove(task)
+
+        if not pin:
+            raise DBusError("org.bluez.Error.Rejected", "user rejected")
+
+        return int(pin)
+
+    @method()
+    @no_type_check
+    async def DisplayPasskey(
+        self, device: "o", passkey: "u", entered: "q"  # noqa: F821
+    ):
+        passkey = f"{passkey:06}"
+        logger.debug("DisplayPasskey %s %s %d", device, passkey, entered)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def RequestConfirmation(self, device: "o", passkey: "u"):  # noqa: F821
+        passkey = f"{passkey:06}"
+        logger.debug("RequestConfirmation %s %s", device, passkey)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def RequestAuthorization(self, device: "o"):  # noqa: F821
+        logger.debug("RequestAuthorization %s", device)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def AuthorizeService(self, device: "o", uuid: "s"):  # noqa: F821
+        logger.debug("AuthorizeService %s", device, uuid)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    def Cancel(self):  # noqa: F821
+        logger.debug("Cancel")
+        for t in self._tasks:
+            t.cancel()
+
+
+@contextlib.asynccontextmanager
+async def bluez_agent(bus: MessageBus, callbacks: BaseBleakAgentCallbacks):
+    agent = Agent(callbacks)
+
+    # REVISIT: implement passing capability if needed
+    # "DisplayOnly", "DisplayYesNo", "KeyboardOnly", "NoInputNoOutput", "KeyboardDisplay"
+    capability = ""
+
+    # this should be a unique path to allow multiple python interpreters
+    # running bleak and multiple agents at the same time
+    agent_path = f"/org/bleak/agent/{os.getpid()}/{id(agent)}"
+
+    bus.export(agent_path, agent)
+
+    try:
+        reply = await bus.call(
+            Message(
+                destination=defs.BLUEZ_SERVICE,
+                path="/org/bluez",
+                interface=defs.AGENT_MANAGER_INTERFACE,
+                member="RegisterAgent",
+                signature="os",
+                body=[agent_path, capability],
+            )
+        )
+
+        assert_reply(reply)
+
+        try:
+            yield
+        finally:
+            reply = await bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path="/org/bluez",
+                    interface=defs.AGENT_MANAGER_INTERFACE,
+                    member="UnregisterAgent",
+                    signature="o",
+                    body=[agent_path],
+                )
+            )
+
+            assert_reply(reply)
+
+    finally:
+        bus.unexport(agent_path, agent)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -21,6 +21,7 @@ from dbus_fast.message import Message
 from dbus_fast.signature import Variant
 
 from ... import BleakScanner
+from ...agent import BaseBleakAgentCallbacks
 from ...exc import BleakDBusError, BleakError, BleakDeviceNotFoundError
 from ..characteristic import BleakGATTCharacteristic
 from ..client import BaseBleakClient, NotifyCallback
@@ -335,16 +336,16 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         return True
 
-    async def pair(self, *args, **kwargs) -> bool:
-        """Pair with the peripheral.
-
-        You can use ConnectDevice method if you already know the MAC address of the device.
-        Else you need to StartDiscovery, Trust, Pair and Connect in sequence.
-
-        Returns:
-            Boolean regarding success of pairing.
-
+    async def pair(
+        self, callbacks: Optional[BaseBleakAgentCallbacks], **kwargs
+    ) -> bool:
         """
+        Pair with the peripheral.
+        """
+
+        if callbacks:
+            raise NotImplementedError
+
         # See if it is already paired.
         reply = await self._bus.call(
             Message(

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -17,6 +17,8 @@ BLUEZ_SERVICE = "org.bluez"
 ADAPTER_INTERFACE = "org.bluez.Adapter1"
 ADVERTISEMENT_MONITOR_INTERFACE = "org.bluez.AdvertisementMonitor1"
 ADVERTISEMENT_MONITOR_MANAGER_INTERFACE = "org.bluez.AdvertisementMonitorManager1"
+AGENT_INTERFACE = "org.bluez.Agent1"
+AGENT_MANAGER_INTERFACE = "org.bluez.AgentManager1"
 DEVICE_INTERFACE = "org.bluez.Device1"
 BATTERY_INTERFACE = "org.bluez.Battery1"
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -621,6 +621,20 @@ class BlueZManager:
 
         return services
 
+    def get_device_props(self, device_path: str) -> Device1:
+        """
+        Gets the current properties of a device.
+
+        Args:
+            device_path: The D-Bus object path of the device.
+
+        Returns:
+            The current properties.
+        """
+        return cast(
+            Device1, self._properties[device_path][defs.DEVICE_INTERFACE].copy()
+        )
+
     def get_device_name(self, device_path: str) -> str:
         """
         Gets the value of the "Name" property for a device.

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -13,10 +13,11 @@ import uuid
 from typing import Callable, Optional, Type, Union
 from warnings import warn
 
+from ..agent import BaseBleakAgentCallbacks
 from ..exc import BleakError
-from .service import BleakGATTServiceCollection
 from .characteristic import BleakGATTCharacteristic
 from .device import BLEDevice
+from .service import BleakGATTServiceCollection
 
 NotifyCallback = Callable[[bytearray], None]
 
@@ -105,7 +106,9 @@ class BaseBleakClient(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    async def pair(self, *args, **kwargs) -> bool:
+    async def pair(
+        self, callbacks: Optional[BaseBleakAgentCallbacks], **kwargs
+    ) -> bool:
         """Pair with the peripheral."""
         raise NotImplementedError()
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -49,6 +49,9 @@ class BaseBleakClient(abc.ABC):
         self._timeout = kwargs.get("timeout", 10.0)
         self._disconnected_callback = kwargs.get("disconnected_callback")
 
+    def close(self):
+        pass
+
     @property
     @abc.abstractmethod
     def mtu_size(self) -> int:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -17,7 +17,8 @@ from CoreBluetooth import (
 from Foundation import NSArray, NSData
 
 from ... import BleakScanner
-from ...exc import BleakError, BleakDeviceNotFoundError
+from ...agent import BaseBleakAgentCallbacks
+from ...exc import BleakDeviceNotFoundError, BleakError
 from ..characteristic import BleakGATTCharacteristic
 from ..client import BaseBleakClient, NotifyCallback
 from ..device import BLEDevice
@@ -154,24 +155,11 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             + 3
         )
 
-    async def pair(self, *args, **kwargs) -> bool:
-        """Attempt to pair with a peripheral.
-
-        .. note::
-
-            This is not available on macOS since there is not explicit method to do a pairing, Instead the docs
-            state that it "auto-pairs" when trying to read a characteristic that requires encryption, something
-            Bleak cannot do apparently.
-
-        Reference:
-
-            - `Apple Docs <https://developer.apple.com/library/archive/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/BestPracticesForSettingUpYourIOSDeviceAsAPeripheral/BestPracticesForSettingUpYourIOSDeviceAsAPeripheral.html#//apple_ref/doc/uid/TP40013257-CH5-SW1>`_
-            - `Stack Overflow post #1 <https://stackoverflow.com/questions/25254932/can-you-pair-a-bluetooth-le-device-in-an-ios-app>`_
-            - `Stack Overflow post #2 <https://stackoverflow.com/questions/47546690/ios-bluetooth-pairing-request-dialog-can-i-know-the-users-choice>`_
-
-        Returns:
-            Boolean regarding success of pairing.
-
+    async def pair(
+        self, callbacks: Optional[BaseBleakAgentCallbacks], **kwargs
+    ) -> bool:
+        """
+        Attempt to pair with a peripheral.
         """
         raise NotImplementedError("Pairing is not available in Core Bluetooth.")
 

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -11,6 +11,7 @@ from typing import Optional, Union
 from android.broadcast import BroadcastReceiver
 from jnius import java_method
 
+from ...agent import BaseBleakAgentCallbacks
 from ...exc import BleakError
 from ..characteristic import BleakGATTCharacteristic
 from ..client import BaseBleakClient, NotifyCallback
@@ -156,16 +157,15 @@ class BleakClientP4Android(BaseBleakClient):
 
         return True
 
-    async def pair(self, *args, **kwargs) -> bool:
-        """Pair with the peripheral.
-
-        You can use ConnectDevice method if you already know the MAC address of the device.
-        Else you need to StartDiscovery, Trust, Pair and Connect in sequence.
-
-        Returns:
-            Boolean regarding success of pairing.
-
+    async def pair(
+        self, callbacks: Optional[BaseBleakAgentCallbacks], **kwargs
+    ) -> bool:
         """
+        Pair with the peripheral.
+        """
+        if callbacks is not None:
+            warnings.warn("callbacks ignored on Android", RuntimeWarning, stacklevel=2)
+
         loop = asyncio.get_running_loop()
 
         bondedFuture = loop.create_future()

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -57,6 +57,7 @@ from bleak_winrt.windows.foundation import (
 from bleak_winrt.windows.storage.streams import Buffer
 
 from ... import BleakScanner
+from ...agent import BaseBleakAgentCallbacks
 from ...exc import PROTOCOL_ERROR_CODES, BleakDeviceNotFoundError, BleakError
 from ..characteristic import BleakGATTCharacteristic
 from ..client import BaseBleakClient, NotifyCallback
@@ -457,21 +458,18 @@ class BleakClientWinRT(BaseBleakClient):
         """Get ATT MTU size for active connection"""
         return self._session.max_pdu_size
 
-    async def pair(self, protection_level: int = None, **kwargs) -> bool:
-        """Attempts to pair with the device.
-
-        Keyword Args:
-            protection_level (int): A ``DevicePairingProtectionLevel`` enum value:
-
-                1. None - Pair the device using no levels of protection.
-                2. Encryption - Pair the device using encryption.
-                3. EncryptionAndAuthentication - Pair the device using
-                   encryption and authentication. (This will not work in Bleak...)
-
-        Returns:
-            Boolean regarding success of pairing.
-
+    async def pair(
+        self,
+        callbacks: Optional[BaseBleakAgentCallbacks],
+        protection_level: int = None,
+        **kwargs,
+    ) -> bool:
         """
+        Attempts to pair with the device.
+        """
+        if callbacks:
+            raise NotImplementedError
+
         # New local device information object created since the object from the requester isn't updated
         device_information = await DeviceInformation.create_from_id_async(
             self._requester.device_information.id

--- a/bleak/exc.py
+++ b/bleak/exc.py
@@ -27,6 +27,18 @@ class BleakDeviceNotFoundError(BleakError):
         self.identifier = identifier
 
 
+class BleakPairingCancelledError(BleakError):
+    """
+    Specialized exception to indicate that pairing was canceled.
+    """
+
+
+class BleakPairingFailedError(BleakError):
+    """
+    Specialized exception to indicate that pairing failed.
+    """
+
+
 class BleakDBusError(BleakError):
     """Specialized exception type for D-Bus errors."""
 

--- a/examples/pairing_agent.py
+++ b/examples/pairing_agent.py
@@ -1,0 +1,88 @@
+import argparse
+import asyncio
+import sys
+
+from bleak import BleakScanner, BleakClient, BaseBleakAgentCallbacks
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakPairingCancelledError, BleakPairingFailedError
+
+
+class AgentCallbacks(BaseBleakAgentCallbacks):
+    def __init__(self) -> None:
+        super().__init__()
+        self._reader = asyncio.StreamReader()
+
+    async def __aenter__(self):
+        loop = asyncio.get_running_loop()
+        protocol = asyncio.StreamReaderProtocol(self._reader)
+        self._input_transport, _ = await loop.connect_read_pipe(
+            lambda: protocol, sys.stdin
+        )
+        return self
+
+    async def __aexit__(self, *args):
+        self._input_transport.close()
+
+    async def _input(self, msg: str) -> str:
+        """
+        Async version of the builtin input function.
+        """
+        print(msg, end=" ", flush=True)
+        return (await self._reader.readline()).decode().strip()
+
+    async def confirm(self, device: BLEDevice) -> bool:
+        print(f"{device.name} wants to pair.")
+        response = await self._input("confirm (y/n)?")
+
+        return response.lower().startswith("y")
+
+    async def confirm_pin(self, device: BLEDevice, pin: str) -> bool:
+        print(f"{device.name} wants to pair.")
+        response = await self._input(f"does {pin} match (y/n)?")
+
+        return response.lower().startswith("y")
+
+    async def display_pin(self, device: BLEDevice, pin: str) -> None:
+        print(f"{device.name} wants to pair.")
+        print(f"enter this pin on the device: {pin}")
+        # wait for cancellation
+        await asyncio.Event().wait()
+
+    async def request_pin(self, device: BLEDevice) -> str:
+        print(f"{device.name} wants to pair.")
+        response = await self._input("enter pin:")
+
+        return response
+
+
+async def main(addr: str, unpair: bool) -> None:
+    if unpair:
+        print("unpairing...")
+        await BleakClient(addr).unpair()
+
+    print("scanning...")
+
+    device = await BleakScanner.find_device_by_address(addr)
+
+    if device is None:
+        print("device was not found")
+        return
+
+    async with BleakClient(device) as client, AgentCallbacks() as callbacks:
+        try:
+            await client.pair(callbacks)
+        except BleakPairingCancelledError:
+            print("paring was canceled")
+        except BleakPairingFailedError:
+            print("pairing failed (bad pin?)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("pairing_agent.py")
+    parser.add_argument("address", help="the Bluetooth address (or UUID on macOS)")
+    parser.add_argument(
+        "--unpair", action="store_true", help="unpair first before pairing"
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(args.address, args.unpair))


### PR DESCRIPTION
This is a work-in-progress attempt at implementing to implement programmatic pairing on Linux and Windows (alternative to the stalled #640).

I'm fairly happy with the Linux/BlueZ implementation at this point. But the Windows implementation is quite flaky need work.

Fixes #827

Issues to be resolved before merging:
- [ ] Clarify new exception types. Currently there are two new exceptions to indicate that pairing failed based on error returned by BlueZ. It was expected that these should correspond to the org.bluez.Error.Canceled and org.bluez.Error.Rejected responses sent by the agent. However, these don't seem to get passed through the Bluetooth stack and both come out the other end as a generic org.bluez.Error.AuthenticationFailed error. org.bluez.Error.AuthenticationCanceled seems to only happen when the device disconnects before pairing is complete.
- [ ] Additional pairing methods need to be implemented in BlueZ backed. Currently, only "RequestPasskey" is implemented, which corresponds to `BaseBleakAgentCallbacks.request_pin()`.
- [ ] Figure out how to properly do cancellation on Windows. It seems very easy to get the Bluetooth stack on Windows in a bad state if you end the Python process without allowing the pairing to complete. I had to reboot my computer many times while working on this to restore the Windows Bluetooth stack to a good state.
- [ ] Figure out how to get the `pair_async()` method to return when `accept()` is not called. The pair method seems to block forever unless the `accept()` method of the [DevicePairingRequestedEventArgs](https://learn.microsoft.com/en-us/uwp/api/windows.devices.enumeration.devicepairingrequestedeventargs.accept?view=winrt-22621#windows-devices-enumeration-devicepairingrequestedeventargs-accept) is called. But the user might not want to accept the pairing, so how do we handle this case? Also, if a pin is requested and you reply with a non-numeric string, the `pair_async()` method never returns instead of the expected invalid pin error.
- [ ] Settle on pin type, int vs str. BlueZ uses UInt32 for the pin while Windows uses a string. It is currently implemented here using str. But (as noted in the previous item) Windows seems to have problems with non-numeric pins, so it might be better to use int.
- [ ] Figure out how to do cross-platform async reading from stdin for the example. I found a method that works nicely on *nix, but it doesn't work on Windows. Everything I have tried on Windows so far causes a crash or locks up stdin.