### PR TITLE
winrt/client: fix logger.warn deprecation warning

### DIFF
--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -256,7 +256,7 @@ class BleakClientWinRT(BaseBleakClient):
 
         def handle_services_changed():
             if not self._services_changed_events:
-                logger.warn("%s: unhandled services changed event", self.address)
+                logger.warning("%s: unhandled services changed event", self.address)
             else:
                 for event in self._services_changed_events:
                     event.set()


### PR DESCRIPTION
When run with python3.10 -dev X, we get a warning that warn is deprecated and we should replace it with warning.
