### PR TITLE
backends/scanner: Fix typing for callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,8 @@ Changed
 Fixed
 -----
 - Fix handling all access denied errors when enumerating characteristics on Windows. Fixes #1291.
-- Added support for 32bit UUIDs. Fixes #1314 
+- Added support for 32bit UUIDs. Fixes #1314.
+- Fixed typing for ``BaseBleakScanner`` detection callback.
 
 `0.20.2`_ (2023-04-19)
 ======================

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -5,8 +5,8 @@ import os
 import platform
 from typing import (
     Any,
-    Awaitable,
     Callable,
+    Coroutine,
     Dict,
     List,
     NamedTuple,
@@ -91,7 +91,7 @@ class AdvertisementData(NamedTuple):
 
 AdvertisementDataCallback = Callable[
     [BLEDevice, AdvertisementData],
-    Optional[Awaitable[None]],
+    Optional[Coroutine[Any, Any, None]],
 ]
 """
 Type alias for callback called when advertisement data is received.
@@ -134,7 +134,7 @@ class BaseBleakScanner(abc.ABC):
         service_uuids: Optional[List[str]],
     ):
         super(BaseBleakScanner, self).__init__()
-        self._callback: Optional[AdvertisementDataCallback] = None
+        self._callback: Optional[Callable[[BLEDevice, AdvertisementData], None]] = None
         self.register_detection_callback(detection_callback)
         self._service_uuids: Optional[List[str]] = (
             [u.lower() for u in service_uuids] if service_uuids is not None else None


### PR DESCRIPTION
Function `register_detection_callback()` of `BaseBleakScanner` ensures that `_callback` is a synchronous function, so change its typing accordingly.

Additionally, passing `Awaitable` to `asyncio.create_task()` results in warning:
>  Unexpected type(s): (Awaitable[None] | None)
>  Possible type(s): (Generator[Any, None, Any] | Coroutine)

Every coroutine is an awaitable, but not every awaitable is a coroutine, so change the `AdvertisementDataFilter` type accordingly.

---


Not sure if this needs an entry in `CHANGELOG.rst` as it does not affect runtime functionality in any way?