### PR TITLE
backends/winrt: add address acquisition process when advertising data is None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* Retrieve the BLE address required by ``BleakClientWinRT`` from scan response if advertising is None (WinRT).
+* Changed type hint for ``adv`` attribute of ``bleak.backends.winrt.scanner._RawAdvData``.
+
 `0.22.1`_ (2024-05-07)
 ======================
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -218,7 +218,10 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Backend specific. WinRT objects.
         if isinstance(address_or_ble_device, BLEDevice):
-            self._device_info = address_or_ble_device.details.adv.bluetooth_address
+            if address_or_ble_device.details.adv is not None:
+                self._device_info = address_or_ble_device.details.adv.bluetooth_address
+            else:
+                self._device_info = address_or_ble_device.details.scan.bluetooth_address
         else:
             self._device_info = None
         self._requested_services = (
@@ -293,7 +296,10 @@ class BleakClientWinRT(BaseBleakClient):
                     self.address, f"Device with address {self.address} was not found."
                 )
 
-            self._device_info = device.details.adv.bluetooth_address
+            if device.details.adv is not None:
+                self._device_info = device.details.adv.bluetooth_address
+            else:
+                self._device_info = device.details.scan.bluetooth_address
 
         logger.debug("Connecting to BLE device @ %s", self.address)
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -218,10 +218,8 @@ class BleakClientWinRT(BaseBleakClient):
 
         # Backend specific. WinRT objects.
         if isinstance(address_or_ble_device, BLEDevice):
-            if address_or_ble_device.details.adv is not None:
-                self._device_info = address_or_ble_device.details.adv.bluetooth_address
-            else:
-                self._device_info = address_or_ble_device.details.scan.bluetooth_address
+            data = address_or_ble_device.details
+            self._device_info = (data.adv or data.scan).bluetooth_address
         else:
             self._device_info = None
         self._requested_services = (
@@ -296,10 +294,8 @@ class BleakClientWinRT(BaseBleakClient):
                     self.address, f"Device with address {self.address} was not found."
                 )
 
-            if device.details.adv is not None:
-                self._device_info = device.details.adv.bluetooth_address
-            else:
-                self._device_info = device.details.scan.bluetooth_address
+            data = device.details
+            self._device_info = (data.adv or data.scan).bluetooth_address
 
         logger.debug("Connecting to BLE device @ %s", self.address)
 

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -50,7 +50,7 @@ class _RawAdvData(NamedTuple):
     advertising data like other platforms, so se have to do it ourselves.
     """
 
-    adv: BluetoothLEAdvertisementReceivedEventArgs
+    adv: Optional[BluetoothLEAdvertisementReceivedEventArgs]
     """
     The advertisement data received from the BluetoothLEAdvertisementWatcher.Received event.
     """


### PR DESCRIPTION
In some situations, device.details has the scan response data only and advertising data is None.

Since the ble address cannot be obtained from device.details.adv this time, the ble address is obtained from the device.details.scan (scan response data).

