### PR TITLE
Fix "has can" typo in macOS docs

### DIFF
--- a/docs/backends/macos.rst
+++ b/docs/backends/macos.rst
@@ -48,7 +48,7 @@ CoreBluetooth does not differentiate between data from a notification and data f
 This can cause confusion in cases where a device may send a notification message on a characteristic
 as a signal that the characteristic needs to be read again.
 
-Bleak has can accept a ``notification_discriminator`` callback in the ``cb`` dict parameter that is
+Bleak can accept a ``notification_discriminator`` callback in the ``cb`` dict parameter that is
 passed to the :meth:`bleak.BleakClient.start_notify` method that can differentiate between these types of data.
 
 .. code-block:: python


### PR DESCRIPTION
Remove the can / has wording in place of can.

Pull Request Guidelines for Bleak
---------------------------------

Before you submit a pull request, check that it meets these guidelines:

1. If the pull request adds functionality, the docs should be updated.
2. Modify the `CHANGELOG.rst`, describing your changes as is specified by the
   guidelines in that document.
3. The pull request should work for Python 3.9+ on the following platforms:
    - Windows 10, version 16299 (Fall Creators Update) and greater
    - Linux distributions with BlueZ >= 5.55
    - OS X / macOS >= 10.13
4. Squash all your commits on your PR branch, if the commits are not solving
   different problems and you are committing them in the same PR. In that case,
   consider making several PRs instead.
5. Feel free to add your name as a contributor to the `AUTHORS.rst` file!
