### PR TITLE
Android: fix 'Descriptor None was not found!'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Fixed
 -----
 * Fixed ``discovered_devices_and_advertisement_data`` returning devices that should
   be filtered out by service UUIDs. Fixes #1576.
+* Fixed a ``Descriptor None was not found!`` exception occurring in ``start_notify()`` on Android. Fixes #823
+  and #828.
 
 `0.22.1`_ (2024-05-07)
 ======================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,8 +19,7 @@ Fixed
 -----
 * Fixed ``discovered_devices_and_advertisement_data`` returning devices that should
   be filtered out by service UUIDs. Fixes #1576.
-* Fixed a ``Descriptor None was not found!`` exception occurring in ``start_notify()`` on Android. Fixes #823
-  and #828.
+* Fixed a ``Descriptor None was not found!`` exception occurring in ``start_notify()`` on Android. Fixes #823.
 
 `0.22.1`_ (2024-05-07)
 ======================

--- a/bleak/backends/p4android/defs.py
+++ b/bleak/backends/p4android/defs.py
@@ -5,6 +5,7 @@ import enum
 from jnius import autoclass, cast
 
 import bleak.exc
+from bleak.uuids import normalize_uuid_16
 
 # caching constants avoids unnecessary extra use of the jni-python interface, which can be slow
 
@@ -87,4 +88,4 @@ CHARACTERISTIC_PROPERTY_DBUS_NAMES = {
     BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE: "write-without-response",
 }
 
-CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = "2902"
+CLIENT_CHARACTERISTIC_CONFIGURATION_UUID = normalize_uuid_16(0x2902)


### PR DESCRIPTION
Use the 128bit UUID plus the Bluetooth base UUID for the notification descriptor on android devices. This fixes `Descriptor None was not found!` exceptions, as discussed in #823.

On the three android devices (API Level 33 and 32) I tested, this seems to work reliably. 

As this is just a minor fix, I did not add an entry to the `CHANGELOG.rst`. 
Let me know if that should be changed.


This fix may also address #828.