### PR TITLE
Added support for 32bit UUID's added in 4.1 of the Bluetooth spec

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changed
 Fixed
 -----
 - Fix handling all access denied errors when enumerating characteristics on Windows. Fixes #1291.
+- Added support for 32bit UUIDs. Fixes #1314 
 
 `0.20.2`_ (2023-04-19)
 ======================

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -1155,7 +1155,7 @@ def normalize_uuid_str(uuid: str) -> str:
     Normaizes a UUID to the format used by Bleak.
 
     - Converted to lower case.
-    - 16-bit UUIDs are expanded to 128-bit.
+    - 16-bit and 32-bit UUIDs are expanded to 128-bit.
 
     BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part B - Section 2.5.1
 

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -1160,6 +1160,8 @@ def normalize_uuid_str(uuid: str) -> str:
     BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part B - Section 2.5.1
 
     .. versionadded:: 0.20.0
+    .. versionchanged:: 0.21.0
+        Added support for 32-bit UUIDs.
     """
     if len(uuid) == 4:
         # Bluetooth SIG registered 16-bit UUIDs

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -1157,11 +1157,16 @@ def normalize_uuid_str(uuid: str) -> str:
     - Converted to lower case.
     - 16-bit UUIDs are expanded to 128-bit.
 
+    BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part B - Section 2.5.1
+
     .. versionadded:: 0.20.0
     """
     if len(uuid) == 4:
         # Bluetooth SIG registered 16-bit UUIDs
         uuid = f"0000{uuid}-0000-1000-8000-00805f9b34fb"
+    elif len(uuid) == 8:
+        # Bluetooth SIG registered 32-bit UUIDs
+        uuid = f"{uuid}-0000-1000-8000-00805f9b34fb"
 
     # let UUID class do the validation and conversion to lower case
     return str(UUID(uuid))

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -1157,12 +1157,11 @@ def normalize_uuid_str(uuid: str) -> str:
     - Converted to lower case.
     - 16-bit and 32-bit UUIDs are expanded to 128-bit.
 
-    BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part B - Section 2.5.1
-
     .. versionadded:: 0.20.0
     .. versionchanged:: 0.21.0
         Added support for 32-bit UUIDs.
     """
+    # See: BLUETOOTH CORE SPECIFICATION Version 5.4 | Vol 3, Part B - Section 2.5.1
     if len(uuid) == 4:
         # Bluetooth SIG registered 16-bit UUIDs
         uuid = f"0000{uuid}-0000-1000-8000-00805f9b34fb"

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -3,6 +3,7 @@ from bleak.uuids import normalize_uuid_str
 
 def test_uuid_length_normalization():
     assert normalize_uuid_str("1801") == "00001801-0000-1000-8000-00805f9b34fb"
+    assert normalize_uuid_str("DAF51C01") == "daf51c01-0000-1000-8000-00805f9b34fb"
 
 
 def test_uuid_case_normalization():


### PR DESCRIPTION
Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.7+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
