### PR TITLE
winrt/client: fix AttributeError in _ensure_success

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,9 @@ Changed
 * Deprecated ``BLEDevice.rssi`` and ``BLEDevice.metadata``. Fixes #1025.
 * ``BLEDevice`` now uses ``__slots__`` to reduce memory usage.
 
+Fixed
+-----
+- Fixed ``AttributeError`` in ``_ensure_success`` in WinRT backend.
 
 `0.19.5`_ (2022-11-19)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -122,7 +122,7 @@ def _ensure_success(result: Any, attr: Optional[str], fail_msg: str) -> Any:
     if status == GattCommunicationStatus.UNREACHABLE:
         raise BleakError(f"{fail_msg}: Unreachable")
 
-    raise BleakError(f"{fail_msg}: Unexpected status code 0x{result.status:02X}")
+    raise BleakError(f"{fail_msg}: Unexpected status code 0x{status:02X}")
 
 
 class WinRTClientArgs(TypedDict, total=False):


### PR DESCRIPTION
result could be None, in which case, result.status would raise an AttributeError. `status` is the intended value in any case.
