### PR TITLE
bleak: fix leaking of ensure_future()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,12 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* Fixed possible garbage collection of running async callback from ``BleakClient.start_notify()``.
+* Fixed possible garbage collection of running async callback from ``BleakScanner(detection_callback=)``.
+* Fixed possible garbage collection of disconnect monitor in BlueZ backend. Fixed #1258.
+
 `0.20.0`_ (2023-03-17)
 ======================
 


### PR DESCRIPTION
As noted in the Python docs, a reference to the return value of `asyncio.ensure_future()` must be held in order to prevent it from being garbage collected before the task completes.

This applies the recommended fix from the docs of holding the reference in a global set and then discarding the reference when the task completes.

Also change `asyncio.ensure_future()` to `asyncio.create_task()` while we are touching this since the minimum supported Python version is now 3.7.

Fixes: https://github.com/hbldh/bleak/issues/1258
