### PR TITLE
Py39 types

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -23,7 +23,6 @@ from typing import (
     Iterable,
     Literal,
     Optional,
-    Set,
     Type,
     TypedDict,
     Union,
@@ -75,7 +74,7 @@ if bool(os.environ.get("BLEAK_LOGGING", False)):
 
 
 # prevent tasks from being garbage collected
-_background_tasks: Set[asyncio.Task] = set()
+_background_tasks = set[asyncio.Task]()
 
 
 class BleakScanner:

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -20,7 +20,6 @@ from typing import (
     AsyncGenerator,
     Awaitable,
     Callable,
-    Dict,
     Iterable,
     Literal,
     Optional,
@@ -239,7 +238,7 @@ class BleakScanner:
     @classmethod
     async def discover(
         cls, timeout: float = 5.0, *, return_adv: Literal[True], **kwargs
-    ) -> Dict[str, tuple[BLEDevice, AdvertisementData]]: ...
+    ) -> dict[str, tuple[BLEDevice, AdvertisementData]]: ...
 
     @classmethod
     async def discover(
@@ -284,7 +283,7 @@ class BleakScanner:
     @property
     def discovered_devices_and_advertisement_data(
         self,
-    ) -> Dict[str, tuple[BLEDevice, AdvertisementData]]:
+    ) -> dict[str, tuple[BLEDevice, AdvertisementData]]:
         """
         Gets a map of device address to tuples of devices and the most recently
         received advertisement data for that device.

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -22,7 +22,6 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    List,
     Literal,
     Optional,
     Set,
@@ -133,7 +132,7 @@ class BleakScanner:
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback] = None,
-        service_uuids: Optional[List[str]] = None,
+        service_uuids: Optional[list[str]] = None,
         scanning_mode: Literal["active", "passive"] = "active",
         *,
         bluez: BlueZScannerArgs = {},
@@ -205,7 +204,7 @@ class BleakScanner:
         other convenience methods.
         """
 
-        service_uuids: List[str]
+        service_uuids: list[str]
         """
         Optional list of service UUIDs to filter on. Only advertisements
         containing this advertising data will be received. Required on
@@ -235,7 +234,7 @@ class BleakScanner:
     @classmethod
     async def discover(
         cls, timeout: float = 5.0, *, return_adv: Literal[False] = False, **kwargs
-    ) -> List[BLEDevice]: ...
+    ) -> list[BLEDevice]: ...
 
     @overload
     @classmethod
@@ -275,7 +274,7 @@ class BleakScanner:
         return scanner.discovered_devices
 
     @property
-    def discovered_devices(self) -> List[BLEDevice]:
+    def discovered_devices(self) -> list[BLEDevice]:
         """
         Gets list of the devices that the scanner has discovered during the scanning.
 

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -25,7 +25,6 @@ from typing import (
     Literal,
     Optional,
     Set,
-    Tuple,
     Type,
     TypedDict,
     Union,
@@ -175,7 +174,7 @@ class BleakScanner:
 
     async def advertisement_data(
         self,
-    ) -> AsyncGenerator[Tuple[BLEDevice, AdvertisementData], None]:
+    ) -> AsyncGenerator[tuple[BLEDevice, AdvertisementData], None]:
         """
         Yields devices and associated advertising data packets as they are discovered.
 
@@ -240,7 +239,7 @@ class BleakScanner:
     @classmethod
     async def discover(
         cls, timeout: float = 5.0, *, return_adv: Literal[True], **kwargs
-    ) -> Dict[str, Tuple[BLEDevice, AdvertisementData]]: ...
+    ) -> Dict[str, tuple[BLEDevice, AdvertisementData]]: ...
 
     @classmethod
     async def discover(
@@ -285,7 +284,7 @@ class BleakScanner:
     @property
     def discovered_devices_and_advertisement_data(
         self,
-    ) -> Dict[str, Tuple[BLEDevice, AdvertisementData]]:
+    ) -> Dict[str, tuple[BLEDevice, AdvertisementData]]:
         """
         Gets a map of device address to tuples of devices and the most recently
         received advertisement data for that device.

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -23,7 +23,6 @@ from typing import (
     Iterable,
     Literal,
     Optional,
-    Type,
     TypedDict,
     Union,
     overload,
@@ -134,7 +133,7 @@ class BleakScanner:
         *,
         bluez: BlueZScannerArgs = {},
         cb: CBScannerArgs = {},
-        backend: Optional[Type[BaseBleakScanner]] = None,
+        backend: Optional[type[BaseBleakScanner]] = None,
         **kwargs,
     ) -> None:
         PlatformBleakScanner = (
@@ -156,7 +155,7 @@ class BleakScanner:
 
     async def __aexit__(
         self,
-        exc_type: Type[BaseException],
+        exc_type: type[BaseException],
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> None:
@@ -221,7 +220,7 @@ class BleakScanner:
         """
         Dictionary of arguments specific to the CoreBluetooth backend.
         """
-        backend: Type[BaseBleakScanner]
+        backend: type[BaseBleakScanner]
         """
         Used to override the automatically selected backend (i.e. for a
             custom backend).
@@ -452,7 +451,7 @@ class BleakClient:
         timeout: float = 10.0,
         pair: bool = False,
         winrt: WinRTClientArgs = {},
-        backend: Optional[Type[BaseBleakClient]] = None,
+        backend: Optional[type[BaseBleakClient]] = None,
         **kwargs,
     ) -> None:
         PlatformBleakClient = (
@@ -511,7 +510,7 @@ class BleakClient:
 
     async def __aexit__(
         self,
-        exc_type: Type[BaseException],
+        exc_type: type[BaseException],
         exc_val: BaseException,
         exc_tb: TracebackType,
     ) -> None:

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -14,19 +14,9 @@ import logging
 import os
 import sys
 import uuid
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    Iterable,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Literal, Optional, TypedDict, Union, overload
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -7,7 +7,8 @@ monitor api <https://github.com/bluez/bluez/blob/master/doc/org.bluez.Advertisem
 """
 
 import logging
-from typing import Iterable, NamedTuple, Union, no_type_check
+from collections.abc import Iterable
+from typing import NamedTuple, Union, no_type_check
 
 from dbus_fast.service import PropertyAccess, ServiceInterface, dbus_property, method
 

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -7,7 +7,7 @@ monitor api <https://github.com/bluez/bluez/blob/master/doc/org.bluez.Advertisem
 """
 
 import logging
-from typing import Iterable, NamedTuple, Tuple, Union, no_type_check
+from typing import Iterable, NamedTuple, Union, no_type_check
 
 from dbus_fast.service import PropertyAccess, ServiceInterface, dbus_property, method
 
@@ -30,7 +30,7 @@ class OrPattern(NamedTuple):
 
 
 # Windows has a similar structure, so we allow generic tuple for cross-platform compatibility
-OrPatternLike = Union[OrPattern, Tuple[int, AdvertisementDataType, bytes]]
+OrPatternLike = Union[OrPattern, tuple[int, AdvertisementDataType, bytes]]
 
 
 class AdvertisementMonitor(ServiceInterface):

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Union
+from typing import Callable, Union
 from uuid import UUID
 
 from ..characteristic import BleakGATTCharacteristic
@@ -48,7 +48,7 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         return self.obj.get("UUID")
 
     @property
-    def properties(self) -> List[str]:
+    def properties(self) -> list[str]:
         """Properties of this characteristic
 
         Returns the characteristics `Flags` present in the DBus API.
@@ -56,7 +56,7 @@ class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):
         return self.obj["Flags"]
 
     @property
-    def descriptors(self) -> List[BleakGATTDescriptor]:
+    def descriptors(self) -> list[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         return self.__descriptors
 

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -1,4 +1,5 @@
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 from uuid import UUID
 
 from ..characteristic import BleakGATTCharacteristic

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -8,7 +8,7 @@ import os
 import sys
 import warnings
 from contextlib import AsyncExitStack
-from typing import Callable, Optional, Set, Union, cast
+from typing import Callable, Optional, Union, cast
 from uuid import UUID
 
 if sys.version_info < (3, 12):
@@ -47,7 +47,7 @@ from .version import BlueZFeatures
 logger = logging.getLogger(__name__)
 
 # prevent tasks from being garbage collected
-_background_tasks: Set[asyncio.Task] = set()
+_background_tasks = set[asyncio.Task]()
 
 
 class BleakClientBlueZDBus(BaseBleakClient):
@@ -70,7 +70,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
     def __init__(
         self,
         address_or_ble_device: Union[BLEDevice, str],
-        services: Optional[Set[str]] = None,
+        services: Optional[set[str]] = None,
         **kwargs,
     ):
         super(BleakClientBlueZDBus, self).__init__(address_or_ble_device, **kwargs)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -7,8 +7,9 @@ import logging
 import os
 import sys
 import warnings
+from collections.abc import Callable
 from contextlib import AsyncExitStack
-from typing import Callable, Optional, Union, cast
+from typing import Optional, Union, cast
 from uuid import UUID
 
 if sys.version_info < (3, 12):

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -8,7 +8,7 @@ import os
 import sys
 import warnings
 from contextlib import AsyncExitStack
-from typing import Callable, Dict, Optional, Set, Union, cast
+from typing import Callable, Optional, Set, Union, cast
 from uuid import UUID
 
 if sys.version_info < (3, 12):
@@ -98,7 +98,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # used to ensure device gets disconnected if event loop crashes
         self._disconnect_monitor_event: Optional[asyncio.Event] = None
         # map of characteristic D-Bus object path to notification callback
-        self._notification_callbacks: Dict[str, NotifyCallback] = {}
+        self._notification_callbacks: dict[str, NotifyCallback] = {}
 
         # used to override mtu_size property
         self._mtu_size: Optional[int] = None

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Literal, Tuple, TypedDict
+from typing import Dict, Literal, TypedDict
 
 # DBus Interfaces
 OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
@@ -53,7 +53,7 @@ class AdvertisementMonitor1(TypedDict):
     RSSILowTimeout: int
     RSSIHighTimeout: int
     RSSISamplingPeriod: int
-    Patterns: list[Tuple[int, int, bytes]]
+    Patterns: list[tuple[int, int, bytes]]
 
 
 # https://github.com/bluez/bluez/blob/master/doc/org.bluez.AdvertisementMonitorManager.rst

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Literal, TypedDict
+from typing import Literal, TypedDict
 
 # DBus Interfaces
 OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
@@ -95,11 +95,11 @@ class Device1(TypedDict):
     Modalias: str
     RSSI: int
     TxPower: int
-    ManufacturerData: Dict[int, bytes]
-    ServiceData: Dict[str, bytes]
+    ManufacturerData: dict[int, bytes]
+    ServiceData: dict[str, bytes]
     ServicesResolved: bool
     AdvertisingFlags: bytes
-    AdvertisingData: Dict[int, bytes]
+    AdvertisingData: dict[int, bytes]
 
 
 # https://github.com/bluez/bluez/blob/master/doc/org.bluez.GattService.rst

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict, List, Literal, Tuple, TypedDict
+from typing import Dict, Literal, Tuple, TypedDict
 
 # DBus Interfaces
 OBJECT_MANAGER_INTERFACE = "org.freedesktop.DBus.ObjectManager"
@@ -37,10 +37,10 @@ class Adapter1(TypedDict):
     PairableTimeout: int
     DiscoverableTimeout: int
     Discovering: int
-    UUIDs: List[str]
+    UUIDs: list[str]
     Modalias: str
-    Roles: List[str]
-    ExperimentalFeatures: List[str]
+    Roles: list[str]
+    ExperimentalFeatures: list[str]
 
 
 # https://github.com/bluez/bluez/blob/master/doc/org.bluez.AdvertisementMonitor.rst
@@ -53,23 +53,23 @@ class AdvertisementMonitor1(TypedDict):
     RSSILowTimeout: int
     RSSIHighTimeout: int
     RSSISamplingPeriod: int
-    Patterns: List[Tuple[int, int, bytes]]
+    Patterns: list[Tuple[int, int, bytes]]
 
 
 # https://github.com/bluez/bluez/blob/master/doc/org.bluez.AdvertisementMonitorManager.rst
 
 
 class AdvertisementMonitorManager1(TypedDict):
-    SupportedMonitorTypes: List[str]
-    SupportedFeatures: List[str]
+    SupportedMonitorTypes: list[str]
+    SupportedFeatures: list[str]
 
 
 # https://github.com/bluez/bluez/blob/master/doc/org.bluez.Battery.rst
 
 
 class Battery1(TypedDict):
-    SupportedMonitorTypes: List[str]
-    SupportedFeatures: List[str]
+    SupportedMonitorTypes: list[str]
+    SupportedFeatures: list[str]
 
 
 # https://github.com/bluez/bluez/blob/master/doc/org.bluez.Device.rst
@@ -82,7 +82,7 @@ class Device1(TypedDict):
     Icon: str
     Class: int
     Appearance: int
-    UUIDs: List[str]
+    UUIDs: list[str]
     Paired: bool
     Bonded: bool
     Connected: bool
@@ -109,7 +109,7 @@ class GattService1(TypedDict):
     UUID: str
     Primary: bool
     Device: str
-    Includes: List[str]
+    Includes: list[str]
     # Handle is server-only and not available in Bleak
 
 
@@ -120,7 +120,7 @@ class GattCharacteristic1(TypedDict):
     WriteAcquired: bool
     NotifyAcquired: bool
     Notifying: bool
-    Flags: List[
+    Flags: list[
         Literal[
             "broadcast",
             "read",
@@ -151,7 +151,7 @@ class GattDescriptor1(TypedDict):
     UUID: str
     Characteristic: str
     Value: bytes
-    Flags: List[
+    Flags: list[
         Literal[
             "read",
             "write",

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -11,7 +11,8 @@ import contextlib
 import logging
 import os
 from collections import defaultdict
-from typing import Any, Callable, Coroutine, MutableMapping, NamedTuple, Optional, cast
+from collections.abc import Callable, Coroutine, MutableMapping
+from typing import Any, NamedTuple, Optional, cast
 from weakref import WeakKeyDictionary
 
 from dbus_fast import BusType, Message, MessageType, Variant, unpack_variants

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -15,7 +15,6 @@ from typing import (
     Any,
     Callable,
     Coroutine,
-    Dict,
     MutableMapping,
     NamedTuple,
     Optional,
@@ -162,7 +161,7 @@ class BlueZManager:
         self._bus_lock = asyncio.Lock()
 
         # dict of object path: dict of interface name: dict of property name: property value
-        self._properties: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        self._properties: dict[str, dict[str, dict[str, Any]]] = {}
 
         # set of available adapters for quick lookup
         self._adapters: Set[str] = set()
@@ -171,19 +170,19 @@ class BlueZManager:
         # to quickly find the children of a parent D-Bus object.
 
         # map of device d-bus object paths to set of service d-bus object paths
-        self._service_map: Dict[str, Set[str]] = {}
+        self._service_map: dict[str, Set[str]] = {}
         # map of service d-bus object paths to set of characteristic d-bus object paths
-        self._characteristic_map: Dict[str, Set[str]] = {}
+        self._characteristic_map: dict[str, Set[str]] = {}
         # map of characteristic d-bus object paths to set of descriptor d-bus object paths
-        self._descriptor_map: Dict[str, Set[str]] = {}
+        self._descriptor_map: dict[str, Set[str]] = {}
 
         self._advertisement_callbacks: defaultdict[str, list[AdvertisementCallback]] = (
             defaultdict(list)
         )
         self._device_removed_callbacks: list[DeviceRemovedCallbackAndState] = []
-        self._device_watchers: Dict[str, Set[DeviceWatcher]] = {}
-        self._condition_callbacks: Dict[str, Set[DeviceConditionCallback]] = {}
-        self._services_cache: Dict[str, BleakGATTServiceCollection] = {}
+        self._device_watchers: dict[str, Set[DeviceWatcher]] = {}
+        self._condition_callbacks: dict[str, Set[DeviceConditionCallback]] = {}
+        self._services_cache: dict[str, BleakGATTServiceCollection] = {}
 
     def _check_adapter(self, adapter_path: str) -> None:
         """
@@ -362,7 +361,7 @@ class BlueZManager:
     async def active_scan(
         self,
         adapter_path: str,
-        filters: Dict[str, Variant],
+        filters: dict[str, Variant],
         advertisement_callback: AdvertisementCallback,
         device_removed_callback: DeviceRemovedCallback,
     ) -> Callable[[], Coroutine]:
@@ -893,10 +892,10 @@ class BlueZManager:
 
         # type hints
         obj_path: str
-        interfaces_and_props: Dict[str, Dict[str, Variant]]
+        interfaces_and_props: dict[str, dict[str, Variant]]
         interfaces: list[str]
         interface: str
-        changed: Dict[str, Variant]
+        changed: dict[str, Variant]
         invalidated: list[str]
 
         if message.member == "InterfacesAdded":

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -16,7 +16,6 @@ from typing import (
     Callable,
     Coroutine,
     Dict,
-    List,
     MutableMapping,
     NamedTuple,
     Optional,
@@ -178,10 +177,10 @@ class BlueZManager:
         # map of characteristic d-bus object paths to set of descriptor d-bus object paths
         self._descriptor_map: Dict[str, Set[str]] = {}
 
-        self._advertisement_callbacks: defaultdict[str, List[AdvertisementCallback]] = (
+        self._advertisement_callbacks: defaultdict[str, list[AdvertisementCallback]] = (
             defaultdict(list)
         )
-        self._device_removed_callbacks: List[DeviceRemovedCallbackAndState] = []
+        self._device_removed_callbacks: list[DeviceRemovedCallbackAndState] = []
         self._device_watchers: Dict[str, Set[DeviceWatcher]] = {}
         self._condition_callbacks: Dict[str, Set[DeviceConditionCallback]] = {}
         self._services_cache: Dict[str, BleakGATTServiceCollection] = {}
@@ -474,7 +473,7 @@ class BlueZManager:
     async def passive_scan(
         self,
         adapter_path: str,
-        filters: List[OrPatternLike],
+        filters: list[OrPatternLike],
         advertisement_callback: AdvertisementCallback,
         device_removed_callback: DeviceRemovedCallback,
     ) -> Callable[[], Coroutine]:
@@ -895,10 +894,10 @@ class BlueZManager:
         # type hints
         obj_path: str
         interfaces_and_props: Dict[str, Dict[str, Variant]]
-        interfaces: List[str]
+        interfaces: list[str]
         interface: str
         changed: Dict[str, Variant]
-        invalidated: List[str]
+        invalidated: list[str]
 
         if message.member == "InterfacesAdded":
             obj_path, interfaces_and_props = message.body

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -11,16 +11,7 @@ import contextlib
 import logging
 import os
 from collections import defaultdict
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    MutableMapping,
-    NamedTuple,
-    Optional,
-    Set,
-    cast,
-)
+from typing import Any, Callable, Coroutine, MutableMapping, NamedTuple, Optional, cast
 from weakref import WeakKeyDictionary
 
 from dbus_fast import BusType, Message, MessageType, Variant, unpack_variants
@@ -164,24 +155,24 @@ class BlueZManager:
         self._properties: dict[str, dict[str, dict[str, Any]]] = {}
 
         # set of available adapters for quick lookup
-        self._adapters: Set[str] = set()
+        self._adapters = set[str]()
 
         # The BlueZ APIs only maps children to parents, so we need to keep maps
         # to quickly find the children of a parent D-Bus object.
 
         # map of device d-bus object paths to set of service d-bus object paths
-        self._service_map: dict[str, Set[str]] = {}
+        self._service_map: dict[str, set[str]] = {}
         # map of service d-bus object paths to set of characteristic d-bus object paths
-        self._characteristic_map: dict[str, Set[str]] = {}
+        self._characteristic_map: dict[str, set[str]] = {}
         # map of characteristic d-bus object paths to set of descriptor d-bus object paths
-        self._descriptor_map: dict[str, Set[str]] = {}
+        self._descriptor_map: dict[str, set[str]] = {}
 
         self._advertisement_callbacks: defaultdict[str, list[AdvertisementCallback]] = (
             defaultdict(list)
         )
         self._device_removed_callbacks: list[DeviceRemovedCallbackAndState] = []
-        self._device_watchers: dict[str, Set[DeviceWatcher]] = {}
-        self._condition_callbacks: dict[str, Set[DeviceConditionCallback]] = {}
+        self._device_watchers: dict[str, set[DeviceWatcher]] = {}
+        self._condition_callbacks: dict[str, set[DeviceConditionCallback]] = {}
         self._services_cache: dict[str, BleakGATTServiceCollection] = {}
 
     def _check_adapter(self, adapter_path: str) -> None:
@@ -623,7 +614,7 @@ class BlueZManager:
             del self._device_watchers[device_path]
 
     async def get_services(
-        self, device_path: str, use_cached: bool, requested_services: Optional[Set[str]]
+        self, device_path: str, use_cached: bool, requested_services: Optional[set[str]]
     ) -> BleakGATTServiceCollection:
         """
         Builds a new :class:`BleakGATTServiceCollection` from the current state.

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Coroutine, Dict, Literal, Optional, TypedDict
+from typing import Callable, Coroutine, Literal, Optional, TypedDict
 
 from dbus_fast import Variant
 
@@ -131,7 +131,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
 
         # Discovery filters
 
-        self._filters: Dict[str, Variant] = {}
+        self._filters: dict[str, Variant] = {}
 
         self._filters["Transport"] = Variant("s", "le")
         self._filters["DuplicateData"] = Variant("b", False)

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable, Coroutine, Dict, List, Literal, Optional, TypedDict
+from typing import Callable, Coroutine, Dict, Literal, Optional, TypedDict
 
 from dbus_fast import Variant
 
@@ -21,7 +21,7 @@ class BlueZDiscoveryFilters(TypedDict, total=False):
     https://github.com/bluez/bluez/blob/master/doc/org.bluez.Adapter.rst#void-setdiscoveryfilterdict-filter
     """
 
-    UUIDs: List[str]
+    UUIDs: list[str]
     """
     Filter by service UUIDs, empty means match _any_ UUID.
 
@@ -79,7 +79,7 @@ class BlueZScannerArgs(TypedDict, total=False):
     Only used for active scanning.
     """
 
-    or_patterns: List[OrPatternLike]
+    or_patterns: list[OrPatternLike]
     """
     Or patterns to pass to the AdvertisementMonitor1 D-Bus interface.
 
@@ -113,7 +113,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback],
-        service_uuids: Optional[List[str]],
+        service_uuids: Optional[list[str]],
         scanning_mode: Literal["active", "passive"],
         *,
         bluez: BlueZScannerArgs,

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Callable, Coroutine, Literal, Optional, TypedDict
+from collections.abc import Callable, Coroutine
+from typing import Literal, Optional, TypedDict
 
 from dbus_fast import Variant
 

--- a/bleak/backends/bluezdbus/service.py
+++ b/bleak/backends/bluezdbus/service.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from ..service import BleakGATTService
 from .characteristic import BleakGATTCharacteristicBlueZDBus
@@ -25,7 +25,7 @@ class BleakGATTServiceBlueZDBus(BleakGATTService):
         return self.__handle
 
     @property
-    def characteristics(self) -> List[BleakGATTCharacteristicBlueZDBus]:
+    def characteristics(self) -> list[BleakGATTCharacteristicBlueZDBus]:
         """List of characteristics for this service"""
         return self.__characteristics
 

--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Coroutine, Optional
+from collections.abc import Coroutine
+from typing import Any, Optional
 
 from dbus_fast.aio.message_bus import MessageBus
 from dbus_fast.errors import InvalidObjectPathError

--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Coroutine, Dict, Optional
+from typing import Any, Coroutine, Optional
 
 from dbus_fast.aio.message_bus import MessageBus
 from dbus_fast.errors import InvalidObjectPathError
@@ -132,7 +132,7 @@ class MatchRules:
                     assert_object_path_valid(v[:-1] if v.endswith("/") else v)
                 else:
                     raise ValueError("kwargs must be in the form 'arg0' or 'arg0path'")
-            self.args: Dict[str, str] = kwargs
+            self.args: dict[str, str] = kwargs
         else:
             self.args = None
 

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -7,7 +7,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 import enum
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, Union
 from uuid import UUID
 
 from ..uuids import uuidstr_to_str
@@ -76,7 +76,7 @@ class BleakGATTCharacteristic(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def properties(self) -> List[str]:
+    def properties(self) -> list[str]:
         """Properties of this characteristic"""
         raise NotImplementedError()
 
@@ -113,7 +113,7 @@ class BleakGATTCharacteristic(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def descriptors(self) -> List[BleakGATTDescriptor]:
+    def descriptors(self) -> list[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         raise NotImplementedError()
 

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -7,7 +7,8 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 import enum
-from typing import Any, Callable, Union
+from collections.abc import Callable
+from typing import Any, Union
 from uuid import UUID
 
 from ..uuids import uuidstr_to_str

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -10,7 +10,7 @@ import os
 import platform
 import sys
 import uuid
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Optional, Union
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer
@@ -221,7 +221,7 @@ class BaseBleakClient(abc.ABC):
         raise NotImplementedError()
 
 
-def get_platform_client_backend_type() -> Type[BaseBleakClient]:
+def get_platform_client_backend_type() -> type[BaseBleakClient]:
     """
     Gets the platform-specific :class:`BaseBleakClient` type.
     """

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -10,7 +10,8 @@ import os
 import platform
 import sys
 import uuid
-from typing import Callable, Optional, Union
+from collections.abc import Callable
+from typing import Optional, Union
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -10,7 +10,8 @@ import asyncio
 import logging
 import sys
 import threading
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import sys
 import threading
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout
@@ -113,7 +113,7 @@ class CentralManagerDelegate(NSObject):
     # User defined functions
 
     @objc.python_method
-    async def start_scan(self, service_uuids: Optional[List[str]]) -> None:
+    async def start_scan(self, service_uuids: Optional[list[str]]) -> None:
         service_uuids = (
             NSArray.alloc().initWithArray_(
                 list(map(CBUUID.UUIDWithString_, service_uuids))

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -10,7 +10,7 @@ import asyncio
 import logging
 import sys
 import threading
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Optional
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout
@@ -64,13 +64,13 @@ class CentralManagerDelegate(NSObject):
             return None
 
         self.event_loop = asyncio.get_running_loop()
-        self._connect_futures: Dict[NSUUID, asyncio.Future] = {}
+        self._connect_futures: dict[NSUUID, asyncio.Future] = {}
 
-        self.callbacks: Dict[
-            int, Callable[[CBPeripheral, Dict[str, Any], int], None]
+        self.callbacks: dict[
+            int, Callable[[CBPeripheral, dict[str, Any], int], None]
         ] = {}
-        self._disconnect_callbacks: Dict[NSUUID, DisconnectCallback] = {}
-        self._disconnect_futures: Dict[NSUUID, asyncio.Future] = {}
+        self._disconnect_callbacks: dict[NSUUID, DisconnectCallback] = {}
+        self._disconnect_futures: dict[NSUUID, asyncio.Future] = {}
 
         self._did_update_state_event = threading.Event()
         self.central_manager = CBCentralManager.alloc().initWithDelegate_queue_(

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -12,7 +12,8 @@ import asyncio
 import itertools
 import logging
 import sys
-from typing import Any, Callable, Iterable, NewType, Optional
+from collections.abc import Callable, Iterable
+from typing import Any, NewType, Optional
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -12,7 +12,7 @@ import asyncio
 import itertools
 import logging
 import sys
-from typing import Any, Callable, Dict, Iterable, NewType, Optional
+from typing import Any, Callable, Iterable, NewType, Optional
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout
@@ -63,22 +63,22 @@ class PeripheralDelegate(NSObject):
         self._event_loop = asyncio.get_running_loop()
         self._services_discovered_future = self._event_loop.create_future()
 
-        self._service_characteristic_discovered_futures: Dict[int, asyncio.Future] = {}
-        self._characteristic_descriptor_discover_futures: Dict[int, asyncio.Future] = {}
+        self._service_characteristic_discovered_futures: dict[int, asyncio.Future] = {}
+        self._characteristic_descriptor_discover_futures: dict[int, asyncio.Future] = {}
 
-        self._characteristic_read_futures: Dict[int, asyncio.Future] = {}
-        self._characteristic_write_futures: Dict[int, asyncio.Future] = {}
+        self._characteristic_read_futures: dict[int, asyncio.Future] = {}
+        self._characteristic_write_futures: dict[int, asyncio.Future] = {}
 
-        self._descriptor_read_futures: Dict[int, asyncio.Future] = {}
-        self._descriptor_write_futures: Dict[int, asyncio.Future] = {}
+        self._descriptor_read_futures: dict[int, asyncio.Future] = {}
+        self._descriptor_write_futures: dict[int, asyncio.Future] = {}
 
-        self._characteristic_notify_change_futures: Dict[int, asyncio.Future] = {}
-        self._characteristic_notify_callbacks: Dict[int, NotifyCallback] = {}
-        self._characteristic_notification_discriminators: Dict[
+        self._characteristic_notify_change_futures: dict[int, asyncio.Future] = {}
+        self._characteristic_notify_callbacks: dict[int, NotifyCallback] = {}
+        self._characteristic_notification_discriminators: dict[
             int, Optional[NotificationDiscriminator]
         ] = {}
 
-        self._read_rssi_futures: Dict[NSUUID, asyncio.Future] = {}
+        self._read_rssi_futures: dict[NSUUID, asyncio.Future] = {}
 
         return self
 

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -6,7 +6,7 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 """
 
 from enum import Enum
-from typing import Callable, Dict, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Union
 
 from CoreBluetooth import CBCharacteristic
 
@@ -29,7 +29,7 @@ class CBCharacteristicProperties(Enum):
     INDICATE_ENCRYPTION_REQUIRED = 0x200
 
 
-_GattCharacteristicsPropertiesEnum: Dict[Optional[int], Tuple[str, str]] = {
+_GattCharacteristicsPropertiesEnum: Dict[Optional[int], tuple[str, str]] = {
     None: ("None", "The characteristic doesn’t have any properties that apply"),
     1: ("Broadcast".lower(), "The characteristic supports broadcasting"),
     2: ("Read".lower(), "The characteristic is readable"),

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -6,7 +6,7 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 """
 
 from enum import Enum
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, Optional, Tuple, Union
 
 from CoreBluetooth import CBCharacteristic
 
@@ -63,9 +63,9 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
         self, obj: CBCharacteristic, max_write_without_response_size: Callable[[], int]
     ):
         super().__init__(obj, max_write_without_response_size)
-        self.__descriptors: List[BleakGATTDescriptorCoreBluetooth] = []
+        self.__descriptors: list[BleakGATTDescriptorCoreBluetooth] = []
         # self.__props = obj.properties()
-        self.__props: List[str] = [
+        self.__props: list[str] = [
             _GattCharacteristicsPropertiesEnum[v][0]
             for v in [2**n for n in range(10)]
             if (self.obj.properties() & v)
@@ -92,12 +92,12 @@ class BleakGATTCharacteristicCoreBluetooth(BleakGATTCharacteristic):
         return self._uuid
 
     @property
-    def properties(self) -> List[str]:
+    def properties(self) -> list[str]:
         """Properties of this characteristic"""
         return self.__props
 
     @property
-    def descriptors(self) -> List[BleakGATTDescriptor]:
+    def descriptors(self) -> list[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         return self.__descriptors
 

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -5,8 +5,9 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 
 """
 
+from collections.abc import Callable
 from enum import Enum
-from typing import Callable, Optional, Union
+from typing import Optional, Union
 
 from CoreBluetooth import CBCharacteristic
 

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -6,7 +6,7 @@ Created on 2019-06-28 by kevincar <kevincarrolldavis@gmail.com>
 """
 
 from enum import Enum
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Optional, Union
 
 from CoreBluetooth import CBCharacteristic
 
@@ -29,7 +29,7 @@ class CBCharacteristicProperties(Enum):
     INDICATE_ENCRYPTION_REQUIRED = 0x200
 
 
-_GattCharacteristicsPropertiesEnum: Dict[Optional[int], tuple[str, str]] = {
+_GattCharacteristicsPropertiesEnum: dict[Optional[int], tuple[str, str]] = {
     None: ("None", "The characteristic doesn’t have any properties that apply"),
     1: ("Broadcast".lower(), "The characteristic supports broadcasting"),
     2: ("Read".lower(), "The characteristic is readable"),

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -8,7 +8,7 @@ import asyncio
 import logging
 import sys
 import uuid
-from typing import Optional, Set, TypedDict, Union
+from typing import Optional, TypedDict, Union
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer
@@ -75,7 +75,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
     def __init__(
         self,
         address_or_ble_device: Union[BLEDevice, str],
-        services: Optional[Set[str]] = None,
+        services: Optional[set[str]] = None,
         **kwargs,
     ):
         super(BleakClientCoreBluetooth, self).__init__(address_or_ble_device, **kwargs)

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Literal, Optional, TypedDict
+from typing import Any, Literal, Optional, TypedDict
 
 import objc
 from CoreBluetooth import CBPeripheral
@@ -90,7 +90,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
     async def start(self) -> None:
         self.seen_devices = {}
 
-        def callback(p: CBPeripheral, a: Dict[str, Any], r: int) -> None:
+        def callback(p: CBPeripheral, a: dict[str, Any], r: int) -> None:
 
             service_uuids = [
                 cb_uuid_to_str(u) for u in a.get("kCBAdvDataServiceUUIDs", [])

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Literal, Optional, TypedDict
+from typing import Any, Dict, Literal, Optional, TypedDict
 
 import objc
 from CoreBluetooth import CBPeripheral
@@ -59,7 +59,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback],
-        service_uuids: Optional[List[str]],
+        service_uuids: Optional[list[str]],
         scanning_mode: Literal["active", "passive"],
         *,
         cb: CBScannerArgs,

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from CoreBluetooth import CBService
 
 from ..service import BleakGATTService
@@ -12,7 +10,7 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
 
     def __init__(self, obj: CBService):
         super().__init__(obj)
-        self.__characteristics: List[BleakGATTCharacteristicCoreBluetooth] = []
+        self.__characteristics: list[BleakGATTCharacteristicCoreBluetooth] = []
         # N.B. the `startHandle` method of the CBService is an undocumented Core Bluetooth feature,
         # which Bleak takes advantage of in order to have a service handle to use.
         self.__handle: int = int(self.obj.startHandle())
@@ -28,7 +26,7 @@ class BleakGATTServiceCoreBluetooth(BleakGATTService):
         return cb_uuid_to_str(self.obj.UUID())
 
     @property
-    def characteristics(self) -> List[BleakGATTCharacteristicCoreBluetooth]:
+    def characteristics(self) -> list[BleakGATTCharacteristicCoreBluetooth]:
         """List of characteristics for this service"""
         return self.__characteristics
 

--- a/bleak/backends/p4android/characteristic.py
+++ b/bleak/backends/p4android/characteristic.py
@@ -1,4 +1,4 @@
-from typing import Callable, List, Union
+from typing import Callable, Union
 from uuid import UUID
 
 from ...exc import BleakError
@@ -54,12 +54,12 @@ class BleakGATTCharacteristicP4Android(BleakGATTCharacteristic):
         return self.__uuid
 
     @property
-    def properties(self) -> List[str]:
+    def properties(self) -> list[str]:
         """Properties of this characteristic"""
         return self.__properties
 
     @property
-    def descriptors(self) -> List[BleakGATTDescriptor]:
+    def descriptors(self) -> list[BleakGATTDescriptor]:
         """List of descriptors for this service"""
         return self.__descriptors
 

--- a/bleak/backends/p4android/characteristic.py
+++ b/bleak/backends/p4android/characteristic.py
@@ -1,4 +1,5 @@
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 from uuid import UUID
 
 from ...exc import BleakError

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import uuid
 import warnings
-from typing import Optional, Set, Union
+from typing import Optional, Union
 
 from android.broadcast import BroadcastReceiver
 from jnius import java_method
@@ -38,7 +38,7 @@ class BleakClientP4Android(BaseBleakClient):
     def __init__(
         self,
         address_or_ble_device: Union[BLEDevice, str],
-        services: Optional[Set[uuid.UUID]],
+        services: Optional[set[uuid.UUID]],
         **kwargs,
     ):
         super(BleakClientP4Android, self).__init__(address_or_ble_device, **kwargs)

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import sys
 import warnings
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout
@@ -43,7 +43,7 @@ class BleakScannerP4Android(BaseBleakScanner):
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback],
-        service_uuids: Optional[List[str]],
+        service_uuids: Optional[list[str]],
         scanning_mode: Literal["active", "passive"],
         **kwargs,
     ):

--- a/bleak/backends/p4android/service.py
+++ b/bleak/backends/p4android/service.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from ..service import BleakGATTService
 from .characteristic import BleakGATTCharacteristicP4Android
 
@@ -24,7 +22,7 @@ class BleakGATTServiceP4Android(BleakGATTService):
         return self.__handle
 
     @property
-    def characteristics(self) -> List[BleakGATTCharacteristicP4Android]:
+    def characteristics(self) -> list[BleakGATTCharacteristicP4Android]:
         """List of characteristics for this service"""
         return self.__characteristics
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -3,7 +3,8 @@ import asyncio
 import inspect
 import os
 import platform
-from typing import Any, Callable, Coroutine, Hashable, NamedTuple, Optional
+from collections.abc import Callable, Coroutine, Hashable
+from typing import Any, NamedTuple, Optional
 
 from ..exc import BleakError
 from .device import BLEDevice

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     Callable,
     Coroutine,
-    Dict,
     Hashable,
     NamedTuple,
     Optional,
@@ -33,7 +32,7 @@ class AdvertisementData(NamedTuple):
     The local name of the device or ``None`` if not included in advertising data.
     """
 
-    manufacturer_data: Dict[int, bytes]
+    manufacturer_data: dict[int, bytes]
     """
     Dictionary of manufacturer data in bytes from the received advertisement data or empty dict if not present.
 
@@ -42,7 +41,7 @@ class AdvertisementData(NamedTuple):
     https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers/
     """
 
-    service_data: Dict[str, bytes]
+    service_data: dict[str, bytes]
     """
     Dictionary of service data from the received advertisement data or empty dict if not present.
     """
@@ -121,7 +120,7 @@ class BaseBleakScanner(abc.ABC):
             containing this advertising data will be received.
     """
 
-    seen_devices: Dict[str, tuple[BLEDevice, AdvertisementData]]
+    seen_devices: dict[str, tuple[BLEDevice, AdvertisementData]]
     """
     Map of device identifier to BLEDevice and most recent advertisement data.
 
@@ -135,7 +134,7 @@ class BaseBleakScanner(abc.ABC):
     ):
         super(BaseBleakScanner, self).__init__()
 
-        self._ad_callbacks: Dict[
+        self._ad_callbacks: dict[
             Hashable, Callable[[BLEDevice, AdvertisementData], None]
         ] = {}
         """

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -3,7 +3,7 @@ import asyncio
 import inspect
 import os
 import platform
-from typing import Any, Callable, Coroutine, Hashable, NamedTuple, Optional, Type
+from typing import Any, Callable, Coroutine, Hashable, NamedTuple, Optional
 
 from ..exc import BleakError
 from .device import BLEDevice
@@ -282,7 +282,7 @@ class BaseBleakScanner(abc.ABC):
         raise NotImplementedError()
 
 
-def get_platform_scanner_backend_type() -> Type[BaseBleakScanner]:
+def get_platform_scanner_backend_type() -> type[BaseBleakScanner]:
     """
     Gets the platform-specific :class:`BaseBleakScanner` type.
     """

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -3,7 +3,7 @@ import asyncio
 import inspect
 import os
 import platform
-from typing import Any, Callable, Coroutine, Hashable, NamedTuple, Optional, Tuple, Type
+from typing import Any, Callable, Coroutine, Hashable, NamedTuple, Optional, Type
 
 from ..exc import BleakError
 from .device import BLEDevice
@@ -55,7 +55,7 @@ class AdvertisementData(NamedTuple):
     .. versionadded:: 0.19
     """
 
-    platform_data: Tuple
+    platform_data: tuple[Any, ...]
     """
     Tuple of platform specific data.
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -121,7 +121,7 @@ class BaseBleakScanner(abc.ABC):
             containing this advertising data will be received.
     """
 
-    seen_devices: Dict[str, Tuple[BLEDevice, AdvertisementData]]
+    seen_devices: Dict[str, tuple[BLEDevice, AdvertisementData]]
     """
     Map of device identifier to BLEDevice and most recent advertisement data.
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -9,7 +9,6 @@ from typing import (
     Coroutine,
     Dict,
     Hashable,
-    List,
     NamedTuple,
     Optional,
     Set,
@@ -48,7 +47,7 @@ class AdvertisementData(NamedTuple):
     Dictionary of service data from the received advertisement data or empty dict if not present.
     """
 
-    service_uuids: List[str]
+    service_uuids: list[str]
     """
     List of service UUIDs from the received advertisement data or empty list if not present.
     """
@@ -132,7 +131,7 @@ class BaseBleakScanner(abc.ABC):
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback],
-        service_uuids: Optional[List[str]],
+        service_uuids: Optional[list[str]],
     ):
         super(BaseBleakScanner, self).__init__()
 
@@ -146,7 +145,7 @@ class BaseBleakScanner(abc.ABC):
         if detection_callback is not None:
             self.register_detection_callback(detection_callback)
 
-        self._service_uuids: Optional[List[str]] = (
+        self._service_uuids: Optional[list[str]] = (
             [u.lower() for u in service_uuids] if service_uuids is not None else None
         )
 
@@ -197,7 +196,7 @@ class BaseBleakScanner(abc.ABC):
 
         return remove
 
-    def is_allowed_uuid(self, service_uuids: Optional[List[str]]) -> bool:
+    def is_allowed_uuid(self, service_uuids: Optional[list[str]]) -> bool:
         """
         Check if the advertisement data contains any of the service UUIDs
         matching the filter. If no filter is set, this will always return

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -3,23 +3,13 @@ import asyncio
 import inspect
 import os
 import platform
-from typing import (
-    Any,
-    Callable,
-    Coroutine,
-    Hashable,
-    NamedTuple,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-)
+from typing import Any, Callable, Coroutine, Hashable, NamedTuple, Optional, Tuple, Type
 
 from ..exc import BleakError
 from .device import BLEDevice
 
 # prevent tasks from being garbage collected
-_background_tasks: Set[asyncio.Task] = set()
+_background_tasks = set[asyncio.Task]()
 
 
 class AdvertisementData(NamedTuple):

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -7,7 +7,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 import logging
-from typing import Any, Dict, Iterator, List, Optional, Union
+from typing import Any, Dict, Iterator, Optional, Union
 from uuid import UUID
 
 from ..exc import BleakError
@@ -46,7 +46,7 @@ class BleakGATTService(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def characteristics(self) -> List[BleakGATTCharacteristic]:
+    def characteristics(self) -> list[BleakGATTCharacteristic]:
         """List of characteristics for this service"""
         raise NotImplementedError()
 

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -7,7 +7,8 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 import logging
-from typing import Any, Iterator, Optional, Union
+from collections.abc import Iterator
+from typing import Any, Optional, Union
 from uuid import UUID
 
 from ..exc import BleakError

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -7,7 +7,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 import abc
 import logging
-from typing import Any, Dict, Iterator, Optional, Union
+from typing import Any, Iterator, Optional, Union
 from uuid import UUID
 
 from ..exc import BleakError
@@ -103,17 +103,17 @@ class BleakGATTServiceCollection:
         return iter(self.services.values())
 
     @property
-    def services(self) -> Dict[int, BleakGATTService]:
+    def services(self) -> dict[int, BleakGATTService]:
         """Returns dictionary of handles mapping to BleakGATTService"""
         return self.__services
 
     @property
-    def characteristics(self) -> Dict[int, BleakGATTCharacteristic]:
+    def characteristics(self) -> dict[int, BleakGATTCharacteristic]:
         """Returns dictionary of handles mapping to BleakGATTCharacteristic"""
         return self.__characteristics
 
     @property
-    def descriptors(self) -> Dict[int, BleakGATTDescriptor]:
+    def descriptors(self) -> dict[int, BleakGATTDescriptor]:
         """Returns a dictionary of integer handles mapping to BleakGATTDescriptor"""
         return self.__descriptors
 

--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from typing import Callable, Union
+from collections.abc import Callable
+from typing import Union
 from uuid import UUID
 
 from winrt.windows.devices.bluetooth.genericattributeprofile import (

--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import Callable, List, Union
+from typing import Callable, Union
 from uuid import UUID
 
 from winrt.windows.devices.bluetooth.genericattributeprofile import (
@@ -104,12 +104,12 @@ class BleakGATTCharacteristicWinRT(BleakGATTCharacteristic):
         )
 
     @property
-    def properties(self) -> List[str]:
+    def properties(self) -> list[str]:
         """Properties of this characteristic"""
         return self.__props
 
     @property
-    def descriptors(self) -> List[BleakGATTDescriptor]:
+    def descriptors(self) -> list[BleakGATTDescriptor]:
         """List of descriptors for this characteristic"""
         return self.__descriptors
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -14,7 +14,6 @@ from typing import (
     Any,
     Dict,
     Generic,
-    List,
     Literal,
     Optional,
     Protocol,
@@ -203,9 +202,9 @@ class BleakClientWinRT(BaseBleakClient):
             [uuid.UUID(s) for s in services] if services else None
         )
         self._requester: Optional[BluetoothLEDevice] = None
-        self._services_changed_events: List[asyncio.Event] = []
-        self._session_active_events: List[asyncio.Event] = []
-        self._session_closed_events: List[asyncio.Event] = []
+        self._services_changed_events: list[asyncio.Event] = []
+        self._session_active_events: list[asyncio.Event] = []
+        self._session_closed_events: list[asyncio.Event] = []
         self._session: Optional[GattSession] = None
         self._notification_callbacks: Dict[int, EventRegistrationToken] = {}
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -17,7 +17,6 @@ from typing import (
     Optional,
     Protocol,
     Sequence,
-    Set,
     TypedDict,
     TypeVar,
     Union,
@@ -181,7 +180,7 @@ class BleakClientWinRT(BaseBleakClient):
     def __init__(
         self,
         address_or_ble_device: Union[BLEDevice, str],
-        services: Optional[Set[str]] = None,
+        services: Optional[set[str]] = None,
         *,
         winrt: WinRTClientArgs,
         **kwargs,

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -12,7 +12,6 @@ import uuid
 from ctypes import WinError
 from typing import (
     Any,
-    Dict,
     Generic,
     Literal,
     Optional,
@@ -206,7 +205,7 @@ class BleakClientWinRT(BaseBleakClient):
         self._session_active_events: list[asyncio.Event] = []
         self._session_closed_events: list[asyncio.Event] = []
         self._session: Optional[GattSession] = None
-        self._notification_callbacks: Dict[int, EventRegistrationToken] = {}
+        self._notification_callbacks: dict[int, EventRegistrationToken] = {}
 
         # os-specific options
         self._use_cached_services = winrt.get("use_cached_services")

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Dict, Literal, NamedTuple, Optional
+from typing import Literal, NamedTuple, Optional
 from uuid import UUID
 
 from winrt.windows.devices.bluetooth.advertisement import (
@@ -77,7 +77,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         super(BleakScannerWinRT, self).__init__(detection_callback, service_uuids)
 
         self.watcher: Optional[BluetoothLEAdvertisementWatcher] = None
-        self._advertisement_pairs: Dict[str, _RawAdvData] = {}
+        self._advertisement_pairs: dict[str, _RawAdvData] = {}
         self._stopped_event: Optional[asyncio.Event] = None
 
         # case insensitivity is for backwards compatibility on Windows only

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Dict, List, Literal, NamedTuple, Optional
+from typing import Dict, Literal, NamedTuple, Optional
 from uuid import UUID
 
 from winrt.windows.devices.bluetooth.advertisement import (
@@ -70,7 +70,7 @@ class BleakScannerWinRT(BaseBleakScanner):
     def __init__(
         self,
         detection_callback: Optional[AdvertisementDataCallback],
-        service_uuids: Optional[List[str]],
+        service_uuids: Optional[list[str]],
         scanning_mode: Literal["active", "passive"],
         **kwargs,
     ):

--- a/bleak/backends/winrt/service.py
+++ b/bleak/backends/winrt/service.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from winrt.windows.devices.bluetooth.genericattributeprofile import GattDeviceService
 
 from ..service import BleakGATTService
@@ -22,7 +20,7 @@ class BleakGATTServiceWinRT(BleakGATTService):
         return self.obj.attribute_handle
 
     @property
-    def characteristics(self) -> List[BleakGATTCharacteristicWinRT]:
+    def characteristics(self) -> list[BleakGATTCharacteristicWinRT]:
         """List of characteristics for this service"""
         return self.__characteristics
 

--- a/bleak/backends/winrt/util.py
+++ b/bleak/backends/winrt/util.py
@@ -3,7 +3,6 @@ import ctypes
 import sys
 from ctypes import wintypes
 from enum import IntEnum
-from typing import Tuple
 
 from ...exc import BleakError
 
@@ -99,7 +98,7 @@ class _AptQualifierType(IntEnum):
     RESERVED_1 = 7
 
 
-def _get_apartment_type() -> Tuple[_AptType, _AptQualifierType]:
+def _get_apartment_type() -> tuple[_AptType, _AptQualifierType]:
     """
     Calls CoGetApartmentType to get the current apartment type and qualifier.
 

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from typing import Dict
 from uuid import UUID
 
-uuid16_dict: Dict[int, str] = {
+uuid16_dict: dict[int, str] = {
     0x0001: "SDP",
     0x0003: "RFCOMM",
     0x0005: "TCS-BIN",
@@ -1028,7 +1027,7 @@ uuid16_dict: Dict[int, str] = {
     0xFFFE: "Alliance for Wireless Power (A4WP)",
 }
 
-uuid128_dict: Dict[str, str] = {
+uuid128_dict: dict[str, str] = {
     "a3c87500-8ed3-4bdf-8a39-a01bebede295": "Eddystone Configuration Service",
     "a3c87501-8ed3-4bdf-8a39-a01bebede295": "Capabilities",
     "a3c87502-8ed3-4bdf-8a39-a01bebede295": "Active Slot",
@@ -1193,7 +1192,7 @@ def uuidstr_to_str(uuid_: str) -> str:
     return s
 
 
-def register_uuids(uuids_to_descriptions: Dict[str, str]) -> None:
+def register_uuids(uuids_to_descriptions: dict[str, str]) -> None:
     """Add or modify the mapping of 128-bit UUIDs for services and characteristics to descriptions.
 
     Args:

--- a/typings/CoreBluetooth/__init__.pyi
+++ b/typings/CoreBluetooth/__init__.pyi
@@ -19,16 +19,16 @@ TCBCentralManager = TypeVar("TCBCentralManager", bound=CBCentralManager)
 
 class CBCentralManager(CBManager):
     @classmethod
-    def init(cls: Type[TCBCentralManager]) -> Optional[TCBCentralManager]: ...
+    def init(cls: type[TCBCentralManager]) -> Optional[TCBCentralManager]: ...
     @classmethod
     def initWithDelegate_queue_(
-        cls: Type[TCBCentralManager],
+        cls: type[TCBCentralManager],
         delegate: CBCentralManagerDelegate,
         queue: dispatch_queue_t,
     ) -> Optional[TCBCentralManager]: ...
     @classmethod
     def initWithDelegate_queue_options_(
-        cls: Type[TCBCentralManager],
+        cls: type[TCBCentralManager],
         delegate: CBCentralManagerDelegate,
         queue: dispatch_queue_t,
         options: NSDictionary,

--- a/typings/Foundation/__init__.pyi
+++ b/typings/Foundation/__init__.pyi
@@ -1,4 +1,5 @@
-from typing import NewType, Optional, Sequence, TypeVar
+from collections.abc import Sequence
+from typing import NewType, Optional, TypeVar
 
 TNSObject = TypeVar("TNSObject", bound=NSObject)
 

--- a/typings/Foundation/__init__.pyi
+++ b/typings/Foundation/__init__.pyi
@@ -1,10 +1,10 @@
-from typing import NewType, Optional, Sequence, Type, TypeVar
+from typing import NewType, Optional, Sequence, TypeVar
 
 TNSObject = TypeVar("TNSObject", bound=NSObject)
 
 class NSObject:
     @classmethod
-    def alloc(cls: Type[TNSObject]) -> TNSObject: ...
+    def alloc(cls: type[TNSObject]) -> TNSObject: ...
     def init(self: TNSObject) -> Optional[TNSObject]: ...
     def addObserver_forKeyPath_options_context_(
         self,

--- a/typings/objc/__init__.py
+++ b/typings/objc/__init__.py
@@ -1,11 +1,11 @@
-from typing import Optional, Type, TypeVar
+from typing import Optional, TypeVar
 
 from Foundation import NSObject
 
 T = TypeVar("T")
 
 
-def super(cls: Type[T], self: T) -> T: ...
+def super(cls: type[T], self: T) -> T: ...
 
 
 def macos_available(major: int, minor: int, patch: int = 0) -> bool: ...


### PR DESCRIPTION
Now that we have dropped support for Python 3.8, we can stop using a bunch of deprecated typing types.