### PR TITLE
docs: Change code example for BleakClient.start_notify callback

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -644,8 +644,9 @@ class BleakClient:
         and the second will be a ``bytearray`` containing the data received.
 
         .. code-block:: python
+            from bleak.backends.characteristic import BleakGATTCharacteristic
 
-            def callback(sender: int, data: bytearray):
+            def callback(sender: BleakGATTCharacteristic, data: bytearray):
                 print(f"{sender}: {data}")
 
             client.start_notify(char_uuid, callback)

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -44,7 +44,7 @@ from .backends.device import BLEDevice
 from .backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
-    AdvertisementDataFilter,
+    AdvertisementDataFilter
     BaseBleakScanner,
     get_platform_scanner_backend_type,
 )
@@ -644,7 +644,6 @@ class BleakClient:
         and the second will be a ``bytearray`` containing the data received.
 
         .. code-block:: python
-            from bleak.backends.characteristic import BleakGATTCharacteristic
 
             def callback(sender: BleakGATTCharacteristic, data: bytearray):
                 print(f"{sender}: {data}")

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -44,7 +44,7 @@ from .backends.device import BLEDevice
 from .backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
-    AdvertisementDataFilter
+    AdvertisementDataFilter,
     BaseBleakScanner,
     get_platform_scanner_backend_type,
 )


### PR DESCRIPTION
The type of the first argument to the callback changed from `int` to `BleakGATTCharacteristic` in 0.18.0. The code example was still type hinting it as an int.

I have added an import statement for `BleakGATTCharacteristic`, to make the code runnable, but I'm not sure if it should be omitted for clarity/readability/minimize confusion (since type hinting is optional). Feel free to delete that line if you prefer