### PR TITLE
Instantiate BaseBleakClient.services collection only after service discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Changed
 * Dropped ``async-timeout`` dependency on Python >= 3.11.
 * Deprecated ``BLEDevice.rssi`` and ``BLEDevice.metadata``. Fixes #1025.
 * ``BLEDevice`` now uses ``__slots__`` to reduce memory usage.
+* ``BaseBleakClient.services`` is now ``None`` instead of empty service collection
+  until services are discovered.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -576,7 +576,13 @@ class BleakClient:
         Gets the collection of GATT services available on the device.
 
         The returned value is only valid as long as the device is connected.
+
+        Raises:
+            BleakError: if service discovery has not been performed yet during this connection.
         """
+        if not self._backend.services:
+            raise BleakError("Service Discovery has not been performed yet")
+
         return self._backend.services
 
     # I/O methods

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -309,8 +309,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             self._bus = None
 
             # Reset all stored services.
-            self.services = BleakGATTServiceCollection()
-            self._services_resolved = False
+            self.services = None
 
     async def disconnect(self) -> bool:
         """Disconnect from the specified GATT server.
@@ -587,7 +586,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         if not self.is_connected:
             raise BleakError("Not connected")
 
-        if self._services_resolved:
+        if self.services is not None:
             return self.services
 
         manager = await get_global_bluez_manager()
@@ -595,7 +594,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
         self.services = await manager.get_services(
             self._device_path, dangerous_use_bleak_cache
         )
-        self._services_resolved = True
 
         return self.services
 

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -42,9 +42,7 @@ class BaseBleakClient(abc.ABC):
         else:
             self.address = address_or_ble_device
 
-        self.services = BleakGATTServiceCollection()
-
-        self._services_resolved = False
+        self.services: Optional[BleakGATTServiceCollection] = None
 
         self._timeout = kwargs.get("timeout", 10.0)
         self._disconnected_callback = kwargs.get("disconnected_callback")

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -151,8 +151,7 @@ class BleakClientP4Android(BaseBleakClient):
         self.__callbacks = None
 
         # Reset all stored services.
-        self.services = BleakGATTServiceCollection()
-        self._services_resolved = False
+        self.services = None
 
         return True
 
@@ -246,14 +245,16 @@ class BleakClientP4Android(BaseBleakClient):
            A :py:class:`bleak.backends.service.BleakGATTServiceCollection` with this device's services tree.
 
         """
-        if self._services_resolved:
+        if self.services is not None:
             return self.services
+
+        services = BleakGATTServiceCollection()
 
         logger.debug("Get Services...")
         for java_service in self.__gatt.getServices():
 
             service = BleakGATTServiceP4Android(java_service)
-            self.services.add_service(service)
+            services.add_service(service)
 
             for java_characteristic in java_service.getCharacteristics():
 
@@ -263,7 +264,7 @@ class BleakClientP4Android(BaseBleakClient):
                     service.handle,
                     self.__mtu - 3,
                 )
-                self.services.add_characteristic(characteristic)
+                services.add_characteristic(characteristic)
 
                 for descriptor_index, java_descriptor in enumerate(
                     java_characteristic.getDescriptors()
@@ -275,9 +276,9 @@ class BleakClientP4Android(BaseBleakClient):
                         characteristic.handle,
                         descriptor_index,
                     )
-                    self.services.add_descriptor(descriptor)
+                    services.add_descriptor(descriptor)
 
-        self._services_resolved = True
+        self.services = services
         return self.services
 
     # IO methods

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -414,7 +414,6 @@ class BleakClientWinRT(BaseBleakClient):
                             # services did not change while getting services,
                             # so this is the final result
                             self.services = get_services_task.result()
-                            self._services_resolved = True
                             break
 
                         logger.debug(
@@ -463,10 +462,10 @@ class BleakClientWinRT(BaseBleakClient):
         self._notification_callbacks.clear()
 
         # Dispose all service components that we have requested and created.
-        for service in self.services:
-            service.obj.close()
-        self.services = BleakGATTServiceCollection()
-        self._services_resolved = False
+        if self.services:
+            for service in self.services:
+                service.obj.close()
+            self.services = None
 
         # Without this, disposing the BluetoothLEDevice won't disconnect it
         if self._session:
@@ -616,7 +615,7 @@ class BleakClientWinRT(BaseBleakClient):
         """
 
         # Return the Service Collection.
-        if self._services_resolved:
+        if self.services is not None:
             return self.services
 
         logger.debug(


### PR DESCRIPTION
Instead of using `_services_resolved: bool` and direct access to `services: BleakGATTServiceCollection` collection, this PR changes it to property with additional check whether services were actually discovered - they shall be before `connect()` returns.