### PR TITLE
backends/service: normalize UUIDs in get_characteristic()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 * Fixed rare unhandled exception when scanning on macOS when using ``use_bdaddr``. Fixes #1523.
 * Fixed scanning silently failing on Windows when Bluetooth is off. Fixes #1535.
 * Fixed using wrong value for ``tx_power`` in Android backend. Fixes #1532.
+* Fixed 4-character UUIDs not working on ``BleakClient.*_gatt_char`` methods. Fixes #1498.
 
 `0.21.1`_ (2023-09-08)
 ======================

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -176,10 +176,12 @@ class BleakGATTServiceCollection:
         if isinstance(specifier, int):
             return self.characteristics.get(specifier)
 
+        uuid = normalize_uuid_str(str(specifier))
+
         # Assume uuid usage.
         x = list(
             filter(
-                lambda x: x.uuid == str(specifier).lower(),
+                lambda x: x.uuid == uuid,
                 self.characteristics.values(),
             )
         )


### PR DESCRIPTION
This fixes 4-character UUIDs causing BleakCharacteristicNotFoundError instead of being properly resolved.

Fixes: https://github.com/hbldh/bleak/issues/1498
