### PR TITLE
Raise BleakError if the device disappears before trying to resolve services

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,8 @@ Fixed
 * Fixed typing for ``BaseBleakScanner`` detection callback.
 * Fixed possible crash in ``_stopped_handler()`` in WinRT backend. Fixes #1330.
 * Reduced expensive logging in the BlueZ backend. Merged #1376.
+* Raise ``BleakError`` instead of ``KeyError`` when a device disappears from
+  the bus in BlueZ backend when starting to wait for services to be resolved.
 
 `0.20.2`_ (2023-04-19)
 ======================

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -668,6 +668,11 @@ class BlueZManager:
 
         If a disconnect happens before the completion a BleakError exception is raised.
         """
+        if device_path not in self._properties:
+            raise BleakError(
+                f"Device '{device_path}' disappeared while waiting to discover services"
+            )
+
         services_discovered_wait_task = asyncio.create_task(
             self._wait_condition(device_path, "ServicesResolved", True)
         )


### PR DESCRIPTION
split from https://github.com/hbldh/bleak/pull/1329