### PR TITLE
fix: incorrect mypy diagnosis of Unpack[ExtraArgs].

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Contributors
 * Edward Betts <edward@4angle.com>
 * Robbe Gaeremynck <robbe.gaeremynck@outlook.com>
 * David Johansen <davejohansen@gmail.com>
+* JP Hutchins <jphutchins@gmail.com>
 
 Sponsors
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changed
 Fixed
 -----
 * Fixed BlueZ version in passive scanning error message. Fixes #1433.
+* Fixed mypy requiring ``Unpack[ExtraArgs]`` that were intended to be optional.  Fixes #1487.
 
 `0.21.1`_ (2023-09-08)
 ======================

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -245,7 +245,7 @@ class BleakScanner:
         finally:
             unregister_callback()
 
-    class ExtraArgs(TypedDict):
+    class ExtraArgs(TypedDict, total=False):
         """
         Keyword args from :class:`~bleak.BleakScanner` that can be passed to
         other convenience methods.


### PR DESCRIPTION
Fixes #1487 in the simplest way, according to https://peps.python.org/pep-0692/#required-and-non-required-keys.  This has the effect of making the `BleakScanner` `ExtraArgs` optional instead of required.

For reference:

```python
    class ExtraArgs(TypedDict):
        """
        Keyword args from :class:`~bleak.BleakScanner` that can be passed to
        other convenience methods.
        """

        service_uuids: List[str]
        """
        Optional list of service UUIDs to filter on. Only advertisements
        containing this advertising data will be received. Required on
        macOS >= 12.0, < 12.3 (unless you create an app with ``py2app``).
        """
        scanning_mode: Literal["active", "passive"]
        """
        Set to ``"passive"`` to avoid the ``"active"`` scanning mode.
        Passive scanning is not supported on macOS! Will raise
        :class:`BleakError` if set to ``"passive"`` on macOS.
        """
        bluez: BlueZScannerArgs
        """
        Dictionary of arguments specific to the BlueZ backend.
        """
        cb: CBScannerArgs
        """
        Dictionary of arguments specific to the CoreBluetooth backend.
        """
        backend: Type[BaseBleakScanner]
        """
        Used to override the automatically selected backend (i.e. for a
            custom backend).
        """
```