### PR TITLE
fix BlueZ wait condition disconnect race

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,7 @@ Fixed
 * Fixed typing for ``BaseBleakScanner`` detection callback.
 * Fixed possible crash in ``_stopped_handler()`` in WinRT backend. Fixes #1330.
 * Reduced expensive logging in the BlueZ backend. Merged #1376.
+* Fixed race condition with ``"InterfaceRemoved"`` when getting services in BlueZ backend.
 
 `0.20.2`_ (2023-04-19)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
 * Scanner backends modified to allow multiple advertisement callbacks. Merged #1367.
 * Changed default handling of the ``response`` argument in ``BleakClient.write_gatt_char``.
   Fixes #909.
+* Changed `BlueZManager` methods to raise `BleakError` when device is not in BlueZ.
 
 Fixed
 -----


### PR DESCRIPTION
Alternative to #1329 and #1377.

@bdraco could you please take a look?

The issue addressed by #1377 seems more widespread, so I took it a bit farther to make sure it is fixed in all public functions (first commit).

Instead of synthesizing a `"Connected"` property change as proposed in #1329, here I have opted to just add a 3rd race condition on `"InterfacesRemoved"` when waiting for services to be resolved (second commit).