### PR TITLE
Examples: added debug flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 -----
 * Added optional hack to use Bluetooth address instead of UUID on macOS.
 * Added ``BleakScanner.find_device_by_name()`` class method.
+* Added optional command line argument to use debug log level to all applicable examples.
 
 Changed
 -------

--- a/examples/async_callback_with_queue.py
+++ b/examples/async_callback_with_queue.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    log_level = "DEBUG" if args.debug else "INFO"
+    log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=log_level,
         format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",

--- a/examples/async_callback_with_queue.py
+++ b/examples/async_callback_with_queue.py
@@ -86,11 +86,6 @@ async def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
-    )
-
     parser = argparse.ArgumentParser()
 
     device_group = parser.add_mutually_exclusive_group(required=True)
@@ -118,6 +113,19 @@ if __name__ == "__main__":
         help="UUID of a characteristic that supports notifications",
     )
 
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="sets the logging level to debug",
+    )
+
     args = parser.parse_args()
+
+    log_level = "DEBUG" if args.debug else "INFO"
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
 
     asyncio.run(main(args))

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -36,11 +36,6 @@ async def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
-    )
-
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -56,6 +51,19 @@ if __name__ == "__main__":
         help="UUIDs of one or more services to filter for",
     )
 
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="sets the logging level to debug",
+    )
+
     args = parser.parse_args()
+
+    log_level = "DEBUG" if args.debug else "INFO"
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
 
     asyncio.run(main(args))

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    log_level = "DEBUG" if args.debug else "INFO"
+    log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=log_level,
         format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",

--- a/examples/disconnect_callback.py
+++ b/examples/disconnect_callback.py
@@ -51,11 +51,6 @@ async def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
-    )
-
     parser = argparse.ArgumentParser()
 
     device_group = parser.add_mutually_exclusive_group(required=True)
@@ -77,6 +72,19 @@ if __name__ == "__main__":
         help="when true use Bluetooth address instead of UUID on macOS",
     )
 
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="sets the log level to debug",
+    )
+
     args = parser.parse_args()
+
+    log_level = "DEBUG" if args.debug else "INFO"
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
 
     asyncio.run(main(args))

--- a/examples/disconnect_callback.py
+++ b/examples/disconnect_callback.py
@@ -81,7 +81,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    log_level = "DEBUG" if args.debug else "INFO"
+    log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=log_level,
         format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    log_level = "DEBUG" if args.debug else "INFO"
+    log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=log_level,
         format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -53,11 +53,6 @@ async def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
-    )
-
     parser = argparse.ArgumentParser()
 
     device_group = parser.add_mutually_exclusive_group(required=True)
@@ -85,6 +80,19 @@ if __name__ == "__main__":
         help="UUID of a characteristic that supports notifications",
     )
 
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="sets the log level to debug",
+    )
+
     args = parser.parse_args()
+
+    log_level = "DEBUG" if args.debug else "INFO"
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
 
     asyncio.run(main(args))

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -80,11 +80,6 @@ async def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
-    )
-
     parser = argparse.ArgumentParser()
 
     device_group = parser.add_mutually_exclusive_group(required=True)
@@ -106,6 +101,19 @@ if __name__ == "__main__":
         help="when true use Bluetooth address instead of UUID on macOS",
     )
 
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        help="sets the log level to debug",
+    )
+
     args = parser.parse_args()
+
+    log_level = "DEBUG" if args.debug else "INFO"
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",
+    )
 
     asyncio.run(main(args))

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    log_level = "DEBUG" if args.debug else "INFO"
+    log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(
         level=log_level,
         format="%(asctime)-15s %(name)-8s %(levelname)s: %(message)s",


### PR DESCRIPTION
Added a debug flag to all applicable examples that enables DEBUG level logging instead of default INFO level.
The flag can be called with either `-d` or `--debug`.