### PR TITLE
bleak: undeprecate response=None arg to BleakClient.write_gatt_char()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,7 @@ Added
 
 Changed
 -------
-* Made `response` argument of class ``BleakClient.write_gatt_char()`` explicitly optional. #1730
-* Deprecated omitting the ``response`` argument.
+* Made `response` argument of class ``BleakClient.write_gatt_char()`` explicitly optional. Fixes #1730.
 * Updated Poetry build system version to ``>=2.0``.
 * Log to stderr instead of stdout when ``BLEAK_LOGGING`` is enabled.
 * Updated ``winrt`` backend to use PyWinRT >= 3.1.

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -777,10 +777,6 @@ class BleakClient:
         .. versionchanged:: 0.21
             The default behavior when ``response=`` is omitted was changed.
 
-        .. versionchanged:: unreleased
-            Omitting the ``response=`` argument is deprecated and may be required
-            in a future release.
-
         Example::
 
             MY_CHAR_UUID = "1234"
@@ -796,14 +792,10 @@ class BleakClient:
             raise BleakCharacteristicNotFoundError(char_specifier)
 
         if response is None:
-            # if not specified, prefer write-with-response over write-without-
+            # If not specified, prefer write-with-response over write-without-
             # response if it is available since it is the more reliable write.
-            warn(
-                "Omitting the response argument is not recommended."
-                "Legacy usage may be not allowed in the future.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
+            # This assumes that the peripheral correctly reports the
+            # characteristic properties, so doesn't work in some cases.
             response = "write" in characteristic.properties
 
         await self._backend.write_gatt_char(characteristic, data, response)


### PR DESCRIPTION
Fixes: https://github.com/hbldh/bleak/issues/1743

