### PR TITLE
github: add bot to close stale issues

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,0 +1,14 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '37 1 * * 0'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 500
+          days-before-close: 100
+          any-of-labels: '3rd party issue, more info required'


### PR DESCRIPTION
May issues are 3rd-party or need more info. We don't aggressively close these, but there is no reason to leave them open forever.
