### PR TITLE
winrt/client: fix crash when getting services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+------
+* Fixed crash when getting services in WinRT backend.
+
 `0.19.1`_ (2022-10-29)
 ======================
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -568,7 +568,11 @@ class BleakClientWinRT(BaseBleakClient):
                 services_changed_event.wait()
             )
             self._services_changed_events.append(services_changed_event)
-            get_services_task = self._requester.get_gatt_services_async(*args)
+
+            async def get_services():
+                return await self._requester.get_gatt_services_async(*args)
+
+            get_services_task = asyncio.create_task(get_services())
 
             try:
                 await asyncio.wait(
@@ -590,7 +594,7 @@ class BleakClientWinRT(BaseBleakClient):
             args = [BluetoothCacheMode.UNCACHED]
 
         services: Sequence[GattDeviceService] = _ensure_success(
-            get_services_task.get_results(),
+            get_services_task.result(),
             "services",
             "Could not get GATT services",
         )


### PR DESCRIPTION
Python 3.11 crashes on Windows when connecting to a device:

    Traceback (most recent call last):
    File "C:\Users\david\Documents\GitHub\Pybricks\bleak\examples\service_explorer.py", line 64, in <module>
        asyncio.run(main(sys.argv[1] if len(sys.argv) == 2 else ADDRESS))
    File "C:\Users\david\AppData\Local\Programs\Python\Python311\Lib\asyncio\runners.py", line 190, in run
        return runner.run(main)
            ^^^^^^^^^^^^^^^^
    File "C:\Users\david\AppData\Local\Programs\Python\Python311\Lib\asyncio\runners.py", line 118, in run
        return self._loop.run_until_complete(task)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\david\AppData\Local\Programs\Python\Python311\Lib\asyncio\base_events.py", line 650, in run_until_complete
        return future.result()
            ^^^^^^^^^^^^^^^
    File "C:\Users\david\Documents\GitHub\Pybricks\bleak\examples\service_explorer.py", line 29, in main
        async with BleakClient(address) as client:
    File "C:\Users\david\Documents\GitHub\Pybricks\bleak\bleak\__init__.py", line 433, in __aenter__
        await self.connect()
    File "C:\Users\david\Documents\GitHub\Pybricks\bleak\bleak\__init__.py", line 471, in connect
        return await self._backend.connect(**kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        await self.get_services()
    File "C:\Users\david\Documents\GitHub\Pybricks\bleak\bleak\backends\winrt\client.py", line 574, in get_services
    File "C:\Users\david\AppData\Local\Programs\Python\Python311\Lib\asyncio\tasks.py", line 418, in wait
        return await _wait(fs, timeout, return_when, loop)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\david\AppData\Local\Programs\Python\Python311\Lib\asyncio\tasks.py", line 522, in _wait
        f.add_done_callback(_on_completion)
        ^^^^^^^^^^^^^^^^^^^
    AttributeError: '_bleak_winrt_Windows_Foundation.IAsyncOperation' object has no attribute 'add_done_callback'

asyncio.wait() requires an asyncio.Task or asyncio.Future, but we were passing a WinRT IAsyncResult object. So we have to wrap it in a coroutine and then in a task to avoid the error.
