### PR TITLE
winrt/client: change get services retry cache mode

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 ------
 * Fixed crash when getting services in WinRT backend.
+* Fixed cache mode when retrying get services in WinRT backend.
 
 `0.19.1`_ (2022-10-29)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -591,7 +591,7 @@ class BleakClientWinRT(BaseBleakClient):
                 "%s: restarting get services due to services changed event",
                 self.address,
             )
-            args = [BluetoothCacheMode.UNCACHED]
+            args = [BluetoothCacheMode.CACHED]
 
         services: Sequence[GattDeviceService] = _ensure_success(
             get_services_task.result(),


### PR DESCRIPTION
This changes the cache mode when getting services after a ServicesChanged event in the WinRT backend. This matches the recommendation of the docs.

https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.gattserviceschanged?view=winrt-20348
