### PR TITLE
Avoid setting negotiate_unix_fd with new BlueZ to Dbus reduce latency

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -495,7 +495,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # We would rather not start notifications if we don't have to.
         if BlueZFeatures.has_mtu_property:
             self._mtu_size = (
-                min(
+                max(
                     c.max_write_without_response_size
                     for c in self.services.characteristics.values()
                 )

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -126,7 +126,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # BlueZ quirk where notifications are automatically enabled on reconnect.
         self._bus = await MessageBus(
             bus_type=BusType.SYSTEM,
-            negotiate_unix_fd=not BlueZFeatures.has_mtu_property,
+            negotiate_unix_fd=not BlueZFeatures.has_mtu_property
+            and not BlueZFeatures.write_without_response_workaround_needed,
         ).connect()
 
         def on_connected_changed(connected: bool) -> None:

--- a/bleak/backends/bluezdbus/version.py
+++ b/bleak/backends/bluezdbus/version.py
@@ -29,6 +29,7 @@ class BlueZFeatures:
     write_without_response_workaround_needed = False
     hides_battery_characteristic = True
     hides_device_name_characteristic = True
+    has_mtu_property = False
     _check_bluez_event: Optional[asyncio.Event] = None
 
     @classmethod
@@ -50,6 +51,7 @@ class BlueZFeatures:
             )
             cls.hides_battery_characteristic = major == 5 and minor >= 48 and minor < 55
             cls.hides_device_name_characteristic = major == 5 and minor >= 48
+            cls.has_mtu_property = major == 5 and minor >= 62
         else:
             # Its possible they may be running inside a container where
             # bluetoothctl is not available and they only have access to the


### PR DESCRIPTION
I'm not sure if this would be as reasonable replacement for `_acquire_mtu` but since it hasn't worked and always raises `StopIteration` for me I'm submitting this as a draft for feedback.

1. Avoids another round trip during auth
2. Avoids the slower unmarshaller path

