### PR TITLE
Index BlueZ advertisement_callbacks by adapter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Changed
 -------
 * In bleak.backends.winrt.util the SetTimer, KillTimer and CoGetApartmentType functions define their own prototype and don't change ctypes' global state anymore
+* Improved performance of BlueZ backend when there are many adapters.
 
 `0.22.2`_ (2024-06-01)
 ======================


### PR DESCRIPTION
- Instead of doing a linear search of all the callbacks to find the one for the adapter, store them in a dict so the adapter path can be looked up
- Remove unused arg from _run_advertisement_callbacks


- [x] If the pull request adds functionality, the docs should be updated.
- [x] Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
- [x] The pull request should work for Python 3.8+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
- [x] Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
- [x] Feel free to add your name as a contributor to the `AUTHORS.rst` file!
