### PR TITLE
Fix _wait_removed completion on invalid object path

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Fixed
 * Fixed BlueZ version in passive scanning error message. Fixes #1433.
 * Fixed mypy requiring ``Unpack[ExtraArgs]`` that were intended to be optional.  Fixes #1487.
 * Fixed ``KeyError`` in BlueZ ``is_connected()`` and ``get_global_bluez_manager()`` when device is not present. Fixes #1507.
-* Fixed BlueZ _wait_removed completion on invalid object path. Fixes #1489.
+* Fixed BlueZ ``_wait_removed`` completion on invalid object path. Fixes #1489.
 
 `0.21.1`_ (2023-09-08)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixed
 * Fixed BlueZ version in passive scanning error message. Fixes #1433.
 * Fixed mypy requiring ``Unpack[ExtraArgs]`` that were intended to be optional.  Fixes #1487.
 * Fixed ``KeyError`` in BlueZ ``is_connected()`` and ``get_global_bluez_manager()`` when device is not present. Fixes #1507.
+* Fixed BlueZ _wait_removed completion on invalid object path. Fixes #1489.
 
 `0.21.1`_ (2023-09-08)
 ======================

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -812,8 +812,9 @@ class BlueZManager:
 
         event = asyncio.Event()
 
-        def callback(_: str):
-            event.set()
+        def callback(o: str) -> None:
+            if o == device_path:
+                event.set()
 
         device_removed_callback_and_state = DeviceRemovedCallbackAndState(
             callback, self._properties[device_path][defs.DEVICE_INTERFACE]["Adapter"]


### PR DESCRIPTION
The _wait_removed method registers the "InterfacesRemoved" callback on the adapter path of the device without checking which object was removed when called.
This means that any removed interface while a connection is being established can cause the _wait_removed to complete and cancel the connection.

This commit simply checks that the callback is for the proper device object path.

Fixes #1489