### PR TITLE
winrt/client: ignore session closed event during connect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Fixed
 -----
 - Fixed ``org.bluez.Error.InProgress`` in characteristic and descriptor read and
   write methods in BlueZ backend.
+- Fixed ``OSError: [WinError -2147483629] The object has been closed`` when
+  connecting on Windows. Fixes #1280.
 
 `0.20.1`_ (2023-03-24)
 ======================


### PR DESCRIPTION
As described in https://github.com/hbldh/bleak/issues/1280, it is possible for a session to be closed then activated again while getting services. This will cause an OSError because the closed event triggers the disconnect cleanup code, then trying to use the session after that fails because it has been closed.

This works around the problem by disabling the disconnect cleanup code until the connect method has returned successfully. If the connect method raises an exception, it handles cleanup already so the cleanup code in the session status event handler never gets called in this case.
