### PR TITLE
Provide a local definition of user32.setTimer, user32.KillTimer and ole32.CoGetApartmentType on Windows

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ Contributors
 * Robbe Gaeremynck <robbe.gaeremynck@outlook.com>
 * David Johansen <davejohansen@gmail.com>
 * JP Hutchins <jphutchins@gmail.com>
+* Bram Duvigneau <bram@bramd.nl>
 
 Sponsors
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* In bleak.backends.winrt.util the SetTimer, KillTimer and CoGetApartmentType functions define their own prototype and don't change ctypes' global state anymore
+
 `0.22.2`_ (2024-06-01)
 ======================
 

--- a/bleak/backends/winrt/util.py
+++ b/bleak/backends/winrt/util.py
@@ -36,24 +36,43 @@ _TIMERPROC = ctypes.WINFUNCTYPE(
 )
 
 # https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-settimer
-_SetTimer = ctypes.windll.user32.SetTimer
-_SetTimer.restype = _UINT_PTR
-_SetTimer.argtypes = [wintypes.HWND, _UINT_PTR, wintypes.UINT, _TIMERPROC]
+_SET_TIMER_PROTOTYPE = ctypes.WINFUNCTYPE(
+    _UINT_PTR, wintypes.HWND, _UINT_PTR, wintypes.UINT, _TIMERPROC
+)
+_SET_TIMER_PARAM_FLAGS = (
+    (1, "hwnd", None),
+    (1, "nidevent"),
+    (1, "uelapse"),
+    (1, "lptimerfunc", None),
+)
+_SetTimer = _SET_TIMER_PROTOTYPE(
+    ("SetTimer", ctypes.windll.user32), _SET_TIMER_PARAM_FLAGS
+)
 _SetTimer.errcheck = _check_result
 
 # https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-killtimer
-_KillTimer = ctypes.windll.user32.KillTimer
-_KillTimer.restype = wintypes.BOOL
-_KillTimer.argtypes = [wintypes.HWND, wintypes.UINT]
-
+_KILL_TIMER_PROTOTYPE = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, _UINT_PTR)
+_KILL_TIMER_PARAM_FLAGS = (
+    (1, "hwnd", None),
+    (1, "uidevent"),
+)
+_KillTimer = _KILL_TIMER_PROTOTYPE(
+    ("KillTimer", ctypes.windll.user32), _KILL_TIMER_PARAM_FLAGS
+)
 
 # https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cogetapartmenttype
-_CoGetApartmentType = ctypes.windll.ole32.CoGetApartmentType
-_CoGetApartmentType.restype = ctypes.c_int
-_CoGetApartmentType.argtypes = [
+_CO_GET_APARTMENT_TYPE_PROTOTYPE = ctypes.WINFUNCTYPE(
+    ctypes.c_int,
     ctypes.POINTER(ctypes.c_int),
     ctypes.POINTER(ctypes.c_int),
-]
+)
+_CO_GET_APARTMENT_TYPE_PARAM_FLAGS = (
+    (1, "papttype", None),
+    (1, "paptqualifier", None),
+)
+_CoGetApartmentType = _CO_GET_APARTMENT_TYPE_PROTOTYPE(
+    ("CoGetApartmentType", ctypes.windll.ole32), _CO_GET_APARTMENT_TYPE_PARAM_FLAGS
+)
 _CoGetApartmentType.errcheck = _check_hresult
 
 _CO_E_NOTINITIALIZED = -2147221008


### PR DESCRIPTION
By overriding the type definition of SetTimer, we prevent None being passed as the callback parameter. This causes problems when integrating Bleak in larger Windows applications that call SetTimer in this way.

By defining the function type definition locally, we don't override the global definition so existing code that uses None as a callback keeps working.

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.8+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
