### PR TITLE
backends/bluezdbus: don't import dbus_next directly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+- Fixed importing unnecessary ``gi`` import in BlueZ backend. Fixes #1412.
+
+
 `0.21.0`_ (2023-09-02)
 ======================
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -25,7 +25,9 @@ from typing import (
 )
 from weakref import WeakKeyDictionary
 
-from dbus_fast import BusType, Message, MessageType, Variant, unpack_variants
+from dbus_fast.constants import BusType, MessageType
+from dbus_fast.service import Message, Variant
+from dbus_fast.unpack import unpack_variants
 from dbus_fast.aio.message_bus import MessageBus
 
 from ...exc import BleakDBusError, BleakError

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable, Coroutine, Dict, List, Literal, Optional, TypedDict
 from warnings import warn
 
-from dbus_fast import Variant
+from dbus_fast.service import Variant
 
 from ...exc import BleakError
 from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner


### PR DESCRIPTION
The top-level dbus_next module tries to import the GLib backend that is not used by Bleak. This wastes memory and can cause a crash if the available version of `gi` is not compatible.

Fixes: https://github.com/hbldh/bleak/issues/1412
