### PR TITLE
bluezdbus/manager: ignore KeyError when properties removed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 ------
 * Fixed crash when getting services in WinRT backend.
 * Fixed cache mode when retrying get services in WinRT backend.
+* Fixed ``KeyError`` crash in BlueZ backend when removing non-existent property. Fixes #1107.
 
 `0.19.1`_ (2022-10-29)
 ======================

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -818,7 +818,12 @@ class BlueZManager:
                 self_interface.update(unpack_variants(changed))
 
                 for name in invalidated:
-                    del self_interface[name]
+                    try:
+                        del self_interface[name]
+                    except KeyError:
+                        # sometimes there BlueZ tries to remove properties
+                        # that were never added
+                        pass
 
                 # then call any callbacks so they will be called with the
                 # updated state


### PR DESCRIPTION
Apparently, BlueZ will sometimes request to remove properties that were not set in the first place.

Fixes: #1107
