### PR TITLE
Fix DBus connection leak

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 `Unreleased`_
 =============
+Fixed
+-----
 
 Changed
 -------
@@ -21,6 +23,7 @@ Changed
 Fixed
 -----
 * Fixed possible ``KeyError`` when getting services in BlueZ backend. Fixes #1435.
+* Fix D-Bus connection leak when connecting to a device fails in BlueZ backend. Fixes #1698.
 
 Removed
 -------


### PR DESCRIPTION
Moved the try (in bluezdbus/client.py) in order to include the call to the add_device_watcher function, since it is able to throw an error when the device does not exists in bluez anymore. This causes the just opened dbus connection to not be properly closed.

fixes #1698 

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.8+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.43
    - OS X / macOS >= 10.11
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
