### PR TITLE
backends/corebluetooth/CentralManagerDelegate: fix unhandled exception in __del__

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Fixed
 * Fixed WinRT scanner never calling ``detection_callback`` when a device does
   not send a scan response. Fixes #1211.
 * Fixed ``BLEDevice`` name sometimes incorrectly ``None``.
+* Fixed unhandled exception in ``CentralManagerDelegate`` destructor on macOS. Fixes #1219.
 
 `0.19.5`_ (2022-11-19)
 ======================

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -105,7 +105,13 @@ class CentralManagerDelegate(NSObject):
 
     def __del__(self):
         if objc.macos_available(10, 13):
-            self.central_manager.removeObserver_forKeyPath_(self, "isScanning")
+            try:
+                self.central_manager.removeObserver_forKeyPath_(self, "isScanning")
+            except IndexError:
+                # If self.init() raised an exception before calling
+                # addObserver_forKeyPath_options_context_, attempting
+                # to remove the observer will fail with IndexError
+                pass
 
     # User defined functions
 


### PR DESCRIPTION

Since the init() method can raise an exception before registering the observer, attempting to unregister the observer will fail with IndexError. We can safely ignore this error.

Fixes: https://github.com/hbldh/bleak/issues/1219
