### PR TITLE
fix(client): Ensure that the bus is connected before pairing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@ Contributors
 * David Johansen <davejohansen@gmail.com>
 * JP Hutchins <jphutchins@gmail.com>
 * Bram Duvigneau <bram@bramd.nl>
+* Peter-Newman Messan <p.newmwn.messan@gmail.com>
 
 Sponsors
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-------
+* Fixed uninitialized bus connection when pairing before connection on BlueZ backend.
+
 `0.22.3`_ (2024-10-05)
 ======================
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -436,6 +436,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
             Boolean regarding success of pairing.
 
         """
+        if self._bus is None:
+            self._bus = await MessageBus(
+                bus_type=BusType.SYSTEM, negotiate_unix_fd=True
+            ).connect()
+
         # See if it is already paired.
         reply = await self._bus.call(
             Message(


### PR DESCRIPTION
If pairing is attempted before the bus is connected, the pairing process fails due to an exception being raised.
