### PR TITLE
github: upgrade pip before poetry install

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,8 @@ jobs:
                 id: py
                 with:
                     python-version: ${{ matrix.python-version }}
+            -   name: Upgrade pip
+                run: ${{ steps.py.outputs.python-path }} -m pip install --upgrade pip
             -   name: Create virtual environment
                 run: pipx run poetry env use '${{ steps.py.outputs.python-path }}'
             -   name: Install dependencies


### PR DESCRIPTION
This fixes failures due to invalid wheels on macos with older versions of Python.
