### PR TITLE
bluez: fix service interface leak

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Changed
 * Log to stderr instead of stdout when ``BLEAK_LOGGING`` is enabled.
 * Updated ``winrt`` backend to use PyWinRT >= 3.1.
 
+Fixed
+-----
+* Fixed possible ``KeyError`` when getting services in BlueZ backend. Fixes #1435.
+
 Removed
 -------
 * Removed support for Python 3.8. The minimum supported version is now Python 3.9.

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -945,6 +945,13 @@ class BlueZManager:
                         if obj_path.startswith(adapter_path):
                             callback(obj_path)
                 elif interface == defs.GATT_SERVICE_INTERFACE:
+                    device_path = obj_path[: obj_path.rfind("/")]
+
+                    try:
+                        self._service_map[device_path].remove(obj_path)
+                    except KeyError:
+                        pass
+
                     try:
                         del self._characteristic_map[obj_path]
                     except KeyError:


### PR DESCRIPTION
Fix a leak where service interfaces were not being removed from the service map in the BlueZ manager. This could cause a `KeyError` on later connections when calling `get_services()`.

Fixes: https://github.com/hbldh/bleak/issues/1435
