### PR TITLE
Add troubleshooting step for "Not connected" problems on Raspberry Pi.

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -119,6 +119,33 @@ crash with an ``ImportError`` similar to::
 To fix the error, change the name of the script to something other than ``bleak.py``.
 
 ----------
+Linux Bugs
+----------
+
+Occasional "Not connected" errors on Raspberry Pi
+=================================================
+
+If you are using a Raspberry Pi and are seeing occasional "Not connected" errors,
+also manifesting as HCI error 0x3e and BlueZ error "Software caused connection abort",
+when trying to connect to a device, it may be due to wifi interference on the chip
+level.
+
+As a test the wifi interface can be disabled using either
+
+.. code-block:: shell
+
+    sudo rfkill block wlan
+
+or
+
+.. code-block:: shell
+
+    sudo nmcli radio wifi off
+
+See `this <https://github.com/project-chip/connectedhomeip/issues/16178>`_ Matter issue
+with similar problems on Raspberry Pi and other devices.
+
+----------
 macOS Bugs
 ----------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -125,10 +125,10 @@ Linux Bugs
 Occasional "Not connected" errors on Raspberry Pi
 =================================================
 
-If you are using a Raspberry Pi and are seeing occasional "Not connected" errors,
-also manifesting as HCI error 0x3e and BlueZ error "Software caused connection abort",
-when trying to connect to a device, it may be due to wifi interference on the chip
-level.
+If you are using the built in WiFi/Bluetooth module on a Raspberry Pi and and are seeing occasional
+"Not connected" errors, also manifesting as HCI error 0x3e and BlueZ error "Software caused
+connection abort", when trying to connect to a device, it may be due to wifi interference on
+the chip level.
 
 As a test the wifi interface can be disabled using either
 


### PR DESCRIPTION
After a lot of debugging we have discovered that disabling wifi fixes a _lot_ of sporadic "Not connected" errors we have been seeing in CI. This has been seen improving connectivity on a Raspberry Pi 4 and a Rock Pi 3C.


