### PR TITLE
backends/winrt/client: improve get_services() error messages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+- Improved error messages when failing to get services in WinRT backend.
+
 `0.20.2`_ (2023-04-19)
 ======================
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -543,7 +543,6 @@ class BleakClientWinRT(BaseBleakClient):
             device_information.pairing.can_pair
             and not device_information.pairing.is_paired
         ):
-
             # Currently only supporting Just Works solutions...
             ceremony = DevicePairingKinds.CONFIRM_ONLY
             custom_pairing = device_information.pairing.custom
@@ -706,7 +705,7 @@ class BleakClientWinRT(BaseBleakClient):
                 characteristics: Sequence[GattCharacteristic] = _ensure_success(
                     await FutureLike(service.get_characteristics_async(*args)),
                     "characteristics",
-                    f"Could not get GATT characteristics for {service}",
+                    f"Could not get GATT characteristics for service {service.uuid} ({service.attribute_handle})",
                 )
 
                 logger.debug("returned from get_characteristics_async")
@@ -723,7 +722,7 @@ class BleakClientWinRT(BaseBleakClient):
                     descriptors: Sequence[GattDescriptor] = _ensure_success(
                         await FutureLike(characteristic.get_descriptors_async(*args)),
                         "descriptors",
-                        f"Could not get GATT descriptors for {service}",
+                        f"Could not get GATT descriptors for characteristic {characteristic.uuid} ({characteristic.attribute_handle})",
                     )
 
                     logger.debug("returned from get_descriptors_async")


### PR DESCRIPTION
The error messages were reporting something like:

    <_bleak_winrt_Windows_Devices_Bluetooth_GenericAttributeProfile.GattDeviceService object at 0x00000206F9189750>

This is the repr of the service object which isn't very useful. Change the error message to include some useful identification properties instead.
