### PR TITLE
Update of bleak on android and the android kivy example

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,6 +20,7 @@ Contributors
 * Jonathan Soto <jsotogaviard@alum.mit.edu>
 * Kyle J. Williams <kyle@kjwill.tech>
 * Edward Betts <edward@4angle.com>
+* Robbe Gaeremynck <robbe.gaeremynck@outlook.com>
 
 Sponsors
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ Changed
 * Scanner backends modified to allow multiple advertisement callbacks. Merged #1367.
 * Changed default handling of the ``response`` argument in ``BleakClient.write_gatt_char``.
   Fixes #909.
+* Added missing permissions and requirements in android kivy example. Fixes #1184.
+* Bleak recipe now automatically installs bleak from github release.
 
 Fixed
 -----

--- a/bleak/backends/p4android/recipes/bleak/__init__.py
+++ b/bleak/backends/p4android/recipes/bleak/__init__.py
@@ -8,34 +8,34 @@ from os.path import join
 
 class BleakRecipe(PythonRecipe):
     version = None  # Must be none for p4a to correctly clone repo
-    fix_setup_py_version = 'bleak develop branch'
-    url = 'git+https://github.com/hbldh/bleak.git'
+    fix_setup_py_version = "bleak develop branch"
+    url = "git+https://github.com/hbldh/bleak.git"
     name = "bleak"
 
     depends = ["pyjnius"]
     call_hostpython_via_targetpython = False
 
-    fix_setup_filename = 'fix_setup.py'
+    fix_setup_filename = "fix_setup.py"
 
     def prepare_build_dir(self, arch):
         super().prepare_build_dir(arch)  # Unpack the url file to the get_build_dir
         build_dir = self.get_build_dir(arch)
 
-        setup_py_path = join(build_dir, 'setup.py')
+        setup_py_path = join(build_dir, "setup.py")
         if not os.path.exists(setup_py_path):
             # Perform the p4a temporary fix
             # At the moment, p4a recipe installing requires setup.py to be present
             # So, we create a setup.py file only for android
 
             fix_setup_py_path = join(self.get_recipe_dir(), self.fix_setup_filename)
-            with open(fix_setup_py_path, 'r') as f:
+            with open(fix_setup_py_path, "r") as f:
                 contents = f.read()
 
             # Write to the correct location and fill in the version number
-            with open(setup_py_path, 'w') as f:
-                f.write(contents.replace('[VERSION]', self.fix_setup_py_version))
+            with open(setup_py_path, "w") as f:
+                f.write(contents.replace("[VERSION]", self.fix_setup_py_version))
         else:
-            info('setup.py found in bleak directory, are you installing older version?')
+            info("setup.py found in bleak directory, are you installing older version?")
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         env = super().get_recipe_env(arch, with_flags_in_cc)
@@ -48,7 +48,9 @@ class BleakRecipe(PythonRecipe):
 
         info("Copying java files")
         dest_dir = self.ctx.javaclass_dir
-        path = join(self.get_build_dir(arch.arch), "bleak", "backends", "p4android", "java", ".")
+        path = join(
+            self.get_build_dir(arch.arch), "bleak", "backends", "p4android", "java", "."
+        )
 
         shprint(sh.cp, "-a", path, dest_dir)
 

--- a/bleak/backends/p4android/recipes/bleak/__init__.py
+++ b/bleak/backends/p4android/recipes/bleak/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from pythonforandroid.recipe import PythonRecipe
 from pythonforandroid.toolchain import shprint, info
 import sh
@@ -5,23 +7,34 @@ from os.path import join
 
 
 class BleakRecipe(PythonRecipe):
-    version = None
-    url = None
+    version = '0.20.2'
+    url = 'https://github.com/hbldh/bleak/archive/refs/tags/v{version}.tar.gz'
     name = "bleak"
-
-    src_filename = join("..", "..", "..", "..", "..")
 
     depends = ["pyjnius"]
     call_hostpython_via_targetpython = False
 
+    fix_setup_filename = 'fix_setup.py'
+
     def prepare_build_dir(self, arch):
-        shprint(sh.rm, "-rf", self.get_build_dir(arch))
-        shprint(
-            sh.ln,
-            "-s",
-            join(self.get_recipe_dir(), self.src_filename),
-            self.get_build_dir(arch),
-        )
+        super().prepare_build_dir(arch)  # Unpack the url file to the get_build_dir
+        build_dir = self.get_build_dir(arch)
+
+        setup_py_path = join(build_dir, 'setup.py')
+        if not os.path.exists(setup_py_path):
+            # Perform the p4a temporary fix
+            # At the moment, p4a recipe installing requires setup.py to be present
+            # So, we create a setup.py file only for android
+
+            fix_setup_py_path = join(self.get_recipe_dir(), self.fix_setup_filename)
+            with open(fix_setup_py_path, 'r') as f:
+                contents = f.read()
+
+            # Write to the correct location and fill in the version number
+            with open(setup_py_path, 'w') as f:
+                f.write(contents.replace('[VERSION]', self.version))
+        else:
+            info('setup.py found in bleak directory, are you installing older version?')
 
     def get_recipe_env(self, arch=None, with_flags_in_cc=True):
         env = super().get_recipe_env(arch, with_flags_in_cc)
@@ -33,13 +46,10 @@ class BleakRecipe(PythonRecipe):
         super().postbuild_arch(arch)
 
         info("Copying java files")
+        dest_dir = self.ctx.javaclass_dir
+        path = join(self.get_build_dir(arch.arch), "bleak", "backends", "p4android", "java", ".")
 
-        destdir = self.ctx.javaclass_dir
-        path = join(
-            self.get_build_dir(arch.arch), "bleak", "backends", "p4android", "java", "."
-        )
-
-        shprint(sh.cp, "-a", path, destdir)
+        shprint(sh.cp, "-a", path, dest_dir)
 
 
 recipe = BleakRecipe()

--- a/bleak/backends/p4android/recipes/bleak/__init__.py
+++ b/bleak/backends/p4android/recipes/bleak/__init__.py
@@ -7,8 +7,9 @@ from os.path import join
 
 
 class BleakRecipe(PythonRecipe):
-    version = '0.20.2'
-    url = 'https://github.com/hbldh/bleak/archive/refs/tags/v{version}.tar.gz'
+    version = None  # Must be none for p4a to correctly clone repo
+    fix_setup_py_version = 'bleak develop branch'
+    url = 'git+https://github.com/hbldh/bleak.git'
     name = "bleak"
 
     depends = ["pyjnius"]
@@ -32,7 +33,7 @@ class BleakRecipe(PythonRecipe):
 
             # Write to the correct location and fill in the version number
             with open(setup_py_path, 'w') as f:
-                f.write(contents.replace('[VERSION]', self.version))
+                f.write(contents.replace('[VERSION]', self.fix_setup_py_version))
         else:
             info('setup.py found in bleak directory, are you installing older version?')
 

--- a/bleak/backends/p4android/recipes/bleak/fix_setup.py
+++ b/bleak/backends/p4android/recipes/bleak/fix_setup.py
@@ -1,0 +1,45 @@
+from setuptools import find_packages, setup
+
+VERSION = "[VERSION]"  # Version will be filled in by the bleak recipe
+
+# Package meta-data.
+NAME = "bleak"
+DESCRIPTION = "Bluetooth Low Energy platform Agnostic Klient"
+URL = "https://github.com/hbldh/bleak"
+EMAIL = "henrik.blidh@nedomkull.com"
+AUTHOR = "Henrik Blidh"
+
+# Where the magic happens:
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    author=AUTHOR,
+    author_email=EMAIL,
+    url=URL,
+    packages=find_packages(exclude=("tests", "examples", "docs", "BleakUWPBridge")),
+    entry_points={"console_scripts": ["bleak-lescan=bleak:cli"]},
+    test_suite="tests",
+    include_package_data=True,
+    license="MIT",
+    classifiers=[
+        # Trove classifiers
+        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        "Development Status :: 4 - Beta",
+        "Framework :: AsyncIO",
+        "Intended Audience :: Developers",
+        "Topic :: Communications",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Operating System :: Microsoft :: Windows :: Windows 10",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: Implementation :: CPython",
+    ]
+)

--- a/bleak/backends/p4android/recipes/bleak/fix_setup.py
+++ b/bleak/backends/p4android/recipes/bleak/fix_setup.py
@@ -1,45 +1,10 @@
 from setuptools import find_packages, setup
 
 VERSION = "[VERSION]"  # Version will be filled in by the bleak recipe
-
-# Package meta-data.
 NAME = "bleak"
-DESCRIPTION = "Bluetooth Low Energy platform Agnostic Klient"
-URL = "https://github.com/hbldh/bleak"
-EMAIL = "henrik.blidh@nedomkull.com"
-AUTHOR = "Henrik Blidh"
 
-# Where the magic happens:
 setup(
     name=NAME,
     version=VERSION,
-    description=DESCRIPTION,
-    author=AUTHOR,
-    author_email=EMAIL,
-    url=URL,
     packages=find_packages(exclude=("tests", "examples", "docs", "BleakUWPBridge")),
-    entry_points={"console_scripts": ["bleak-lescan=bleak:cli"]},
-    test_suite="tests",
-    include_package_data=True,
-    license="MIT",
-    classifiers=[
-        # Trove classifiers
-        # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        "Development Status :: 4 - Beta",
-        "Framework :: AsyncIO",
-        "Intended Audience :: Developers",
-        "Topic :: Communications",
-        "License :: OSI Approved :: MIT License",
-        "Natural Language :: English",
-        "Operating System :: Microsoft :: Windows :: Windows 10",
-        "Operating System :: POSIX :: Linux",
-        "Operating System :: MacOS :: MacOS X",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-    ]
 )

--- a/bleak/backends/p4android/recipes/bleak/fix_setup.py
+++ b/bleak/backends/p4android/recipes/bleak/fix_setup.py
@@ -6,5 +6,5 @@ NAME = "bleak"
 setup(
     name=NAME,
     version=VERSION,
-    packages=find_packages(exclude=("tests", "examples", "docs", "BleakUWPBridge")),
+    packages=find_packages(exclude=("tests", "examples", "docs")),
 )

--- a/examples/kivy/README.md
+++ b/examples/kivy/README.md
@@ -1,8 +1,12 @@
-## This is a kivy application that lists scanned devices in a desktop window.
+## This is a kivy application that lists scanned devices in a desktop window
 
 - An iOS backend has not been implemented yet.
 
 - This kivy example can also be run on desktop.
+
+The default target architecture is arm64-v8a.
+If you have an older device, change it in the buildozer.spec file (android.archs = arch1, arch2, ..).
+Multiple targets are allowed (will significantly increase build time).
 
 It can be run on Android via:
 
@@ -13,12 +17,14 @@ It can be run on Android via:
 
 ## To use with local version of bleak source:
 
+Local source path can be specified using the P4A_bleak_DIR environment variable:
+
+    P4A_bleak_DIR="path to bleak source" buildozer android debug
+
+
+
 Note: changes to `bleak/**` will not be automatically picked up when rebuilding.
 Instead the recipe build must be cleaned:
-
-**Update: not tested if bleak source code changes still work via this method.
-Since recipe should now automatically install bleak from GitHub release.**
-
 
     buildozer android p4a -- clean_recipe_build --local-recipes $(pwd)/../../bleak/backends/p4android/recipes bleak
 
@@ -26,6 +32,6 @@ Since recipe should now automatically install bleak from GitHub release.**
 
 - Copy the bleak folder under bleak/backends/p4android/recipes into the app recipes folder.
 Make sure that 'local_recipes' in buildozer.spec points to the app recipes folder.
-The release version set in the recipe will be installed automatically.
+The latest version of bleak will be installed automatically.
 
 - Add 'bleak' and it's dependencies to the requirements in your buildozer.spec file.

--- a/examples/kivy/README.md
+++ b/examples/kivy/README.md
@@ -15,3 +15,9 @@ Instead the recipe build must be cleaned:
 An iOS backend has not been implemented yet.
 
 This kivy example can also be run on desktop.
+
+**To use bleak in your own app:**
+
+Copy the bleak folder under bleak/backends/p4android/recipes into the app recipes folder.
+Make sure that 'local_recipes' in buildozer.spec points to the app recipes folder.
+Add 'bleak' and it's dependencies to the requirements in your buildozer.spec file.

--- a/examples/kivy/README.md
+++ b/examples/kivy/README.md
@@ -1,4 +1,8 @@
-This is a kivy application that lists scanned devices in a desktop window.
+## This is a kivy application that lists scanned devices in a desktop window.
+
+- An iOS backend has not been implemented yet.
+
+- This kivy example can also be run on desktop.
 
 It can be run on Android via:
 
@@ -7,17 +11,21 @@ It can be run on Android via:
     # connect phone with USB and enable USB debugging
     buildozer android deploy run logcat
 
+## To use with local version of bleak source:
+
 Note: changes to `bleak/**` will not be automatically picked up when rebuilding.
 Instead the recipe build must be cleaned:
 
+**Update: not tested if bleak source code changes still work via this method.
+Since recipe should now automatically install bleak from GitHub release.**
+
+
     buildozer android p4a -- clean_recipe_build --local-recipes $(pwd)/../../bleak/backends/p4android/recipes bleak
 
-An iOS backend has not been implemented yet.
+## To use bleak in your own app:
 
-This kivy example can also be run on desktop.
-
-**To use bleak in your own app:**
-
-Copy the bleak folder under bleak/backends/p4android/recipes into the app recipes folder.
+- Copy the bleak folder under bleak/backends/p4android/recipes into the app recipes folder.
 Make sure that 'local_recipes' in buildozer.spec points to the app recipes folder.
-Add 'bleak' and it's dependencies to the requirements in your buildozer.spec file.
+The release version set in the recipe will be installed automatically.
+
+- Add 'bleak' and it's dependencies to the requirements in your buildozer.spec file.

--- a/examples/kivy/buildozer.spec
+++ b/examples/kivy/buildozer.spec
@@ -38,7 +38,12 @@ version = 0.1.0
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3,kivy,bleak,async_to_sync
+requirements =
+    python3,
+    kivy,
+    bleak,
+    async_to_sync,
+    async-timeout
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes
@@ -90,7 +95,14 @@ fullscreen = 0
 #android.presplash_lottie = "path/to/lottie/file.json"
 
 # (list) Permissions
-android.permissions = BLUETOOTH,BLUETOOTH_ADMIN,ACCESS_FINE_LOCATION,ACCESS_COARSE_LOCATION,ACCESS_BACKGROUND_LOCATION
+android.permissions =
+    BLUETOOTH,
+    BLUETOOTH_SCAN,
+    BLUETOOTH_CONNECT,
+    BLUETOOTH_ADMIN,
+    ACCESS_FINE_LOCATION,
+    ACCESS_COARSE_LOCATION,
+    ACCESS_BACKGROUND_LOCATION
 
 # (list) features (adds uses-feature -tags to manifest)
 #android.features = android.hardware.usb.host
@@ -225,7 +237,7 @@ android.accept_sdk_license = True
 #android.copy_libs = 1
 
 # (str) The Android arch to build for, choices: armeabi-v7a, arm64-v8a, x86, x86_64
-android.arch = armeabi-v7a
+android.archs = arm64-v8a
 
 # (int) overrides automatic versionCode computation (used in build.gradle)
 # this is not the same as app version and should only be edited if you know what you're doing
@@ -243,7 +255,6 @@ android.allow_backup = True
 
 # (str) python-for-android fork to use, defaults to upstream (kivy)
 #p4a.fork = kivy
-#p4a.fork = xloem
 
 # (str) python-for-android branch to use, defaults to master
 #p4a.branch = master


### PR DESCRIPTION
Update of bleak on android  and the android kivy example
---------------------------------

When trying to build my app with bleak, the android kivy example seemed out of date.

**Commmit: 51b277ee3fce9d7f6fa77579e3371b5fdcaa2045 :**
-  'async-timeout' was missing as a requirement in the buildozer.spec file. Fixes https://github.com/hbldh/bleak/issues/1184 ?
- 'BLUETOOTH_SCAN' and 'BLUETOOTH_CONNECT' permissions were missing in buildoze.spec file
- android.arch is deprecated, android.archs is preferred now
- updated armeabi-v7a to arm64-v8a as default architecture

**Commit:  17afc9553d2dbc7b41d4185dbb4c13fc25f7ab4e :**
- The bleak recipe was not working, this had two issues:

1. The recipe was quite project directory structure dependant. This works for the example, but not for your own projects and if docker mounts come into play (as is the case for me). To solve this, the recipe now has a url to the latest release of bleak. So now to use bleak in your own app, just copy the recipe and point to it and add the necessary requirements to buildozer.spec.

2.  The current develop branch of p4a installs recipes based on the setup.py file. See  [p4a PythonRecipe](https://github.com/kivy/python-for-android/blob/fa3e5bfe39286e4a293882a4db0728d9bf9f4968/pythonforandroid/recipe.py#L930C5-L957C54). Which is not available anymore in the current develop branch of bleak. As a temporary fix, fix_setup.py is copied into the bleak build directory. 


Looking forward to a response,

Kind regards,

robgar2001