### PR TITLE
Added list of events to set on disconnection to corebluetooth

### DIFF
--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -107,6 +107,11 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                     # the future was already done
                     pass
 
+            # sets all events in self._events_to_set_on_disconnection, without failing if
+            # the list or some of its elements are None
+            for event in filter(None, self._events_to_set_on_disconnection or []):
+                event.set()
+
             if self._disconnected_callback:
                 self._disconnected_callback(self)
 


### PR DESCRIPTION
This is related to #1154. It adds a keyword argument to pass a list of events that are set on disconnection. It could be a way to make the intention of the developer clearer to a reader than passing a `disconnected_callback` setting the events.

I implemented a list because maybe someone would want more than one event to be set on disconnection for whatever reason, but I don't know if this is an overkill and switching to a single event is indeed a better alternative.

This commit was tested on a MacBook Air with M1 and macOS 12.6, and was working.
Similar changes may be easily implemented for other backends too.