### PR TITLE
bleak: include %(threadName)s in BLEAK_LOGGING

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 * Dropped ``async-timeout`` dependency on Python >= 3.11.
 * Deprecated ``BLEDevice.rssi`` and ``BLEDevice.metadata``. Fixes #1025.
 * ``BLEDevice`` now uses ``__slots__`` to reduce memory usage.
+* Include thread name in ``BLEAK_LOGGING`` output.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -60,7 +60,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 _logger.addHandler(logging.NullHandler())
 if bool(os.environ.get("BLEAK_LOGGING", False)):
-    FORMAT = "%(asctime)-15s %(name)-8s %(levelname)s: %(message)s"
+    FORMAT = "%(asctime)-15s %(name)-8s %(threadName)s %(levelname)s: %(message)s"
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(logging.Formatter(fmt=FORMAT))


### PR DESCRIPTION
This adds `%(threadName)s` to `FORMAT` passed to `logging.basicConfig()` when `BLEAK_LOGGING` is used. This can be useful to debug OS callbacks on background threads.
