### PR TITLE
Reduce memory usage of BLEDevice with __slots__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changed
 -------
 * Dropped ``async-timeout`` dependency on Python >= 3.11.
 * Deprecated ``BLEDevice.rssi`` and ``BLEDevice.metadata``. Fixes #1025.
+* ``BLEDevice`` now uses ``__slots__`` to reduce memory usage.
 
 `0.19.2`_ (2022-11-06)
 ======================

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -17,6 +17,8 @@ class BLEDevice:
     A simple wrapper class representing a BLE server detected during scanning.
     """
 
+    __slots__ = ("address", "name", "details", "_rssi", "_metadata")
+
     def __init__(
         self, address: str, name: Optional[str], details: Any, rssi: int, **kwargs
     ):


### PR DESCRIPTION
We have thousands of these floating around in memory so it helps a bit for the RPI3b users.

Not done for `AdvertisementData` since `NamedTuple` already uses `__slots__` under the hood
