### PR TITLE
backends: winrt: scanner: enable extended advertising

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* Enabled extended advertising scanning on the ``BleakClientWinRT`` backend.
+
 `0.22.3`_ (2024-10-05)
 ======================
 

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -230,6 +230,7 @@ class BleakScannerWinRT(BaseBleakScanner):
 
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.scanning_mode = self._scanning_mode
+        self.watcher.allow_extended_advertisements = True
 
         event_loop = asyncio.get_running_loop()
         self._stopped_event = asyncio.Event()


### PR DESCRIPTION
Enable extended advertising scanning by default by setting the `AllowExtendedAdvertisements` property, which defaults to false.

https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementwatcher.allowextendedadvertisements