### PR TITLE
winrt/scanner: drop waiting for matching scan rsp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,8 @@ Fixed
 * Fixed ``BleakScanner.stop()`` can raise ``BleakDBusError`` with ``org.bluez.Error.NotReady`` in BlueZ backend.
 * Fixed ``BleakScanner.stop()`` hanging in WinRT backend when Bluetooth is disabled.
 * Fixed leaking services when ``get_services()`` is cancelled in WinRT backend.
+* Fixed WinRT scanner never calling ``detection_callback`` when a device does
+  not send a scan response. Fixes #1211.
 
 `0.19.5`_ (2022-11-19)
 ======================

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -101,6 +101,13 @@ class BleakScanner:
         **kwargs:
             Additional args for backwards compatibility.
 
+    .. tip:: The first received advertisement in ``detection_callback`` may or
+        may not include scan response data if the remote device supports it.
+        Be sure to take this into account when handing the callback. For example,
+        the scan response often contains the local name of the device so if you
+        are matching a device based on other data but want to display the local
+        name to the user, be sure to wait for ``adv_data.local_name is not None``.
+
     .. versionchanged:: 0.15.0
         ``detection_callback``, ``service_uuids`` and ``scanning_mode`` are no longer keyword-only.
         Added ``bluez`` parameter.

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -124,21 +124,6 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         self._advertisement_pairs[bdaddr] = raw_data
 
-        # if we are expecting scan response and we haven't received both a
-        # regular advertisement and a scan response, don't do callbacks yet,
-        # wait until we have both instead so we get a callback with partial data
-
-        if (raw_data.adv is None or raw_data.scan is None) and (
-            event_args.advertisement_type
-            in [
-                BluetoothLEAdvertisementType.CONNECTABLE_UNDIRECTED,
-                BluetoothLEAdvertisementType.SCANNABLE_UNDIRECTED,
-                BluetoothLEAdvertisementType.SCAN_RESPONSE,
-            ]
-        ):
-            logger.debug("skipping callback, waiting for scan response")
-            return
-
         uuids = []
         mfg_data = {}
         service_data = {}


### PR DESCRIPTION
This removes the logic that skips the detection callback when expecting a scan response. It is valid for devices to broadcast ADV_IND but not respond to a SCAN_REQ (there is no flag that means connectable but not scannable so ADV_IND is the only choice in this case).

Fixes: https://github.com/hbldh/bleak/issues/1211
