### PR TITLE
Escape demonstration bytes in BleakClient docstring.

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -726,7 +726,7 @@ class BleakClient:
         data: Buffer,
         response: bool = None,
     ) -> None:
-        """
+        r"""
         Perform a write operation on the specified GATT characteristic.
 
         There are two possible kinds of writes. *Write with response* (sometimes


### PR DESCRIPTION
The bytes inside the example weren't properly escaped. Some IDE's threw an error, readthedocs showed this as empty.
