### PR TITLE
bluezdbus/manager: suppress org.bluez.Error.NotReady when stopping scanner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Changed
 
 Fixed
 -----
-- Fixed ``AttributeError`` in ``_ensure_success`` in WinRT backend.
+* Fixed ``AttributeError`` in ``_ensure_success`` in WinRT backend.
+* Fixed ``BleakScanner.stop()`` can raise ``BleakDBusError`` with ``org.bluez.Error.NotReady`` in BlueZ backend.
 
 Fixed
 -----


### PR DESCRIPTION
When stopping scanning, we don't want to raise errors if we can be sure that scanning is in fact stopped.

`org.bluez.Error.NotReady` can be triggered if the Bluetooth adapter is turned off after scanning started, in which case we know that it is not scanning, so it is safe to ignore this error.
