### PR TITLE
backends: allow multiple advertisement callbacks per scanner

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Changed
 -------
 - Improved error messages when failing to get services in WinRT backend.
-- Scanner backends modified to allow multiple advertisement callbacks.
+- Scanner backends modified to allow multiple advertisement callbacks. Merged #1367.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Changed
 -------
 - Improved error messages when failing to get services in WinRT backend.
+- Scanner backends modified to allow multiple advertisement callbacks.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -175,7 +175,17 @@ class BleakScanner:
             FutureWarning,
             stacklevel=2,
         )
-        self._backend.register_detection_callback(callback)
+
+        try:
+            unregister = getattr(self, "_unregister_")
+        except AttributeError:
+            pass
+        else:
+            unregister()
+
+        if callback is not None:
+            unregister = self._backend.register_detection_callback(callback)
+            setattr(self, "_unregister_", unregister)
 
     async def start(self):
         """Start scanning for devices"""

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -273,10 +273,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             advertisement_data,
         )
 
-        if self._callback is None:
-            return
-
-        self._callback(device, advertisement_data)
+        self.call_detection_callbacks(device, advertisement_data)
 
     def _handle_device_removed(self, device_path: str) -> None:
         """

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -146,10 +146,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
                 advertisement_data,
             )
 
-            if not self._callback:
-                return
-
-            self._callback(device, advertisement_data)
+            self.call_detection_callbacks(device, advertisement_data)
 
         self._manager.callbacks[id(self)] = callback
         await self._manager.start_scan(self._service_uuids)

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -271,10 +271,7 @@ class BleakScannerP4Android(BaseBleakScanner):
             advertisement,
         )
 
-        if not self._callback:
-            return
-
-        self._callback(device, advertisement)
+        self.call_detection_callbacks(device, advertisement)
 
 
 class _PythonScanCallback(utils.AsyncJavaCallbacks):

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -194,7 +194,7 @@ class BaseBleakScanner(abc.ABC):
 
     def call_detection_callbacks(
         self, device: BLEDevice, advertisement_data: AdvertisementData
-    ):
+    ) -> None:
         """
         Calls all registered detection callbacks.
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -137,7 +137,7 @@ class BaseBleakScanner(abc.ABC):
 
         self._ad_callbacks: List[Callable[[BLEDevice, AdvertisementData], None]] = []
         """
-        List of callbacks to call when an advertisement is received
+        List of callbacks to call when an advertisement is received.
         """
 
         if detection_callback is not None:

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -134,8 +134,15 @@ class BaseBleakScanner(abc.ABC):
         service_uuids: Optional[List[str]],
     ):
         super(BaseBleakScanner, self).__init__()
-        self._callback: Optional[Callable[[BLEDevice, AdvertisementData], None]] = None
-        self.register_detection_callback(detection_callback)
+
+        self._ad_callbacks: List[Callable[[BLEDevice, AdvertisementData], None]] = []
+        """
+        List of callbacks to call when an advertisement is received
+        """
+
+        if detection_callback is not None:
+            self.register_detection_callback(detection_callback)
+
         self._service_uuids: Optional[List[str]] = (
             [u.lower() for u in service_uuids] if service_uuids is not None else None
         )
@@ -144,11 +151,10 @@ class BaseBleakScanner(abc.ABC):
 
     def register_detection_callback(
         self, callback: Optional[AdvertisementDataCallback]
-    ) -> None:
-        """Register a callback that is called when a device is discovered or has a property changed.
-
-        If another callback has already been registered, it will be replaced with ``callback``.
-        ``None`` can be used to remove the current callback.
+    ) -> Callable[[], None]:
+        """
+        Register a callback that is called when an advertisement event from the
+        OS is received.
 
         The ``callback`` is a function or coroutine that takes two arguments: :class:`BLEDevice`
         and :class:`AdvertisementData`.
@@ -156,15 +162,18 @@ class BaseBleakScanner(abc.ABC):
         Args:
             callback: A function, coroutine or ``None``.
 
+        Returns:
+            A method that can be called to unregister the callback.
         """
-        if callback is not None:
-            error_text = "callback must be callable with 2 parameters"
-            if not callable(callback):
-                raise TypeError(error_text)
+        error_text = "callback must be callable with 2 parameters"
 
-            handler_signature = inspect.signature(callback)
-            if len(handler_signature.parameters) != 2:
-                raise TypeError(error_text)
+        if not callable(callback):
+            raise TypeError(error_text)
+
+        handler_signature = inspect.signature(callback)
+
+        if len(handler_signature.parameters) != 2:
+            raise TypeError(error_text)
 
         if inspect.iscoroutinefunction(callback):
 
@@ -176,7 +185,24 @@ class BaseBleakScanner(abc.ABC):
         else:
             detection_callback = callback
 
-        self._callback = detection_callback
+        self._ad_callbacks.append(detection_callback)
+
+        def remove():
+            self._ad_callbacks.remove(detection_callback)
+
+        return remove
+
+    def call_detection_callbacks(
+        self, device: BLEDevice, advertisement_data: AdvertisementData
+    ):
+        """
+        Calls all registered detection callbacks.
+
+        Backend implementations should call this method when an advertisement
+        event is received from the OS.
+        """
+        for callback in self._ad_callbacks:
+            callback(device, advertisement_data)
 
     def create_or_update_device(
         self, address: str, name: str, details: Any, adv: AdvertisementData

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -188,9 +188,6 @@ class BleakScannerWinRT(BaseBleakScanner):
             bdaddr, local_name, raw_data, advertisement_data
         )
 
-        if self._callback is None:
-            return
-
         # On Windows, we have to fake service UUID filtering. If we were to pass
         # a BluetoothLEAdvertisementFilter to the BluetoothLEAdvertisementWatcher
         # with the service UUIDs appropriately set, we would no longer receive
@@ -205,7 +202,7 @@ class BleakScannerWinRT(BaseBleakScanner):
                 # if there were no matching service uuids, the don't call the callback
                 return
 
-        self._callback(device, advertisement_data)
+        self.call_detection_callbacks(device, advertisement_data)
 
     def _stopped_handler(self, sender, e):
         logger.debug(


### PR DESCRIPTION
We are considering adding an async iterator that can be used to handle advertisement data as it is received. It will be trivial for users to create multiple parallel iterators, so instead of disallowing it, this prepares the way to allow multiple simultaneous subscribers.
