### PR TITLE
Proposal for adding a callback for when peripherals modify services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Added
 -----
 * Added optional hack to use Bluetooth address instead of UUID on macOS.
 * Added ``BleakScanner.find_device_by_name()`` class method.
+* Added services_modified_callback to ``BleakClient``.
 
 Changed
 -------

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -623,6 +623,18 @@ class BleakClient:
         """
         await self._backend.write_gatt_char(char_specifier, data, response)
 
+    def set_services_modified_callback(self, callback: Callable[[], None]) -> None:
+        """
+        Set a callback to be called when the services tree is modified.
+
+        This is only available on macOS and will raise an exception on other platforms.
+
+        Args:
+            callback: The callback to be called when the services tree is modified.
+
+        """
+        self._backend.set_services_modified_callback(callback)
+
     async def start_notify(
         self,
         char_specifier: Union[BleakGATTCharacteristic, int, str, uuid.UUID],

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -10,7 +10,7 @@ import asyncio
 import os
 import platform
 import uuid
-from typing import Callable, Optional, Type, Union
+from typing import Any, Callable, Optional, Type, Union
 from warnings import warn
 
 from ..exc import BleakError
@@ -19,6 +19,7 @@ from .characteristic import BleakGATTCharacteristic
 from .device import BLEDevice
 
 NotifyCallback = Callable[[bytearray], None]
+ServicesModifiedCallback = Callable[[Any], None]
 
 
 class BaseBleakClient(abc.ABC):
@@ -48,6 +49,7 @@ class BaseBleakClient(abc.ABC):
 
         self._timeout = kwargs.get("timeout", 10.0)
         self._disconnected_callback = kwargs.get("disconnected_callback")
+        self._services_modified_callback = kwargs.get("services_modified_callback")
 
     @property
     @abc.abstractmethod
@@ -80,6 +82,30 @@ class BaseBleakClient(abc.ABC):
 
         """
         self._disconnected_callback = callback
+
+    def set_services_modified_callback(
+        self, callback: Optional[ServicesModifiedCallback], **kwargs
+    ) -> None:
+        """Set the services modified callback.
+        The callback will only be called on services modified event.
+
+        Callbacks must accept one input which is the client object itself.
+
+        Set the callback to ``None`` to remove any existing callback.
+
+        .. code-block:: python
+
+            def callback(client):
+                print("Client with address {} got services modified!".format(client.address))
+
+            client.set_services_modified_callback(callback)
+            client.connect()
+
+        Args:
+            callback: callback to be called on services modified.
+
+        """
+        self._services_modified_callback = callback
 
     @abc.abstractmethod
     async def connect(self, **kwargs) -> bool:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -19,7 +19,7 @@ from Foundation import NSArray, NSData
 from ... import BleakScanner
 from ...exc import BleakError, BleakDeviceNotFoundError
 from ..characteristic import BleakGATTCharacteristic
-from ..client import BaseBleakClient, NotifyCallback
+from ..client import BaseBleakClient, NotifyCallback, ServicesModifiedCallback
 from ..device import BLEDevice
 from ..service import BleakGATTServiceCollection
 from .CentralManagerDelegate import CentralManagerDelegate
@@ -379,6 +379,12 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             raise BleakError("Characteristic {} not found!".format(char_specifier))
 
         await self._delegate.stop_notifications(characteristic.obj)
+
+    def set_services_modified_callback(
+        self, callback: Optional[ServicesModifiedCallback], **kwargs
+    ) -> None:
+        super().set_services_modified_callback(callback, **kwargs)
+        self._delegate.set_services_modified_callback(callback, **kwargs)
 
     async def get_rssi(self) -> int:
         """To get RSSI value in dBm of the connected Peripheral"""


### PR DESCRIPTION
This is a proposal for adding a callback that is called when a peripheral modifies its services.

This is useful in the case the peripheral invalidates one or more of its services and I want to trigger a disconnection if the invalidated services are mandatory for the functioning of the application.

I implemented it for the CoreBluetooth backend only as of now, but it should be easy to implement it for other backends as well if needed.

At the moment, the callback takes a list of invalidates services in input, that are the UUIDs of the `NSArray` of invalidated services. It should probably be implemented a utility function to help standardize the UUIDs (because now only a 4chars UUID is returned).
Maybe, a representation of the peripheral invalidating the services should be provided as input too to the callback, but I didn't find a way to convert the peripheral object to a platform independent representation of it.