### PR TITLE
winrt/client: fix leaking service objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,13 +27,11 @@ Changed
 
 Fixed
 -----
+* Fixed invalid UTF*8 in ``uuids.uuid16_dict``.
 * Fixed ``AttributeError`` in ``_ensure_success`` in WinRT backend.
 * Fixed ``BleakScanner.stop()`` can raise ``BleakDBusError`` with ``org.bluez.Error.NotReady`` in BlueZ backend.
 * Fixed ``BleakScanner.stop()`` hanging in WinRT backend when Bluetooth is disabled.
-
-Fixed
------
-- Fixed invalid UTF-8 in ``uuids.uuid16_dict``.
+* Fixed leaking services when ``get_services()`` is cancelled in WinRT backend.
 
 `0.19.5`_ (2022-11-19)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -391,6 +391,7 @@ class BleakClientWinRT(BaseBleakClient):
 
                 async with async_timeout(timeout):
                     while True:
+                        services_changed_event.clear()
                         services_changed_event_task = asyncio.create_task(
                             services_changed_event.wait()
                         )
@@ -421,7 +422,6 @@ class BleakClientWinRT(BaseBleakClient):
                             self.address,
                         )
                         service_cache_mode = BluetoothCacheMode.CACHED
-                        services_changed_event.clear()
 
                         # ensure the task ran to completion to avoid OSError
                         # on next call to get_services()


### PR DESCRIPTION
If `get_servcies()` is cancelled or otherwise raises an error, the WinRT service objects need to be disposed by calling `close()`. Otherwise, it is going to cause problems for the Windows Bluetooth stack.
