### PR TITLE
backends/p4android: fix using wrong tx_power value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixed
 * Fixed BlueZ ``_wait_removed`` completion on invalid object path. Fixes #1489.
 * Fixed rare unhandled exception when scanning on macOS when using ``use_bdaddr``. Fixes #1523.
 * Fixed scanning silently failing on Windows when Bluetooth is off. Fixes #1535.
+* Fixed using wrong value for ``tx_power`` in Android backend. Fixes #1532.
 
 `0.21.1`_ (2023-09-08)
 ======================

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -243,10 +243,10 @@ class BleakScannerP4Android(BaseBleakScanner):
             entry.getKey().toString(): bytes(entry.getValue())
             for entry in record.getServiceData().entrySet()
         }
-        tx_power = result.getTxPower()
+        tx_power = record.getTxPowerLevel()
 
         # change "not present" value to None to match other backends
-        if tx_power == defs.ScanResult.TX_POWER_NOT_PRESENT:
+        if tx_power == -2147483648:  # Integer#MIN_VALUE
             tx_power = None
 
         advertisement = AdvertisementData(


### PR DESCRIPTION
This was using the advertisement received signal strength indicator instead of the transmitted power level. This is now fixed.

Fixes: https://github.com/hbldh/bleak/issues/1532
