### PR TITLE
bluezdbus/client: Make sure the disconnect monitor task is properly cancelled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Added
 * Added optional hack to use Bluetooth address instead of UUID on macOS.
 * Added ``BleakScanner.find_device_by_name()`` class method.
 * Added optional command line argument to use debug log level to all applicable examples.
+* Make sure the disconnect monitor task is properly cancelled on the BlueZ client.
 
 Changed
 -------


### PR DESCRIPTION
Sometimes the exception on connect is raised so early that the disconnect monitor task does not get the disconnect event set because the on_connected_changed callback is already unregistered and the task stays in pending state causing asyncio to throw an exception:
  Task was destroyed but it is pending!