### PR TITLE
backends/winrt/client.py: Add delay before closing services.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixed
 * Reduced expensive logging in the BlueZ backend. Merged #1376.
 * Fixed race condition with ``"InterfaceRemoved"`` when getting services in BlueZ backend.
 * Optimize BlueZ backend device watchers and condition callbacks to avoid linear searches
+* Fixed WinRT backend sometimes hanging forever when a device goes out of range during connection. Fixes #1359.
 
 `0.20.2`_ (2023-04-19)
 ======================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -469,6 +469,11 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Dispose all service components that we have requested and created.
         if self.services:
+            # HACK: sometimes GattDeviceService.Close() hangs forever, so we
+            # add a delay to give the Windows Bluetooth stack some time to
+            # "settle" before closing the services
+            await asyncio.sleep(0.1)
+
             for service in self.services:
                 service.obj.close()
             self.services = None
@@ -729,6 +734,12 @@ class BleakClientWinRT(BaseBleakClient):
             # Don't leak services. WinRT is quite particular about services
             # being closed.
             logger.debug("disposing service objects")
+
+            # HACK: sometimes GattDeviceService.Close() hangs forever, so we
+            # add a delay to give the Windows Bluetooth stack some time to
+            # "settle" before closing the services
+            await asyncio.sleep(0.1)
+
             for service in services:
                 service.close()
             raise


### PR DESCRIPTION
It appears that GattDeviceService.Close() can hang forever under
certain circumstances.  This change adds a 0.1 second delay before
closing services to see if that helps.

Fixes: https://github.com/hbldh/bleak/issues/1359
