### PR TITLE
BleakScanner: Add async iterator scanning capability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Changed
 * Scanner backends modified to allow multiple advertisement callbacks. Merged #1367.
 * Changed default handling of the ``response`` argument in ``BleakClient.write_gatt_char``.
   Fixes #909.
-* Added ``advertisement_data()`` async iterator method to ``BleakScanner``.
+* Added ``advertisement_data()`` async iterator method to ``BleakScanner``. Merged #1361.
 * Added ``scan_iterator.py`` example.
 
 Fixed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,8 @@ Changed
 * Scanner backends modified to allow multiple advertisement callbacks. Merged #1367.
 * Changed default handling of the ``response`` argument in ``BleakClient.write_gatt_char``.
   Fixes #909.
+* Added ``advertisement_data()`` async iterator method to ``BleakScanner``.
+* Added ``scan_iterator.py`` example.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -227,7 +227,7 @@ class BleakScanner:
         Returns:
             An async iterator that yields tuples (:class:`BLEDevice`, :class:`AdvertisementData`).
 
-        .. versionadded:: 0.20.1
+        .. versionadded:: 0.21
         """
         devices = asyncio.Queue()
 

--- a/docs/api/scanner.rst
+++ b/docs/api/scanner.rst
@@ -62,12 +62,18 @@ following methods:
 Getting discovered devices and advertisement data
 -------------------------------------------------
 
-If you aren't using the "easy" class methods, there are two ways to get the
+If you aren't using the "easy" class methods, there are three ways to get the
 discovered devices and advertisement data.
 
 For event-driven programming, you can provide a ``detection_callback`` callback
 to the :class:`BleakScanner` constructor. This will be called back each time
 and advertisement is received.
+
+Alternatively, you can utilize the asynchronous iterator to iterate over
+advertisements as they are received. The method below returns an async iterator
+that yields the same tuples as otherwise provided to ``detection_callback``.
+
+.. automethod:: bleak.BleakScanner.advertisement_data
 
 Otherwise, you can use one of the properties below after scanning has stopped.
 

--- a/examples/scan_iterator.py
+++ b/examples/scan_iterator.py
@@ -1,0 +1,37 @@
+"""
+Scan/Discovery Async Iterator
+--------------
+
+Example showing how to scan for BLE devices using async iterator instead of callback function
+
+Created on 2023-07-07 by bojanpotocnik <info@bojanpotocnik.com>
+
+"""
+import asyncio
+
+from bleak import BleakScanner
+
+
+async def main():
+    async with BleakScanner() as scanner:
+        print("Scanning...")
+
+        n = 5
+        print(f"\n{n} advertisement packets:")
+        async for bd, ad in scanner.advertisement_data():
+            print(f" {n}. {bd!r} with {ad!r}")
+            n -= 1
+            if n == 0:
+                break
+
+        n = 10
+        print(f"\nFind device with name longer than {n} characters...")
+        async for bd, ad in scanner.advertisement_data():
+            found = len(bd.name or "") > n or len(ad.local_name or "") > n
+            print(f" Found{' it' if found else ''} {bd!r} with {ad!r}")
+            if found:
+                break
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
> Enable using `BleakScanner()` as an async iterator (async for), combining detection_callback and filtering functionality. `BleakScanner().devices()` method has the same functionality with option to provide timeout.

I noticed that almost every time I use `bleak`, one of the first things is to create scanner method which combines `discover()` and `find_device_by_filter()` functionality "in concurrent fashion", without the need of using callbacks and queue. This enables reporting scanned devices immediately while giving all the filtering flexibility, even when scanning for multiple devices with different filters.