### PR TITLE
backends/characteristic: make max_write_without_response_size dynamic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changed
 -------
 * Retrieve the BLE address required by ``BleakClientWinRT`` from scan response if advertising is None (WinRT).
 * Changed type hint for ``adv`` attribute of ``bleak.backends.winrt.scanner._RawAdvData``.
-* ``BleakGATTCharacteristic.max_write_without_response_size`` is is now dynamic.
+* ``BleakGATTCharacteristic.max_write_without_response_size`` is now dynamic.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Changed
 -------
 * Retrieve the BLE address required by ``BleakClientWinRT`` from scan response if advertising is None (WinRT).
 * Changed type hint for ``adv`` attribute of ``bleak.backends.winrt.scanner._RawAdvData``.
+* ``BleakGATTCharacteristic.max_write_without_response_size`` is is now dynamic.
 
 Fixed
 -----
@@ -56,7 +57,7 @@ Fixed
 * Fixed scanning silently failing on Windows when Bluetooth is off. Fixes #1535.
 * Fixed using wrong value for ``tx_power`` in Android backend. Fixes #1532.
 * Fixed 4-character UUIDs not working on ``BleakClient.*_gatt_char`` methods. Fixes #1498.
-* Fixed race condition with getting max PDU size on Windows. Fixes #1497.
+* Fixed race condition with getting max PDU size on Windows. Fixes #1497. [REVERTED in unreleased]
 * Fixed filtering advertisement data by service UUID when multiple apps are scanning. Fixes #1534.
 
 `0.21.1`_ (2023-09-08)

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Callable, List, Union
 from uuid import UUID
 
 from ..characteristic import BleakGATTCharacteristic
@@ -36,7 +36,7 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         object_path: str,
         service_uuid: str,
         service_handle: int,
-        max_write_without_response_size: int,
+        max_write_without_response_size: Callable[[], int],
     ):
         super(BleakGATTCharacteristicBlueZDBus, self).__init__(
             obj, max_write_without_response_size

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -696,7 +696,7 @@ class BlueZManager:
                     service.handle,
                     # "MTU" property was added in BlueZ 5.62, otherwise fall
                     # back to minimum MTU according to Bluetooth spec.
-                    char_props.get("MTU", 23) - 3,
+                    lambda: char_props.get("MTU", 23) - 3,
                 )
 
                 services.add_characteristic(char)

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -6,7 +6,7 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 """
 
 from enum import Enum
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from CoreBluetooth import CBCharacteristic
 
@@ -59,7 +59,9 @@ _GattCharacteristicsPropertiesEnum: Dict[Optional[int], Tuple[str, str]] = {
 class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
     """GATT Characteristic implementation for the CoreBluetooth backend"""
 
-    def __init__(self, obj: CBCharacteristic, max_write_without_response_size: int):
+    def __init__(
+        self, obj: CBCharacteristic, max_write_without_response_size: Callable[[], int]
+    ):
         super().__init__(obj, max_write_without_response_size)
         self.__descriptors: List[BleakGATTDescriptorCoreBluetooth] = []
         # self.__props = obj.properties()

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -237,7 +237,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
                 services.add_characteristic(
                     BleakGATTCharacteristicCoreBluetooth(
                         characteristic,
-                        self._peripheral.maximumWriteValueLengthForType_(
+                        lambda: self._peripheral.maximumWriteValueLengthForType_(
                             CBCharacteristicWriteWithoutResponse
                         ),
                     )

--- a/bleak/backends/p4android/characteristic.py
+++ b/bleak/backends/p4android/characteristic.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Callable, List, Union
 from uuid import UUID
 
 from ...exc import BleakError
@@ -15,7 +15,7 @@ class BleakGATTCharacteristicP4Android(BleakGATTCharacteristic):
         java,
         service_uuid: str,
         service_handle: int,
-        max_write_without_response_size: int,
+        max_write_without_response_size: Callable[[], int],
     ):
         super(BleakGATTCharacteristicP4Android, self).__init__(
             java, max_write_without_response_size

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -273,7 +273,7 @@ class BleakClientP4Android(BaseBleakClient):
                     java_characteristic,
                     service.uuid,
                     service.handle,
-                    self.__mtu - 3,
+                    lambda: self.__mtu - 3,
                 )
                 services.add_characteristic(characteristic)
 

--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-from typing import List, Union
+from typing import Callable, List, Union
 from uuid import UUID
 
 if sys.version_info >= (3, 12):
@@ -68,7 +68,11 @@ _GattCharacteristicsPropertiesMap = {
 class BleakGATTCharacteristicWinRT(BleakGATTCharacteristic):
     """GATT Characteristic implementation for the .NET backend, implemented with WinRT"""
 
-    def __init__(self, obj: GattCharacteristic, max_write_without_response_size: int):
+    def __init__(
+        self,
+        obj: GattCharacteristic,
+        max_write_without_response_size: Callable[[], int],
+    ):
         super().__init__(obj, max_write_without_response_size)
         self.__descriptors = []
         self.__props = [


### PR DESCRIPTION
It has been observed that the max MTU exchange may not be complete before the connection is established, at least on Windows.

This reverts the previous attempt to work around this on Windows and instead makes the max_write_without_response_size dynamic. This way users can implement a workaround if needed but users who don't need it won't be punished with a longer connection time. The timeout in the previous workaround was also too short for some devices so it wan't complexly fixing the issue.
