### PR TITLE
pyproject: drop async-timeout dependency on Python >= 3.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* Dropped ``async-timeout`` dependency on Python >= 3.11.
+
 Fixed
 ------
 * Fixed crash when getting services in WinRT backend.

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -28,7 +28,10 @@ from typing import (
 )
 from warnings import warn
 
-import async_timeout
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as async_timeout
+else:
+    from asyncio import timeout as async_timeout
 
 if sys.version_info[:2] < (3, 8):
     from typing_extensions import Literal
@@ -322,7 +325,7 @@ class BleakScanner:
 
         async with cls(detection_callback=apply_filter, **kwargs):
             try:
-                async with async_timeout.timeout(timeout):
+                async with async_timeout(timeout):
                     return await found_device_queue.get()
             except asyncio.TimeoutError:
                 return None

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -5,11 +5,16 @@ BLE Client for BlueZ on Linux
 import asyncio
 import logging
 import os
+import sys
 import warnings
 from typing import Callable, Dict, Optional, Union, cast
 from uuid import UUID
 
-import async_timeout
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as async_timeout
+else:
+    from asyncio import timeout as async_timeout
+
 from dbus_fast.aio import MessageBus
 from dbus_fast.constants import BusType, ErrorType, MessageType
 from dbus_fast.message import Message
@@ -168,7 +173,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                 #
                 if not manager.is_connected(self._device_path):
                     logger.debug("Connecting to BlueZ path %s", self._device_path)
-                    async with async_timeout.timeout(timeout):
+                    async with async_timeout(timeout):
                         reply = await self._bus.call(
                             Message(
                                 destination=defs.BLUEZ_SERVICE,
@@ -329,7 +334,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         if self._disconnecting_event:
             # another call to disconnect() is already in progress
             logger.debug(f"already in progress ({self._device_path})")
-            async with async_timeout.timeout(10):
+            async with async_timeout(10):
                 await self._disconnecting_event.wait()
         elif self.is_connected:
             self._disconnecting_event = asyncio.Event()
@@ -344,7 +349,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     )
                 )
                 assert_reply(reply)
-                async with async_timeout.timeout(10):
+                async with async_timeout(10):
                     await self._disconnecting_event.wait()
             finally:
                 self._disconnecting_event = None

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -8,10 +8,15 @@ Created on June, 25 2019 by kevincar <kevincarrolldavis@gmail.com>
 
 import asyncio
 import logging
+import sys
 import threading
 from typing import Any, Callable, Dict, Optional
 
-import async_timeout
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as async_timeout
+else:
+    from asyncio import timeout as async_timeout
+
 import objc
 from CoreBluetooth import (
     CBCentralManager,
@@ -156,7 +161,7 @@ class CentralManagerDelegate(NSObject):
             self._connect_futures[peripheral.identifier()] = future
             try:
                 self.central_manager.connectPeripheral_options_(peripheral, None)
-                async with async_timeout.timeout(timeout):
+                async with async_timeout(timeout):
                     await future
             finally:
                 del self._connect_futures[peripheral.identifier()]

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -9,9 +9,14 @@ Created by kevincar <kevincarrolldavis@gmail.com>
 import asyncio
 import itertools
 import logging
+import sys
 from typing import Any, Dict, Iterable, NewType, Optional
 
-import async_timeout
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as async_timeout
+else:
+    from asyncio import timeout as async_timeout
+
 import objc
 from Foundation import NSNumber, NSObject, NSArray, NSData, NSError, NSUUID, NSString
 from CoreBluetooth import (
@@ -146,7 +151,7 @@ class PeripheralDelegate(NSObject):
         self._characteristic_read_futures[characteristic.handle()] = future
         try:
             self.peripheral.readValueForCharacteristic_(characteristic)
-            async with async_timeout.timeout(timeout):
+            async with async_timeout(timeout):
                 return await future
         finally:
             del self._characteristic_read_futures[characteristic.handle()]

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -6,12 +6,16 @@ import sys
 import warnings
 from typing import List, Optional
 
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as async_timeout
+else:
+    from asyncio import timeout as async_timeout
+
 if sys.version_info[:2] < (3, 8):
     from typing_extensions import Literal
 else:
     from typing import Literal
 
-import async_timeout
 from android.broadcast import BroadcastReceiver
 from android.permissions import Permission, request_permissions
 from jnius import cast, java_method
@@ -137,7 +141,7 @@ class BleakScannerP4Android(BaseBleakScanner):
         self.__javascanner.flushPendingScanResults(self.__callback.java)
 
         try:
-            async with async_timeout.timeout(0.2):
+            async with async_timeout(0.2):
                 await scanfuture
         except asyncio.exceptions.TimeoutError:
             pass

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -14,7 +14,10 @@ import warnings
 from ctypes import pythonapi
 from typing import Any, Dict, List, Optional, Sequence, Union, cast
 
-import async_timeout
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as async_timeout
+else:
+    from asyncio import timeout as async_timeout
 
 if sys.version_info[:2] < (3, 8):
     from typing_extensions import Literal, TypedDict
@@ -367,7 +370,7 @@ class BleakClientWinRT(BaseBleakClient):
             # This keeps the device connected until we set maintain_connection = False.
 
             # wait for the session to become active
-            async with async_timeout.timeout(timeout):
+            async with async_timeout(timeout):
                 await event.wait()
         except BaseException:
             handle_disconnect()
@@ -416,7 +419,7 @@ class BleakClientWinRT(BaseBleakClient):
                 self._requester.close()
                 # sometimes it can take over one minute before Windows decides
                 # to end the GATT session/disconnect the device
-                async with async_timeout.timeout(120):
+                async with async_timeout(120):
                     await event.wait()
             finally:
                 self._session_closed_events.remove(event)

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,7 +37,7 @@ python-versions = ">=3.5"
 dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
 docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
 tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "Babel"
@@ -98,7 +98,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -457,7 +457,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "snowballstemmer"
@@ -637,7 +637,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "de7999d44b4fa4c454de85be9523558c9d375983122f54d97a97440fb25e558a"
+content-hash = "a8845e45f46b310de561b52d1f17d3c6309c28513c16ac25a50ce751c1a6a116"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-async-timeout = ">= 3.0.0, < 5"
+async-timeout = { version = ">= 3.0.0, < 5", python = "<3.11" }
 typing-extensions = { version = "^4.2.0", python = "<3.8" }
 pyobjc-core = { version = "^8.5.1", markers = "platform_system=='Darwin'" }
 pyobjc-framework-CoreBluetooth = { version = "^8.5.1", markers = "platform_system=='Darwin'" }


### PR DESCRIPTION
Python 3.11 introduced a new `asyncio.timeout()` method that can be used instead of the `async_timeout` package.
