### PR TITLE
WinRT: check scanner for abort

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Fixed
 * Fixed ``KeyError`` in BlueZ ``is_connected()`` and ``get_global_bluez_manager()`` when device is not present. Fixes #1507.
 * Fixed BlueZ ``_wait_removed`` completion on invalid object path. Fixes #1489.
 * Fixed rare unhandled exception when scanning on macOS when using ``use_bdaddr``. Fixes #1523.
+* Fixed scanning silently failing on Windows when Bluetooth is off. Fixes #1535.
 
 `0.21.1`_ (2023-09-08)
 ======================

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -22,6 +22,7 @@ else:
     )
 
 from ...assigned_numbers import AdvertisementDataType
+from ...exc import BleakError
 from ...uuids import normalize_uuid_str
 from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
 
@@ -83,7 +84,7 @@ class BleakScannerWinRT(BaseBleakScanner):
     ):
         super(BleakScannerWinRT, self).__init__(detection_callback, service_uuids)
 
-        self.watcher = None
+        self.watcher: Optional[BluetoothLEAdvertisementWatcher] = None
         self._advertisement_pairs: Dict[int, _RawAdvData] = {}
         self._stopped_event = None
 
@@ -220,6 +221,9 @@ class BleakScannerWinRT(BaseBleakScanner):
         self._stopped_event.set()
 
     async def start(self) -> None:
+        if self.watcher:
+            raise BleakError("Scanner already started")
+
         # start with fresh list of discovered devices
         self.seen_devices = {}
         self._advertisement_pairs.clear()

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -248,6 +248,16 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         self.watcher.start()
 
+        # no events for status changes, so we have to poll :-(
+        while self.watcher.status == BluetoothLEAdvertisementWatcherStatus.CREATED:
+            await asyncio.sleep(0.01)
+
+        if self.watcher.status == BluetoothLEAdvertisementWatcherStatus.ABORTED:
+            raise BleakError("Failed to start scanner. Is Bluetooth turned on?")
+
+        if self.watcher.status != BluetoothLEAdvertisementWatcherStatus.STARTED:
+            raise BleakError(f"Unexpected watcher status: {self.watcher.status.name}")
+
     async def stop(self) -> None:
         self.watcher.stop()
 


### PR DESCRIPTION
This adds a check to give a useful error message instead of silently failing if Bluetooth is off.