### PR TITLE
backends: filter discovered devices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Changed
 * Retrieve the BLE address required by ``BleakClientWinRT`` from scan response if advertising is None (WinRT).
 * Changed type hint for ``adv`` attribute of ``bleak.backends.winrt.scanner._RawAdvData``.
 
+Fixed
+-----
+* Fixed ``discovered_devices_and_advertisement_data`` returning devices that should
+  be filtered out by service UUIDs. Fixes #1576.
+
 `0.22.1`_ (2024-05-07)
 ======================
 

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -237,6 +237,10 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             path: The D-Bus object path of the device.
             props: The D-Bus object properties of the device.
         """
+        _service_uuids = props.get("UUIDs", [])
+
+        if not self.is_allowed_uuid(_service_uuids):
+            return
 
         # Get all the information wanted to pack in the advertisement data
         _local_name = props.get("Name")
@@ -244,7 +248,6 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             k: bytes(v) for k, v in props.get("ManufacturerData", {}).items()
         }
         _service_data = {k: bytes(v) for k, v in props.get("ServiceData", {}).items()}
-        _service_uuids = props.get("UUIDs", [])
 
         # Get tx power data
         tx_power = props.get("TxPower")

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -92,6 +92,13 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
 
         def callback(p: CBPeripheral, a: Dict[str, Any], r: int) -> None:
 
+            service_uuids = [
+                cb_uuid_to_str(u) for u in a.get("kCBAdvDataServiceUUIDs", [])
+            ]
+
+            if not self.is_allowed_uuid(service_uuids):
+                return
+
             # Process service data
             service_data_dict_raw = a.get("kCBAdvDataServiceData", {})
             service_data = {
@@ -107,10 +114,6 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
                 )
                 manufacturer_value = bytes(manufacturer_binary_data[2:])
                 manufacturer_data[manufacturer_id] = manufacturer_value
-
-            service_uuids = [
-                cb_uuid_to_str(u) for u in a.get("kCBAdvDataServiceUUIDs", [])
-            ]
 
             # set tx_power data if available
             tx_power = a.get("kCBAdvDataTxPowerLevel")

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -233,6 +233,9 @@ class BleakScannerP4Android(BaseBleakScanner):
         if service_uuids is not None:
             service_uuids = [service_uuid.toString() for service_uuid in service_uuids]
 
+        if not self.is_allowed_uuid(service_uuids):
+            return
+
         manufacturer_data = record.getManufacturerSpecificData()
         manufacturer_data = {
             manufacturer_data.keyAt(index): bytes(manufacturer_data.valueAt(index))

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -188,6 +188,9 @@ class BleakScannerWinRT(BaseBleakScanner):
                 data = bytes(section.data)
                 service_data[str(UUID(bytes=bytes(data[15::-1])))] = data[16:]
 
+        if not self.is_allowed_uuid(uuids):
+            return
+
         # Use the BLEDevice to populate all the fields for the advertisement data to return
         advertisement_data = AdvertisementData(
             local_name=local_name,

--- a/examples/discover.py
+++ b/examples/discover.py
@@ -18,7 +18,9 @@ async def main(args: argparse.Namespace):
     print("scanning for 5 seconds, please wait...")
 
     devices = await BleakScanner.discover(
-        return_adv=True, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+        return_adv=True,
+        service_uuids=args.services,
+        cb=dict(use_bdaddr=args.macos_use_bdaddr),
     )
 
     for d, a in devices.values():
@@ -30,6 +32,13 @@ async def main(args: argparse.Namespace):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--services",
+        metavar="<uuid>",
+        nargs="*",
+        help="UUIDs of one or more services to filter for",
+    )
 
     parser.add_argument(
         "--macos-use-bdaddr",


### PR DESCRIPTION
This is a follow-up to a818521 ("backends/scanner: always filter by service_uuids") to also filter discovered devices by the service UUIDs.

This was overlooked in that change and on Windows actually caused a regression.

Fixes: https://github.com/hbldh/bleak/issues/1576
