### PR TITLE
bleak: fix disconnected_callback arg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Fixed
   not send a scan response. Fixes #1211.
 * Fixed ``BLEDevice`` name sometimes incorrectly ``None``.
 * Fixed unhandled exception in ``CentralManagerDelegate`` destructor on macOS. Fixes #1219.
+* Fixed object passed to ``disconnected_callback`` is not ``BleakClient``. Fixes #1200.
 
 `0.19.5`_ (2022-11-19)
 ======================

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -441,7 +441,9 @@ class BleakClient:
 
         self._backend = PlatformBleakClient(
             address_or_ble_device,
-            disconnected_callback=disconnected_callback,
+            disconnected_callback=None
+            if disconnected_callback is None
+            else functools.partial(disconnected_callback, self),
             services=None
             if services is None
             else set(map(normalize_uuid_str, services)),
@@ -507,7 +509,9 @@ class BleakClient:
             FutureWarning,
             stacklevel=2,
         )
-        self._backend.set_disconnected_callback(callback, **kwargs)
+        self._backend.set_disconnected_callback(
+            None if callback is None else functools.partial(callback, self), **kwargs
+        )
 
     async def connect(self, **kwargs) -> bool:
         """Connect to the specified GATT server.

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -157,7 +157,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
                         self._cleanup_all()
                         if self._disconnected_callback is not None:
-                            self._disconnected_callback(self)
+                            self._disconnected_callback()
                         disconnecting_event = self._disconnecting_event
                         if disconnecting_event:
                             disconnecting_event.set()

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -45,7 +45,9 @@ class BaseBleakClient(abc.ABC):
         self.services: Optional[BleakGATTServiceCollection] = None
 
         self._timeout = kwargs.get("timeout", 10.0)
-        self._disconnected_callback = kwargs.get("disconnected_callback")
+        self._disconnected_callback: Optional[Callable[[], None]] = kwargs.get(
+            "disconnected_callback"
+        )
 
     @property
     @abc.abstractmethod
@@ -56,22 +58,12 @@ class BaseBleakClient(abc.ABC):
     # Connectivity methods
 
     def set_disconnected_callback(
-        self, callback: Optional[Callable[["BaseBleakClient"], None]], **kwargs
+        self, callback: Optional[Callable[[], None]], **kwargs
     ) -> None:
         """Set the disconnect callback.
         The callback will only be called on unsolicited disconnect event.
 
-        Callbacks must accept one input which is the client object itself.
-
         Set the callback to ``None`` to remove any existing callback.
-
-        .. code-block:: python
-
-            def callback(client):
-                print("Client with address {} got disconnected!".format(client.address))
-
-            client.set_disconnected_callback(callback)
-            client.connect()
 
         Args:
             callback: callback to be called on disconnection.

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -117,7 +117,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                     pass
 
             if self._disconnected_callback:
-                self._disconnected_callback(self)
+                self._disconnected_callback()
 
         manager = self._central_manager_delegate
         logger.debug("CentralManagerDelegate  at {}".format(manager))

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -551,7 +551,7 @@ class _PythonBluetoothGattCallback(utils.AsyncJavaCallbacks):
             new_state == defs.BluetoothProfile.STATE_DISCONNECTED
             and self._client._disconnected_callback is not None
         ):
-            self._client._disconnected_callback(self._client)
+            self._client._disconnected_callback()
 
     @java_method("(II)V")
     def onMtuChanged(self, mtu, status):

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -313,7 +313,7 @@ class BleakClientWinRT(BaseBleakClient):
 
             elif args.status == GattSessionStatus.CLOSED:
                 if self._disconnected_callback:
-                    self._disconnected_callback(self)
+                    self._disconnected_callback()
 
                 for e in self._session_closed_events:
                     e.set()


### PR DESCRIPTION
Since reworking to have a common top-level `BleakClient` class, the `disconnected_callback` function was called with the backend object rather than the top-level `BleakClient` object.

This fixes the mistake by using functools.partial to bind the top-level object to the function and eliminates the need to pass an argument in the backends.
