### PR TITLE
Pass on kwargs

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -98,6 +98,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         self._disconnect_monitor_event: Optional[asyncio.Event] = None
         # map of characteristic D-Bus object path to notification callback
         self._notification_callbacks: Dict[str, NotifyCallback] = {}
+        self._kwargs = kwargs
 
         # used to override mtu_size property
         self._mtu_size: Optional[int] = None
@@ -179,7 +180,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     callback = self._notification_callbacks.get(char_path)
 
                     if callback:
-                        callback(bytearray(value))
+                        callback(bytearray(value), **self._kwargs)
 
                 watcher = manager.add_device_watcher(
                     self._device_path, on_connected_changed, on_value_changed


### PR DESCRIPTION
Description

When starting a notification, the callback function will only receive the values that the device sent, not any identification of the sending device. If you have multiple devices sending values on the same characteristic, the callback function cannot identify the device that a value came from. I have 1 to 8 multimeters sending values, and I'd like to use a common callback function for them
What I Did

In backends/bluezdbus/client.py, I added

self._kwargs = kwargs

to init(), and changed

callback(bytearray(value))
to
callback(bytearray(value), **self._kwargs)

in on_value_changed(char_path: str, value: bytes) -> None:

Now, I can create a new Bluetooth device with
client=BleakClient(MAC, devName="MyName")
and devName is passed to the callback function where it can be used to identify the the device that the value came from:
def notification_handler(sender, data, devName, **kwargs):

This makes working with multiple devices much easier.
This method is general, and could be used for other purposes as well.

I haven't looked into how to implement this on Windows or Mac, only Linux.