### PR TITLE
backends/winrt/client: handle arbitrary access denied

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changed
 -------
 - Improved error messages when failing to get services in WinRT backend.
 
+Fixed
+-----
+- Fix handling all access denied errors when enumerating characteristics on Windows. Fixes #1291.
+
 `0.20.2`_ (2023-04-19)
 ======================
 


### PR DESCRIPTION
We had a hard-coded list of services know to return an access denied error when attempting to enumerate characteristics. However, since we don't know Windows internals, the list was not exhaustive and it could also change in the future.

Instead, we can just check for the access denied error and skip any service that returns that error which should also handle additional services we don't know about yet.

Fixes: https://github.com/hbldh/bleak/issues/1291
