### PR TITLE
winrt/scanner: fix stop hanging when Bluetooth disabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,7 +26,8 @@ Changed
 
 Fixed
 -----
-- Fixed ``AttributeError`` in ``_ensure_success`` in WinRT backend.
+* Fixed ``AttributeError`` in ``_ensure_success`` in WinRT backend.
+* Fixed ``BleakScanner.stop()`` hanging in WinRT backend when Bluetooth is disabled.
 
 Fixed
 -----


### PR DESCRIPTION
When Bluetooth is disabled on Windows, we will never get the `BluetoothLEAdvertisementWatcher.Stopped` event from the WinRT API.

We can work around this by checking the status of the watcher to see if we can expect an event.
