### PR TITLE
backends/bluezdbus/client: retry on InProgress

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+- Fixed ``org.bluez.Error.InProgress`` in characteristic and descriptor read and
+  write methods in BlueZ backend.
+
 `0.20.1`_ (2023-03-24)
 ======================
 


### PR DESCRIPTION
Calling "ReadValue" and "WriteValue" on both characteristics and descriptors can fail will "org.bluez.Error.InProgress" if another read or write is currently in progress. This can be a problem if tasks or called in parallel or if a task is cancelled.

Instead of making users manually implement a retry, we can do it for them.
