### PR TITLE
github: upgrade pip before poetry install

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -24,6 +24,8 @@ jobs:
                     python-version: ${{ matrix.python-version }}
             -   name: Create virtual environment
                 run: pipx run poetry env use '${{ steps.py.outputs.python-path }}'
+            -   name: Upgrade pip
+                run: pipx run poetry run python -m pip install --upgrade pip
             -   name: Install dependencies
                 run: pipx run poetry install --only main,test
             -   name: Test with pytest


### PR DESCRIPTION
This fixes failures due to invalid wheels on macos with older versions of Python.
