### PR TITLE
Release/0.19.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+------
+* Fixed crash when getting services in WinRT backend.
+
 `0.19.1`_ (2022-10-29)
 ======================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 ------
 * Fixed crash when getting services in WinRT backend.
+* Fixed cache mode when retrying get services in WinRT backend.
 
 `0.19.1`_ (2022-10-29)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixed
 ------
 * Fixed crash when getting services in WinRT backend.
 * Fixed cache mode when retrying get services in WinRT backend.
+* Fixed ``KeyError`` crash in BlueZ backend when removing non-existent property. Fixes #1107.
 
 `0.19.1`_ (2022-10-29)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,13 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+`0.19.2`_ (2022-11-06)
+======================
+
 Fixed
 ------
-* Fixed crash when getting services in WinRT backend.
-* Fixed cache mode when retrying get services in WinRT backend.
+* Fixed crash when getting services in WinRT backend in Python 3.11. Fixes #1112.
+* Fixed cache mode when retrying get services in WinRT backend. Merged #1102.
 * Fixed ``KeyError`` crash in BlueZ backend when removing non-existent property. Fixes #1107.
 
 `0.19.1`_ (2022-10-29)
@@ -856,7 +859,8 @@ Fixed
 * Bleak created.
 
 
-.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.19.1...develop
+.. _Unreleased: https://github.com/hbldh/bleak/compare/v0.19.2...develop
+.. _0.19.2: https://github.com/hbldh/bleak/compare/v0.19.1...v0.19.2
 .. _0.19.1: https://github.com/hbldh/bleak/compare/v0.19.0...v0.19.1
 .. _0.19.0: https://github.com/hbldh/bleak/compare/v0.18.1...v0.19.0
 .. _0.18.1: https://github.com/hbldh/bleak/compare/v0.18.0...v0.18.1

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -818,7 +818,12 @@ class BlueZManager:
                 self_interface.update(unpack_variants(changed))
 
                 for name in invalidated:
-                    del self_interface[name]
+                    try:
+                        del self_interface[name]
+                    except KeyError:
+                        # sometimes there BlueZ tries to remove properties
+                        # that were never added
+                        pass
 
                 # then call any callbacks so they will be called with the
                 # updated state

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -591,7 +591,7 @@ class BleakClientWinRT(BaseBleakClient):
                 "%s: restarting get services due to services changed event",
                 self.address,
             )
-            args = [BluetoothCacheMode.UNCACHED]
+            args = [BluetoothCacheMode.CACHED]
 
         services: Sequence[GattDeviceService] = _ensure_success(
             get_services_task.result(),

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -568,7 +568,11 @@ class BleakClientWinRT(BaseBleakClient):
                 services_changed_event.wait()
             )
             self._services_changed_events.append(services_changed_event)
-            get_services_task = self._requester.get_gatt_services_async(*args)
+
+            async def get_services():
+                return await self._requester.get_gatt_services_async(*args)
+
+            get_services_task = asyncio.create_task(get_services())
 
             try:
                 await asyncio.wait(
@@ -590,7 +594,7 @@ class BleakClientWinRT(BaseBleakClient):
             args = [BluetoothCacheMode.UNCACHED]
 
         services: Sequence[GattDeviceService] = _ensure_success(
-            get_services_task.get_results(),
+            get_services_task.result(),
             "services",
             "Could not get GATT services",
         )

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -256,7 +256,7 @@ class BleakClientWinRT(BaseBleakClient):
 
         def handle_services_changed():
             if not self._services_changed_events:
-                logger.warn("%s: unhandled services changed event", self.address)
+                logger.warning("%s: unhandled services changed event", self.address)
             else:
                 for event in self._services_changed_events:
                     event.set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bleak"
-version = "0.19.1"
+version = "0.19.2"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 authors = ["Henrik Blidh <henrik.blidh@nedomkull.com>"]
 license = "MIT"


### PR DESCRIPTION

Fixed
------
* Fixed crash when getting services in WinRT backend in Python 3.11. Fixes #1112.
* Fixed cache mode when retrying get services in WinRT backend. Merged #1102.
* Fixed ``KeyError`` crash in BlueZ backend when removing non-existent property. Fixes #1107.
