### PR TITLE
More typing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Changed
 * Updated ``winrt`` backend to use PyWinRT >= 3.1.
 * Added ``notification_discriminator`` parameter to start_notify on CoreBluetooth backend
 * Changed return type of ``connect()``, ``disconnect()``, ``pair()`` and ``unpair()`` methods to ``None``.
+* Moved backend-specific arg types to new ``bleak.args`` sub-package.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -40,25 +40,25 @@ else:
     from asyncio import timeout as async_timeout
     from typing import Never, Unpack, assert_never
 
-from .backends.characteristic import BleakGATTCharacteristic
-from .backends.client import BaseBleakClient, get_platform_client_backend_type
-from .backends.device import BLEDevice
-from .backends.scanner import (
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.client import BaseBleakClient, get_platform_client_backend_type
+from bleak.backends.device import BLEDevice
+from bleak.backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
     AdvertisementDataFilter,
     BaseBleakScanner,
     get_platform_scanner_backend_type,
 )
-from .backends.service import BleakGATTServiceCollection
-from .exc import BleakCharacteristicNotFoundError, BleakError
-from .uuids import normalize_uuid_str
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.exc import BleakCharacteristicNotFoundError, BleakError
+from bleak.uuids import normalize_uuid_str
 
 if TYPE_CHECKING:
-    from .backends.bluezdbus.scanner import BlueZScannerArgs
-    from .backends.corebluetooth.client import CBStartNotifyArgs
-    from .backends.corebluetooth.scanner import CBScannerArgs
-    from .backends.winrt.client import WinRTClientArgs
+    from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
+    from bleak.backends.corebluetooth.client import CBStartNotifyArgs
+    from bleak.backends.corebluetooth.scanner import CBScannerArgs
+    from bleak.backends.winrt.client import WinRTClientArgs
 
 
 _logger = logging.getLogger(__name__)

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -19,17 +19,16 @@ from types import TracebackType
 from typing import Any, Literal, Optional, TypedDict, Union, cast, overload
 
 if sys.version_info < (3, 12):
-    from typing_extensions import Buffer, Self
+    from typing_extensions import Buffer
 else:
     from collections.abc import Buffer
-    from typing import Self
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout
-    from typing_extensions import Never, Unpack, assert_never
+    from typing_extensions import Never, Self, Unpack, assert_never
 else:
     from asyncio import timeout as async_timeout
-    from typing import Never, Unpack, assert_never
+    from typing import Never, Self, Unpack, assert_never
 
 from bleak.args.bluez import BlueZScannerArgs
 from bleak.args.corebluetooth import CBScannerArgs, CBStartNotifyArgs

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -16,16 +16,7 @@ import sys
 import uuid
 from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    Optional,
-    TypedDict,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Literal, Optional, TypedDict, Union, cast, overload
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer, Self
@@ -40,6 +31,9 @@ else:
     from asyncio import timeout as async_timeout
     from typing import Never, Unpack, assert_never
 
+from bleak.args.bluez import BlueZScannerArgs
+from bleak.args.corebluetooth import CBScannerArgs, CBStartNotifyArgs
+from bleak.args.winrt import WinRTClientArgs
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, get_platform_client_backend_type
 from bleak.backends.device import BLEDevice
@@ -53,13 +47,6 @@ from bleak.backends.scanner import (
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakCharacteristicNotFoundError, BleakError
 from bleak.uuids import normalize_uuid_str
-
-if TYPE_CHECKING:
-    from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
-    from bleak.backends.corebluetooth.client import CBStartNotifyArgs
-    from bleak.backends.corebluetooth.scanner import CBScannerArgs
-    from bleak.backends.winrt.client import WinRTClientArgs
-
 
 _logger = logging.getLogger(__name__)
 _logger.addHandler(logging.NullHandler())

--- a/bleak/args/bluez.py
+++ b/bleak/args/bluez.py
@@ -1,0 +1,99 @@
+"""
+-----------------------
+BlueZ backend arguments
+-----------------------
+"""
+
+from typing import NamedTuple, TypedDict, Union
+
+from bleak.assigned_numbers import AdvertisementDataType
+
+
+class BlueZDiscoveryFilters(TypedDict, total=False):
+    """
+    Dictionary of arguments for the ``org.bluez.Adapter1.SetDiscoveryFilter``
+    D-Bus method.
+
+    https://github.com/bluez/bluez/blob/master/doc/org.bluez.Adapter.rst#void-setdiscoveryfilterdict-filter
+    """
+
+    UUIDs: list[str]
+    """
+    Filter by service UUIDs, empty means match _any_ UUID.
+
+    Normally, the ``service_uuids`` argument of :class:`bleak.BleakScanner`
+    is used instead.
+    """
+    RSSI: int
+    """
+    RSSI threshold value.
+    """
+    Pathloss: int
+    """
+    Pathloss threshold value.
+    """
+    Transport: str
+    """
+    Transport parameter determines the type of scan.
+
+    This should not be used since it is required to be set to ``"le"``.
+    """
+    DuplicateData: bool
+    """
+    Disables duplicate detection of advertisement data.
+
+    This does not affect the ``Filter Duplicates`` parameter of the ``LE Set Scan Enable``
+    HCI command to the Bluetooth adapter!
+
+    Although the default value for BlueZ is ``True``, Bleak sets this to ``False`` by default.
+    """
+    Discoverable: bool
+    """
+    Make adapter discoverable while discovering,
+    if the adapter is already discoverable setting
+    this filter won't do anything.
+    """
+    Pattern: str
+    """
+    Discover devices where the pattern matches
+    either the prefix of the address or
+    device name which is convenient way to limited
+    the number of device objects created during a
+    discovery.
+    """
+
+
+class OrPattern(NamedTuple):
+    """
+    BlueZ advertisement monitor or-pattern.
+
+    https://github.com/bluez/bluez/blob/master/doc/org.bluez.AdvertisementMonitor.rst#arrayuint8-uint8-arraybyte-patterns-read-only-optional
+    """
+
+    start_position: int
+    ad_data_type: AdvertisementDataType
+    content_of_pattern: bytes
+
+
+# Windows has a similar structure, so we allow generic tuple for cross-platform compatibility
+OrPatternLike = Union[OrPattern, tuple[int, AdvertisementDataType, bytes]]
+
+
+class BlueZScannerArgs(TypedDict, total=False):
+    """
+    :class:`BleakScanner` args that are specific to the BlueZ backend.
+    """
+
+    filters: BlueZDiscoveryFilters
+    """
+    Filters to pass to the adapter SetDiscoveryFilter D-Bus method.
+
+    Only used for active scanning.
+    """
+
+    or_patterns: list[OrPatternLike]
+    """
+    Or patterns to pass to the AdvertisementMonitor1 D-Bus interface.
+
+    Only used for passive scanning.
+    """

--- a/bleak/args/corebluetooth.py
+++ b/bleak/args/corebluetooth.py
@@ -1,0 +1,41 @@
+"""
+-------------------------------
+CoreBluetooth backend arguments
+-------------------------------
+"""
+
+from collections.abc import Callable
+from typing import Optional, TypedDict
+
+
+class CBScannerArgs(TypedDict, total=False):
+    """
+    Platform-specific :class:`BleakScanner` args for the CoreBluetooth backend.
+    """
+
+    use_bdaddr: bool
+    """
+    If true, use Bluetooth address instead of UUID.
+
+    .. warning:: This uses an undocumented IOBluetooth API to get the Bluetooth
+        address and may break in the future macOS releases. `It is known to not
+        work on macOS 10.15 <https://github.com/hbldh/bleak/issues/1286>`_.
+    """
+
+
+NotificationDiscriminator = Callable[[bytes], bool]
+
+
+class CBStartNotifyArgs(TypedDict, total=False):
+    """CoreBluetooth backend-specific dictionary of arguments for the
+    :meth:`bleak.BleakClient.start_notify` method.
+    """
+
+    notification_discriminator: Optional[NotificationDiscriminator]
+    """
+    A function that takes a single argument of a characteristic value
+    and returns ``True`` if the value is from a notification or
+    ``False`` if the value is from a read response.
+
+    .. seealso:: :ref:`cb-notification-discriminator` for more info.
+    """

--- a/bleak/args/winrt.py
+++ b/bleak/args/winrt.py
@@ -1,0 +1,32 @@
+"""
+-----------------------
+WinRT backend arguments
+-----------------------
+"""
+
+from typing import Literal, TypedDict
+
+
+class WinRTClientArgs(TypedDict, total=False):
+    """
+    Windows-specific arguments for :class:`BleakClient`.
+    """
+
+    address_type: Literal["public", "random"]
+    """
+    Can either be ``"public"`` or ``"random"``, depending on the required address
+    type needed to connect to your device.
+    """
+
+    use_cached_services: bool
+    """
+    ``True`` allows Windows to fetch the services, characteristics and descriptors
+    from the Windows cache instead of reading them from the device. Can be very
+    much faster for known, unchanging devices, but not recommended for DIY peripherals
+    where the GATT layout can change between connections.
+
+    ``False`` will force the attribute database to be read from the remote device
+    instead of using the OS cache.
+
+    If omitted, the OS Bluetooth stack will do what it thinks is best.
+    """

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -15,31 +15,15 @@ if TYPE_CHECKING:
 
 import logging
 from collections.abc import Iterable
-from typing import NamedTuple, Union, no_type_check
+from typing import no_type_check
 
 from dbus_fast import PropertyAccess
 from dbus_fast.service import ServiceInterface, dbus_property, method
 
-from bleak.assigned_numbers import AdvertisementDataType
+from bleak.args.bluez import OrPatternLike
 from bleak.backends.bluezdbus import defs
 
 logger = logging.getLogger(__name__)
-
-
-class OrPattern(NamedTuple):
-    """
-    BlueZ advertisement monitor or-pattern.
-
-    https://github.com/bluez/bluez/blob/master/doc/org.bluez.AdvertisementMonitor.rst#arrayuint8-uint8-arraybyte-patterns-read-only-optional
-    """
-
-    start_position: int
-    ad_data_type: AdvertisementDataType
-    content_of_pattern: bytes
-
-
-# Windows has a similar structure, so we allow generic tuple for cross-platform compatibility
-OrPatternLike = Union[OrPattern, tuple[int, AdvertisementDataType, bytes]]
 
 
 class AdvertisementMonitor(ServiceInterface):

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -20,8 +20,8 @@ from typing import NamedTuple, Union, no_type_check
 from dbus_fast import PropertyAccess
 from dbus_fast.service import ServiceInterface, dbus_property, method
 
-from ...assigned_numbers import AdvertisementDataType
-from . import defs
+from bleak.assigned_numbers import AdvertisementDataType
+from bleak.backends.bluezdbus import defs
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/bluezdbus/characteristic.py
+++ b/bleak/backends/bluezdbus/characteristic.py
@@ -9,10 +9,10 @@ from collections.abc import Callable
 from typing import Union
 from uuid import UUID
 
-from ..characteristic import BleakGATTCharacteristic
-from ..descriptor import BleakGATTDescriptor
-from .defs import GattCharacteristic1
-from .utils import extract_service_handle_from_path
+from bleak.backends.bluezdbus.defs import GattCharacteristic1
+from bleak.backends.bluezdbus.utils import extract_service_handle_from_path
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class BleakGATTCharacteristicBlueZDBus(BleakGATTCharacteristic):

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -33,23 +33,23 @@ from dbus_fast.constants import BusType, ErrorType, MessageType
 from dbus_fast.message import Message
 from dbus_fast.signature import Variant
 
-from ... import BleakScanner
-from ...exc import (
+from bleak import BleakScanner
+from bleak.backends.bluezdbus import defs
+from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus
+from bleak.backends.bluezdbus.manager import get_global_bluez_manager
+from bleak.backends.bluezdbus.scanner import BleakScannerBlueZDBus
+from bleak.backends.bluezdbus.utils import assert_reply, get_dbus_authenticator
+from bleak.backends.bluezdbus.version import BlueZFeatures
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.client import BaseBleakClient, NotifyCallback
+from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.exc import (
     BleakCharacteristicNotFoundError,
     BleakDBusError,
     BleakDeviceNotFoundError,
     BleakError,
 )
-from ..characteristic import BleakGATTCharacteristic
-from ..client import BaseBleakClient, NotifyCallback
-from ..device import BLEDevice
-from ..service import BleakGATTServiceCollection
-from . import defs
-from .characteristic import BleakGATTCharacteristicBlueZDBus
-from .manager import get_global_bluez_manager
-from .scanner import BleakScannerBlueZDBus
-from .utils import assert_reply, get_dbus_authenticator
-from .version import BlueZFeatures
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/bluezdbus/descriptor.py
+++ b/bleak/backends/bluezdbus/descriptor.py
@@ -5,8 +5,8 @@ if TYPE_CHECKING:
     if sys.platform != "linux":
         assert False, "This backend is only available on Linux"
 
-from ..descriptor import BleakGATTDescriptor
-from .defs import GattDescriptor1
+from bleak.backends.bluezdbus.defs import GattDescriptor1
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class BleakGATTDescriptorBlueZDBus(BleakGATTDescriptor):

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -25,20 +25,28 @@ from weakref import WeakKeyDictionary
 from dbus_fast import BusType, Message, MessageType, Variant, unpack_variants
 from dbus_fast.aio.message_bus import MessageBus
 
-from ...exc import BleakDBusError, BleakError
-from ..service import BleakGATTServiceCollection
-from . import defs
-from .advertisement_monitor import AdvertisementMonitor, OrPatternLike
-from .characteristic import BleakGATTCharacteristicBlueZDBus
-from .defs import Device1, GattCharacteristic1, GattDescriptor1, GattService1
-from .descriptor import BleakGATTDescriptorBlueZDBus
-from .service import BleakGATTServiceBlueZDBus
-from .signals import MatchRules, add_match
-from .utils import (
+from bleak.backends.bluezdbus import defs
+from bleak.backends.bluezdbus.advertisement_monitor import (
+    AdvertisementMonitor,
+    OrPatternLike,
+)
+from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus
+from bleak.backends.bluezdbus.defs import (
+    Device1,
+    GattCharacteristic1,
+    GattDescriptor1,
+    GattService1,
+)
+from bleak.backends.bluezdbus.descriptor import BleakGATTDescriptorBlueZDBus
+from bleak.backends.bluezdbus.service import BleakGATTServiceBlueZDBus
+from bleak.backends.bluezdbus.signals import MatchRules, add_match
+from bleak.backends.bluezdbus.utils import (
     assert_reply,
     device_path_from_characteristic_path,
     get_dbus_authenticator,
 )
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.exc import BleakDBusError, BleakError
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -7,11 +7,11 @@ if TYPE_CHECKING:
 
 import logging
 from collections.abc import Callable, Coroutine
-from typing import Any, Literal, Optional, TypedDict
+from typing import Any, Literal, Optional
 
 from dbus_fast import Variant
 
-from bleak.backends.bluezdbus.advertisement_monitor import OrPatternLike
+from bleak.args.bluez import BlueZScannerArgs
 from bleak.backends.bluezdbus.defs import Device1
 from bleak.backends.bluezdbus.manager import get_global_bluez_manager
 from bleak.backends.bluezdbus.utils import bdaddr_from_device_path
@@ -23,80 +23,6 @@ from bleak.backends.scanner import (
 from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
-
-
-class BlueZDiscoveryFilters(TypedDict, total=False):
-    """
-    Dictionary of arguments for the ``org.bluez.Adapter1.SetDiscoveryFilter``
-    D-Bus method.
-
-    https://github.com/bluez/bluez/blob/master/doc/org.bluez.Adapter.rst#void-setdiscoveryfilterdict-filter
-    """
-
-    UUIDs: list[str]
-    """
-    Filter by service UUIDs, empty means match _any_ UUID.
-
-    Normally, the ``service_uuids`` argument of :class:`bleak.BleakScanner`
-    is used instead.
-    """
-    RSSI: int
-    """
-    RSSI threshold value.
-    """
-    Pathloss: int
-    """
-    Pathloss threshold value.
-    """
-    Transport: str
-    """
-    Transport parameter determines the type of scan.
-
-    This should not be used since it is required to be set to ``"le"``.
-    """
-    DuplicateData: bool
-    """
-    Disables duplicate detection of advertisement data.
-
-    This does not affect the ``Filter Duplicates`` parameter of the ``LE Set Scan Enable``
-    HCI command to the Bluetooth adapter!
-
-    Although the default value for BlueZ is ``True``, Bleak sets this to ``False`` by default.
-    """
-    Discoverable: bool
-    """
-    Make adapter discoverable while discovering,
-    if the adapter is already discoverable setting
-    this filter won't do anything.
-    """
-    Pattern: str
-    """
-    Discover devices where the pattern matches
-    either the prefix of the address or
-    device name which is convenient way to limited
-    the number of device objects created during a
-    discovery.
-    """
-
-
-class BlueZScannerArgs(TypedDict, total=False):
-    """
-    :class:`BleakScanner` args that are specific to the BlueZ backend.
-    """
-
-    filters: BlueZDiscoveryFilters
-    """
-    Filters to pass to the adapter SetDiscoveryFilter D-Bus method.
-
-    Only used for active scanning.
-    """
-
-    or_patterns: list[OrPatternLike]
-    """
-    Or patterns to pass to the AdvertisementMonitor1 D-Bus interface.
-
-    Only used for passive scanning.
-    """
 
 
 class BleakScannerBlueZDBus(BaseBleakScanner):

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -11,12 +11,16 @@ from typing import Any, Literal, Optional, TypedDict
 
 from dbus_fast import Variant
 
-from ...exc import BleakError
-from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
-from .advertisement_monitor import OrPatternLike
-from .defs import Device1
-from .manager import get_global_bluez_manager
-from .utils import bdaddr_from_device_path
+from bleak.backends.bluezdbus.advertisement_monitor import OrPatternLike
+from bleak.backends.bluezdbus.defs import Device1
+from bleak.backends.bluezdbus.manager import get_global_bluez_manager
+from bleak.backends.bluezdbus.utils import bdaddr_from_device_path
+from bleak.backends.scanner import (
+    AdvertisementData,
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+)
+from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/bluezdbus/service.py
+++ b/bleak/backends/bluezdbus/service.py
@@ -7,9 +7,9 @@ if TYPE_CHECKING:
 
 from typing import Any
 
-from ..service import BleakGATTService
-from .characteristic import BleakGATTCharacteristicBlueZDBus
-from .utils import extract_service_handle_from_path
+from bleak.backends.bluezdbus.characteristic import BleakGATTCharacteristicBlueZDBus
+from bleak.backends.bluezdbus.utils import extract_service_handle_from_path
+from bleak.backends.service import BleakGATTService
 
 
 class BleakGATTServiceBlueZDBus(BleakGATTService):

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -12,7 +12,7 @@ from dbus_fast.auth import AuthExternal
 from dbus_fast.constants import MessageType
 from dbus_fast.message import Message
 
-from ...exc import BleakDBusError, BleakError
+from bleak.exc import BleakDBusError, BleakError
 
 
 def assert_reply(reply: Message) -> None:

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -11,8 +11,8 @@ from collections.abc import Callable
 from typing import Any, Union
 from uuid import UUID
 
-from ..uuids import uuidstr_to_str
-from .descriptor import BleakGATTDescriptor
+from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.uuids import uuidstr_to_str
 
 
 class GattCharacteristicsFlags(enum.Enum):

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -18,10 +18,10 @@ if sys.version_info < (3, 12):
 else:
     from collections.abc import Buffer
 
-from ..exc import BleakError
-from .characteristic import BleakGATTCharacteristic
-from .device import BLEDevice
-from .service import BleakGATTServiceCollection
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.exc import BleakError
 
 NotifyCallback = Callable[[bytearray], None]
 

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -49,7 +49,7 @@ from Foundation import (
 )
 from libdispatch import DISPATCH_QUEUE_SERIAL, dispatch_queue_create
 
-from ...exc import BleakError
+from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
 CBCentralManagerDelegate = objc.protocolNamed("CBCentralManagerDelegate")

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -36,8 +36,8 @@ from CoreBluetooth import (
 )
 from Foundation import NSUUID, NSArray, NSData, NSError, NSNumber, NSObject, NSString
 
-from ...exc import BleakError
-from ..client import NotifyCallback
+from bleak.backends.client import NotifyCallback
+from bleak.exc import BleakError
 
 # logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 import asyncio
 import itertools
 import logging
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from typing import Any, NewType, Optional
 
 if sys.version_info < (3, 11):
@@ -36,14 +36,13 @@ from CoreBluetooth import (
 )
 from Foundation import NSUUID, NSArray, NSData, NSError, NSNumber, NSObject, NSString
 
+from bleak.args.corebluetooth import NotificationDiscriminator
 from bleak.backends.client import NotifyCallback
 from bleak.exc import BleakError
 
 # logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
-
-NotificationDiscriminator = Callable[[bytes], bool]
 
 CBPeripheralDelegate = objc.protocolNamed("CBPeripheralDelegate")
 

--- a/bleak/backends/corebluetooth/characteristic.py
+++ b/bleak/backends/corebluetooth/characteristic.py
@@ -18,10 +18,10 @@ from typing import Optional, Union
 
 from CoreBluetooth import CBCharacteristic
 
-from ..characteristic import BleakGATTCharacteristic
-from ..descriptor import BleakGATTDescriptor
-from .descriptor import BleakGATTDescriptorCoreBluetooth
-from .utils import cb_uuid_to_str
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class CBCharacteristicProperties(Enum):

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 import asyncio
 import logging
 import uuid
-from typing import Optional, TypedDict, Union
+from typing import Optional, Union
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer
@@ -31,6 +31,7 @@ from CoreBluetooth import (
 from Foundation import NSArray, NSData
 
 from bleak import BleakScanner
+from bleak.args.corebluetooth import CBStartNotifyArgs
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
@@ -38,10 +39,7 @@ from bleak.backends.corebluetooth.characteristic import (
     BleakGATTCharacteristicCoreBluetooth,
 )
 from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
-from bleak.backends.corebluetooth.PeripheralDelegate import (
-    NotificationDiscriminator,
-    PeripheralDelegate,
-)
+from bleak.backends.corebluetooth.PeripheralDelegate import PeripheralDelegate
 from bleak.backends.corebluetooth.scanner import BleakScannerCoreBluetooth
 from bleak.backends.corebluetooth.service import BleakGATTServiceCoreBluetooth
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
@@ -54,21 +52,6 @@ from bleak.exc import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class CBStartNotifyArgs(TypedDict, total=False):
-    """CoreBluetooth backend-specific dictionary of arguments for the
-    :meth:`bleak.BleakClient.start_notify` method.
-    """
-
-    notification_discriminator: Optional[NotificationDiscriminator]
-    """
-    A function that takes a single argument of a characteristic value
-    and returns ``True`` if the value is from a notification or
-    ``False`` if the value is from a read response.
-
-    .. seealso:: :ref:`cb-notification-discriminator` for more info.
-    """
 
 
 class BleakClientCoreBluetooth(BaseBleakClient):

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -30,23 +30,28 @@ from CoreBluetooth import (
 )
 from Foundation import NSArray, NSData
 
-from ... import BleakScanner
-from ...exc import (
+from bleak import BleakScanner
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.client import BaseBleakClient, NotifyCallback
+from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
+from bleak.backends.corebluetooth.characteristic import (
+    BleakGATTCharacteristicCoreBluetooth,
+)
+from bleak.backends.corebluetooth.descriptor import BleakGATTDescriptorCoreBluetooth
+from bleak.backends.corebluetooth.PeripheralDelegate import (
+    NotificationDiscriminator,
+    PeripheralDelegate,
+)
+from bleak.backends.corebluetooth.scanner import BleakScannerCoreBluetooth
+from bleak.backends.corebluetooth.service import BleakGATTServiceCoreBluetooth
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
+from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.exc import (
     BleakCharacteristicNotFoundError,
     BleakDeviceNotFoundError,
     BleakError,
 )
-from ..characteristic import BleakGATTCharacteristic
-from ..client import BaseBleakClient, NotifyCallback
-from ..device import BLEDevice
-from ..service import BleakGATTServiceCollection
-from .CentralManagerDelegate import CentralManagerDelegate
-from .characteristic import BleakGATTCharacteristicCoreBluetooth
-from .descriptor import BleakGATTDescriptorCoreBluetooth
-from .PeripheralDelegate import NotificationDiscriminator, PeripheralDelegate
-from .scanner import BleakScannerCoreBluetooth
-from .service import BleakGATTServiceCoreBluetooth
-from .utils import cb_uuid_to_str
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/corebluetooth/descriptor.py
+++ b/bleak/backends/corebluetooth/descriptor.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 
 from CoreBluetooth import CBDescriptor
 
-from ..corebluetooth.utils import cb_uuid_to_str
-from ..descriptor import BleakGATTDescriptor
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class BleakGATTDescriptorCoreBluetooth(BleakGATTDescriptor):

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -6,12 +6,13 @@ if TYPE_CHECKING:
         assert False, "This backend is only available on macOS"
 
 import logging
-from typing import Any, Literal, Optional, TypedDict
+from typing import Any, Literal, Optional
 
 import objc
 from CoreBluetooth import CBPeripheral
 from Foundation import NSBundle
 
+from bleak.args.corebluetooth import CBScannerArgs
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.scanner import (
@@ -22,21 +23,6 @@ from bleak.backends.scanner import (
 from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
-
-
-class CBScannerArgs(TypedDict, total=False):
-    """
-    Platform-specific :class:`BleakScanner` args for the CoreBluetooth backend.
-    """
-
-    use_bdaddr: bool
-    """
-    If true, use Bluetooth address instead of UUID.
-
-    .. warning:: This uses an undocumented IOBluetooth API to get the Bluetooth
-        address and may break in the future macOS releases. `It is known to not
-        work on macOS 10.15 <https://github.com/hbldh/bleak/issues/1286>`_.
-    """
 
 
 class BleakScannerCoreBluetooth(BaseBleakScanner):

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -12,10 +12,14 @@ import objc
 from CoreBluetooth import CBPeripheral
 from Foundation import NSBundle
 
-from ...exc import BleakError
-from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
-from .CentralManagerDelegate import CentralManagerDelegate
-from .utils import cb_uuid_to_str
+from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
+from bleak.backends.scanner import (
+    AdvertisementData,
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+)
+from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/corebluetooth/service.py
+++ b/bleak/backends/corebluetooth/service.py
@@ -7,9 +7,11 @@ if TYPE_CHECKING:
 
 from CoreBluetooth import CBService
 
-from ..service import BleakGATTService
-from .characteristic import BleakGATTCharacteristicCoreBluetooth
-from .utils import cb_uuid_to_str
+from bleak.backends.corebluetooth.characteristic import (
+    BleakGATTCharacteristicCoreBluetooth,
+)
+from bleak.backends.corebluetooth.utils import cb_uuid_to_str
+from bleak.backends.service import BleakGATTService
 
 
 class BleakGATTServiceCoreBluetooth(BleakGATTService):

--- a/bleak/backends/corebluetooth/utils.py
+++ b/bleak/backends/corebluetooth/utils.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 from CoreBluetooth import CBUUID
 from Foundation import NSData
 
-from ...uuids import normalize_uuid_str
+from bleak.uuids import normalize_uuid_str
 
 
 def cb_uuid_to_str(uuid: CBUUID) -> str:

--- a/bleak/backends/descriptor.py
+++ b/bleak/backends/descriptor.py
@@ -8,7 +8,7 @@ Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 import abc
 from typing import Any
 
-from ..uuids import normalize_uuid_16
+from bleak.uuids import normalize_uuid_16
 
 _descriptor_descriptions = {
     normalize_uuid_16(0x2905): [

--- a/bleak/backends/p4android/characteristic.py
+++ b/bleak/backends/p4android/characteristic.py
@@ -9,10 +9,10 @@ from collections.abc import Callable
 from typing import Union
 from uuid import UUID
 
-from ...exc import BleakError
-from ..characteristic import BleakGATTCharacteristic
-from ..descriptor import BleakGATTDescriptor
-from . import defs
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.backends.p4android import defs
+from bleak.exc import BleakError
 
 
 class BleakGATTCharacteristicP4Android(BleakGATTCharacteristic):

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -18,15 +18,15 @@ from typing import Optional, Union
 from android.broadcast import BroadcastReceiver
 from jnius import java_method
 
-from ...exc import BleakCharacteristicNotFoundError, BleakError
-from ..characteristic import BleakGATTCharacteristic
-from ..client import BaseBleakClient, NotifyCallback
-from ..device import BLEDevice
-from ..service import BleakGATTServiceCollection
-from . import defs, utils
-from .characteristic import BleakGATTCharacteristicP4Android
-from .descriptor import BleakGATTDescriptorP4Android
-from .service import BleakGATTServiceP4Android
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.client import BaseBleakClient, NotifyCallback
+from bleak.backends.device import BLEDevice
+from bleak.backends.p4android import defs, utils
+from bleak.backends.p4android.characteristic import BleakGATTCharacteristicP4Android
+from bleak.backends.p4android.descriptor import BleakGATTDescriptorP4Android
+from bleak.backends.p4android.service import BleakGATTServiceP4Android
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.exc import BleakCharacteristicNotFoundError, BleakError
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/p4android/descriptor.py
+++ b/bleak/backends/p4android/descriptor.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     if sys.platform != "android":
         assert False, "This backend is only available on Android"
 
-from ..descriptor import BleakGATTDescriptor
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class BleakGATTDescriptorP4Android(BleakGATTDescriptor):

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -19,9 +19,13 @@ from android.broadcast import BroadcastReceiver
 from android.permissions import Permission, request_permissions
 from jnius import cast, java_method
 
-from ...exc import BleakError
-from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
-from . import defs, utils
+from bleak.backends.p4android import defs, utils
+from bleak.backends.scanner import (
+    AdvertisementData,
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+)
+from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/p4android/service.py
+++ b/bleak/backends/p4android/service.py
@@ -5,8 +5,8 @@ if TYPE_CHECKING:
     if sys.platform != "android":
         assert False, "This backend is only available on Android"
 
-from ..service import BleakGATTService
-from .characteristic import BleakGATTCharacteristicP4Android
+from bleak.backends.p4android.characteristic import BleakGATTCharacteristicP4Android
+from bleak.backends.service import BleakGATTService
 
 
 class BleakGATTServiceP4Android(BleakGATTService):

--- a/bleak/backends/p4android/utils.py
+++ b/bleak/backends/p4android/utils.py
@@ -11,7 +11,7 @@ import warnings
 
 from jnius import PythonJavaClass
 
-from ...exc import BleakError
+from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -6,8 +6,8 @@ import platform
 from collections.abc import Callable, Coroutine, Hashable
 from typing import Any, NamedTuple, Optional
 
-from ..exc import BleakError
-from .device import BLEDevice
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
 
 # prevent tasks from being garbage collected
 _background_tasks = set[asyncio.Task[None]]()

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -11,10 +11,10 @@ from collections.abc import Iterator
 from typing import Any, Optional, Union
 from uuid import UUID
 
-from ..exc import BleakError
-from ..uuids import normalize_uuid_str, uuidstr_to_str
-from .characteristic import BleakGATTCharacteristic
-from .descriptor import BleakGATTDescriptor
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.descriptor import BleakGATTDescriptor
+from bleak.exc import BleakError
+from bleak.uuids import normalize_uuid_str, uuidstr_to_str
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -134,7 +134,7 @@ class BleakGATTCharacteristicWinRT(BleakGATTCharacteristic):
         except StopIteration:
             return None
 
-    def add_descriptor(self, descriptor: BleakGATTDescriptor):
+    def add_descriptor(self, descriptor: BleakGATTDescriptor) -> None:
         """Add a :py:class:`~BleakGATTDescriptor` to the characteristic.
 
         Should not be used by end user, but rather by `bleak` itself.

--- a/bleak/backends/winrt/characteristic.py
+++ b/bleak/backends/winrt/characteristic.py
@@ -14,8 +14,8 @@ from winrt.windows.devices.bluetooth.genericattributeprofile import (
     GattCharacteristicProperties,
 )
 
-from ..characteristic import BleakGATTCharacteristic
-from ..descriptor import BleakGATTDescriptor
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 _GattCharacteristicsPropertiesMap = {
     GattCharacteristicProperties.NONE: (

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -20,16 +20,16 @@ from ctypes import WinError
 from typing import Any, Generic, Optional, Protocol, Sequence, TypeVar, Union, cast
 
 if sys.version_info < (3, 12):
-    from typing_extensions import Buffer, Self
+    from typing_extensions import Buffer
 else:
-    from collections.abc import Buffer, Self
+    from collections.abc import Buffer
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout
-    from typing_extensions import assert_never
+    from typing_extensions import Self, assert_never
 else:
     from asyncio import timeout as async_timeout
-    from typing import assert_never
+    from typing import assert_never, Self
 
 from winrt.system import Object
 from winrt.windows.devices.bluetooth import (

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -78,21 +78,21 @@ from winrt.windows.foundation import (
 )
 from winrt.windows.storage.streams import Buffer as WinBuffer
 
-from ... import BleakScanner
-from ...exc import (
+from bleak import BleakScanner
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from bleak.backends.client import BaseBleakClient, NotifyCallback
+from bleak.backends.device import BLEDevice
+from bleak.backends.service import BleakGATTServiceCollection
+from bleak.backends.winrt.characteristic import BleakGATTCharacteristicWinRT
+from bleak.backends.winrt.descriptor import BleakGATTDescriptorWinRT
+from bleak.backends.winrt.scanner import BleakScannerWinRT, _RawAdvData
+from bleak.backends.winrt.service import BleakGATTServiceWinRT
+from bleak.exc import (
     PROTOCOL_ERROR_CODES,
     BleakCharacteristicNotFoundError,
     BleakDeviceNotFoundError,
     BleakError,
 )
-from ..characteristic import BleakGATTCharacteristic
-from ..client import BaseBleakClient, NotifyCallback
-from ..device import BLEDevice
-from ..service import BleakGATTServiceCollection
-from .characteristic import BleakGATTCharacteristicWinRT
-from .descriptor import BleakGATTDescriptorWinRT
-from .scanner import BleakScannerWinRT, _RawAdvData
-from .service import BleakGATTServiceWinRT
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -17,18 +17,7 @@ import asyncio
 import logging
 import uuid
 from ctypes import WinError
-from typing import (
-    Any,
-    Generic,
-    Literal,
-    Optional,
-    Protocol,
-    Sequence,
-    TypedDict,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Generic, Optional, Protocol, Sequence, TypeVar, Union, cast
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer, Self
@@ -79,6 +68,7 @@ from winrt.windows.foundation import (
 from winrt.windows.storage.streams import Buffer as WinBuffer
 
 from bleak import BleakScanner
+from bleak.args.winrt import WinRTClientArgs
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback
 from bleak.backends.device import BLEDevice
@@ -149,31 +139,6 @@ def _ensure_success(result: _Result, attr: Optional[str], fail_msg: str) -> Any:
         raise BleakError(f"{fail_msg}: Unreachable")
 
     raise BleakError(f"{fail_msg}: Unexpected status code 0x{status:02X}")
-
-
-class WinRTClientArgs(TypedDict, total=False):
-    """
-    Windows-specific arguments for :class:`BleakClient`.
-    """
-
-    address_type: Literal["public", "random"]
-    """
-    Can either be ``"public"`` or ``"random"``, depending on the required address
-    type needed to connect to your device.
-    """
-
-    use_cached_services: bool
-    """
-    ``True`` allows Windows to fetch the services, characteristics and descriptors
-    from the Windows cache instead of reading them from the device. Can be very
-    much faster for known, unchanging devices, but not recommended for DIY peripherals
-    where the GATT layout can change between connections.
-
-    ``False`` will force the attribute database to be read from the remote device
-    instead of using the OS cache.
-
-    If omitted, the OS Bluetooth stack will do what it thinks is best.
-    """
 
 
 class BleakClientWinRT(BaseBleakClient):

--- a/bleak/backends/winrt/descriptor.py
+++ b/bleak/backends/winrt/descriptor.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
 
 from winrt.windows.devices.bluetooth.genericattributeprofile import GattDescriptor
 
-from ..descriptor import BleakGATTDescriptor
+from bleak.backends.descriptor import BleakGATTDescriptor
 
 
 class BleakGATTDescriptorWinRT(BleakGATTDescriptor):

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -20,11 +20,15 @@ from winrt.windows.devices.bluetooth.advertisement import (
 )
 from winrt.windows.foundation import EventRegistrationToken
 
-from ...assigned_numbers import AdvertisementDataType
-from ...exc import BleakError
-from ...uuids import normalize_uuid_str
-from ..scanner import AdvertisementData, AdvertisementDataCallback, BaseBleakScanner
-from .util import assert_mta
+from bleak.assigned_numbers import AdvertisementDataType
+from bleak.backends.scanner import (
+    AdvertisementData,
+    AdvertisementDataCallback,
+    BaseBleakScanner,
+)
+from bleak.backends.winrt.util import assert_mta
+from bleak.exc import BleakError
+from bleak.uuids import normalize_uuid_str
 
 logger = logging.getLogger(__name__)
 

--- a/bleak/backends/winrt/service.py
+++ b/bleak/backends/winrt/service.py
@@ -7,8 +7,8 @@ if TYPE_CHECKING:
 
 from winrt.windows.devices.bluetooth.genericattributeprofile import GattDeviceService
 
-from ..service import BleakGATTService
-from ..winrt.characteristic import BleakGATTCharacteristicWinRT
+from bleak.backends.service import BleakGATTService
+from bleak.backends.winrt.characteristic import BleakGATTCharacteristicWinRT
 
 
 class BleakGATTServiceWinRT(BleakGATTService):

--- a/bleak/backends/winrt/service.py
+++ b/bleak/backends/winrt/service.py
@@ -14,9 +14,9 @@ from ..winrt.characteristic import BleakGATTCharacteristicWinRT
 class BleakGATTServiceWinRT(BleakGATTService):
     """GATT Characteristic implementation for the .NET backend, implemented with WinRT"""
 
-    def __init__(self, obj: GattDeviceService):
+    def __init__(self, obj: GattDeviceService) -> None:
         super().__init__(obj)
-        self.__characteristics = []
+        self.__characteristics: list[BleakGATTCharacteristicWinRT] = []
 
     @property
     def uuid(self) -> str:
@@ -31,7 +31,7 @@ class BleakGATTServiceWinRT(BleakGATTService):
         """List of characteristics for this service"""
         return self.__characteristics
 
-    def add_characteristic(self, characteristic: BleakGATTCharacteristicWinRT):
+    def add_characteristic(self, characteristic: BleakGATTCharacteristicWinRT) -> None:
         """Add a :py:class:`~BleakGATTCharacteristicWinRT` to the service.
 
         Should not be used by end user, but rather by `bleak` itself.

--- a/bleak/backends/winrt/util.py
+++ b/bleak/backends/winrt/util.py
@@ -10,7 +10,7 @@ import ctypes
 from ctypes import wintypes
 from enum import IntEnum
 
-from ...exc import BleakError
+from bleak.exc import BleakError
 
 if sys.version_info < (3, 11):
     from async_timeout import timeout as async_timeout

--- a/bleak/backends/winrt/util.py
+++ b/bleak/backends/winrt/util.py
@@ -18,14 +18,14 @@ else:
     from asyncio import timeout as async_timeout
 
 
-def _check_result(result, func, args):
+def _check_result(result: int, func, args):
     if not result:
         raise ctypes.WinError()
 
     return args
 
 
-def _check_hresult(result, func, args):
+def _check_hresult(result: int, func, args):
     if result:
         raise ctypes.WinError(result)
 

--- a/docs/api/args.rst
+++ b/docs/api/args.rst
@@ -1,0 +1,16 @@
+============
+Args modules
+============
+
+In order to use some platform-specific features, Bleak provides platform-specific
+arguments to various constructors and methods. This modules all live in the
+``bleak.args`` sub-package.
+
+.. automodule:: bleak.args.bluez
+    :members:
+
+.. automodule:: bleak.args.corebluetooth
+    :members:
+
+.. automodule:: bleak.args.winrt
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -10,6 +10,7 @@ Contents:
 
    scanner
    client
+   args
 
 .. TODO: move everything below to separate pages
 

--- a/docs/backends/macos.rst
+++ b/docs/backends/macos.rst
@@ -67,7 +67,7 @@ passed to the :meth:`bleak.BleakClient.start_notify` method that can differentia
     await client.start_notify(
         char,
         notification_handler,
-        cb=dict(notification_discriminator=notification_check_handler),
+        cb={"notification_discriminator": notification_check_handler},
     )
 
     while True:

--- a/examples/async_callback_with_queue.py
+++ b/examples/async_callback_with_queue.py
@@ -42,14 +42,14 @@ async def run_ble_client(
 
     if args.address:
         device = await BleakScanner.find_device_by_address(
-            args.address, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.address, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with address '%s'", args.address)
             raise DeviceNotFoundError
     elif args.name:
         device = await BleakScanner.find_device_by_name(
-            args.name, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.name, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with name '%s'", args.name)

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -19,11 +19,17 @@ from bleak.backends.scanner import AdvertisementData
 logger = logging.getLogger(__name__)
 
 
+class Args(argparse.Namespace):
+    macos_use_bdaddr: bool
+    services: list[str]
+    debug: bool
+
+
 def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
     logger.info("%s: %r", device.address, advertisement_data)
 
 
-async def main(args: argparse.Namespace):
+async def main(args: Args):
     scanner = BleakScanner(
         simple_callback, args.services, cb=dict(use_bdaddr=args.macos_use_bdaddr)
     )
@@ -57,7 +63,7 @@ if __name__ == "__main__":
         help="sets the logging level to debug",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(namespace=Args())
 
     log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(

--- a/examples/detection_callback.py
+++ b/examples/detection_callback.py
@@ -31,7 +31,7 @@ def simple_callback(device: BLEDevice, advertisement_data: AdvertisementData):
 
 async def main(args: Args):
     scanner = BleakScanner(
-        simple_callback, args.services, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+        simple_callback, args.services, cb={"use_bdaddr": args.macos_use_bdaddr}
     )
 
     while True:

--- a/examples/disconnect_callback.py
+++ b/examples/disconnect_callback.py
@@ -30,14 +30,14 @@ async def main(args: Args):
 
     if args.address:
         device = await BleakScanner.find_device_by_address(
-            args.address, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.address, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with address '%s'", args.address)
             return
     elif args.name:
         device = await BleakScanner.find_device_by_name(
-            args.name, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.name, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with name '%s'", args.name)

--- a/examples/discover.py
+++ b/examples/discover.py
@@ -14,7 +14,12 @@ import asyncio
 from bleak import BleakScanner
 
 
-async def main(args: argparse.Namespace):
+class Args(argparse.Namespace):
+    macos_use_bdaddr: bool
+    services: list[str]
+
+
+async def main(args: Args):
     print("scanning for 5 seconds, please wait...")
 
     devices = await BleakScanner.discover(
@@ -46,6 +51,6 @@ if __name__ == "__main__":
         help="when true use Bluetooth address instead of UUID on macOS",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(namespace=Args())
 
     asyncio.run(main(args))

--- a/examples/discover.py
+++ b/examples/discover.py
@@ -25,7 +25,7 @@ async def main(args: Args):
     devices = await BleakScanner.discover(
         return_adv=True,
         service_uuids=args.services,
-        cb=dict(use_bdaddr=args.macos_use_bdaddr),
+        cb={"use_bdaddr": args.macos_use_bdaddr},
     )
 
     for d, a in devices.values():

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -38,14 +38,14 @@ async def main(args: Args):
 
     if args.address:
         device = await BleakScanner.find_device_by_address(
-            args.address, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.address, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with address '%s'", args.address)
             return
     elif args.name:
         device = await BleakScanner.find_device_by_name(
-            args.name, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.name, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with name '%s'", args.name)

--- a/examples/mtu_size.py
+++ b/examples/mtu_size.py
@@ -26,8 +26,8 @@ async def main():
         # BlueZ doesn't have a proper way to get the MTU, so we have this hack.
         # If this doesn't work for you, you can set the client._mtu_size attribute
         # to override the value instead.
-        if client._backend.__class__.__name__ == "BleakClientBlueZDBus":
-            await client._backend._acquire_mtu()
+        if client._backend.__class__.__name__ == "BleakClientBlueZDBus":  # type: ignore
+            await client._backend._acquire_mtu()  # type: ignore
 
         print("MTU:", client.mtu_size)
 

--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -35,7 +35,7 @@ TEMPERATURE_CHARACTERISTIC = "932c32bd-0004-47a2-835a-a8d455b859dd"
 COLOR_CHARACTERISTIC = "932c32bd-0005-47a2-835a-a8d455b859dd"
 
 
-def convert_rgb(rgb):
+def convert_rgb(rgb: tuple[int, int, int]) -> bytearray:
     scale = 0xFF
     adjusted = [max(1, chan) for chan in rgb]
     total = sum(adjusted)
@@ -45,12 +45,12 @@ def convert_rgb(rgb):
     return bytearray([0x1, adjusted[0], adjusted[2], adjusted[1]])
 
 
-async def main(address):
+async def main(address: str):
     async with BleakClient(address) as client:
         print(f"Connected: {client.is_connected}")
 
-        paired = await client.pair(protection_level=2)
-        print(f"Paired: {paired}")
+        await client.pair(protection_level=2)
+        print("Paired:")
 
         print("Turning Light off...")
         await client.write_gatt_char(LIGHT_CHARACTERISTIC, b"\x00", response=False)
@@ -60,17 +60,17 @@ async def main(address):
         await asyncio.sleep(1.0)
 
         print("Setting color to RED...")
-        color = convert_rgb([255, 0, 0])
+        color = convert_rgb((255, 0, 0))
         await client.write_gatt_char(COLOR_CHARACTERISTIC, color, response=False)
         await asyncio.sleep(1.0)
 
         print("Setting color to GREEN...")
-        color = convert_rgb([0, 255, 0])
+        color = convert_rgb((0, 255, 0))
         await client.write_gatt_char(COLOR_CHARACTERISTIC, color, response=False)
         await asyncio.sleep(1.0)
 
         print("Setting color to BLUE...")
-        color = convert_rgb([0, 0, 255])
+        color = convert_rgb((0, 0, 255))
         await client.write_gatt_char(COLOR_CHARACTERISTIC, color, response=False)
         await asyncio.sleep(1.0)
 

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -82,7 +82,7 @@ IO_CONFIG_CHAR_UUID = "f000aa66-0451-4000-b000-000000000000"
 
 
 async def main(address):
-    async with BleakClient(address, winrt=dict(use_cached_services=True)) as client:
+    async with BleakClient(address, winrt={"use_cached_services": True}) as client:
         print(f"Connected: {client.is_connected}")
 
         system_id = await client.read_gatt_char(SYSTEM_ID_UUID)

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -13,6 +13,7 @@ import platform
 import sys
 
 from bleak import BleakClient
+from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.uuids import normalize_uuid_16, uuid16_dict
 
 ADDRESS = (
@@ -81,7 +82,7 @@ IO_DATA_CHAR_UUID = "f000aa65-0451-4000-b000-000000000000"
 IO_CONFIG_CHAR_UUID = "f000aa66-0451-4000-b000-000000000000"
 
 
-async def main(address):
+async def main(address: str):
     async with BleakClient(address, winrt={"use_cached_services": True}) as client:
         print(f"Connected: {client.is_connected}")
 
@@ -116,7 +117,9 @@ async def main(address):
         battery_level = await client.read_gatt_char(BATTERY_LEVEL_UUID)
         print("Battery Level: {0}%".format(int(battery_level[0])))
 
-        async def notification_handler(characteristic, data):
+        async def notification_handler(
+            characteristic: BleakGATTCharacteristic, data: bytearray
+        ):
             print(f"{characteristic.description}: {data}")
 
         # Turn on the red light on the Sensor Tag by writing to I/O Data and I/O Config.

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -33,14 +33,14 @@ async def main(args: Args):
 
     if args.address:
         device = await BleakScanner.find_device_by_address(
-            args.address, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.address, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with address '%s'", args.address)
             return
     elif args.name:
         device = await BleakScanner.find_device_by_name(
-            args.name, cb=dict(use_bdaddr=args.macos_use_bdaddr)
+            args.name, cb={"use_bdaddr": args.macos_use_bdaddr}
         )
         if device is None:
             logger.error("could not find device with name '%s'", args.name)

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -12,6 +12,7 @@ Created on 2019-03-25 by hbldh <henrik.blidh@nedomkull.com>
 import argparse
 import asyncio
 import logging
+from typing import Optional
 
 from bleak import BleakClient, BleakScanner
 
@@ -19,8 +20,8 @@ logger = logging.getLogger(__name__)
 
 
 class Args(argparse.Namespace):
-    name: str
-    address: str
+    name: Optional[str]
+    address: Optional[str]
     macos_use_bdaddr: bool
     services: list[str]
     pair: bool
@@ -37,13 +38,15 @@ async def main(args: Args):
         if device is None:
             logger.error("could not find device with address '%s'", args.address)
             return
-    else:
+    elif args.name:
         device = await BleakScanner.find_device_by_name(
             args.name, cb=dict(use_bdaddr=args.macos_use_bdaddr)
         )
         if device is None:
             logger.error("could not find device with name '%s'", args.name)
             return
+    else:
+        raise ValueError("Either --name or --address must be provided")
 
     logger.info("connecting to device...")
 

--- a/examples/two_devices.py
+++ b/examples/two_devices.py
@@ -55,7 +55,7 @@ async def connect_to_device(
 
                 if by_address:
                     device = await BleakScanner.find_device_by_address(
-                        name_or_address, cb=dict(use_bdaddr=macos_use_bdaddr)
+                        name_or_address, cb={"use_bdaddr": macos_use_bdaddr}
                     )
                 else:
                     device = await BleakScanner.find_device_by_name(name_or_address)

--- a/examples/two_devices.py
+++ b/examples/two_devices.py
@@ -8,6 +8,16 @@ from bleak import BleakClient, BleakScanner
 from bleak.backends.characteristic import BleakGATTCharacteristic
 
 
+class Args(argparse.Namespace):
+    device1: str
+    uuid1: str
+    device2: str
+    uuid2: str
+    by_address: bool
+    macos_use_bdaddr: bool
+    debug: bool
+
+
 async def connect_to_device(
     lock: asyncio.Lock,
     by_address: bool,
@@ -144,7 +154,7 @@ if __name__ == "__main__":
         help="sets the log level to debug",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(namespace=Args())
 
     log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(

--- a/examples/uart_service.py
+++ b/examples/uart_service.py
@@ -68,7 +68,9 @@ async def uart_terminal():
 
         loop = asyncio.get_running_loop()
         nus = client.services.get_service(UART_SERVICE_UUID)
+        assert nus is not None, "UART service not found"
         rx_char = nus.get_characteristic(UART_RX_CHAR_UUID)
+        assert rx_char is not None, "UART RX characteristic not found"
 
         while True:
             # This waits until you type a line and press ENTER.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.isort]
 profile = "black"
 py_version=38
-src_paths = ["bleak", "examples", "tests", "typings"]
+src_paths = ["bleak", "examples", "tests"]
 extend_skip = [".buildozer"]
 
 [tool.mypy]

--- a/typings/CoreBluetooth/__init__.pyi
+++ b/typings/CoreBluetooth/__init__.pyi
@@ -1,6 +1,6 @@
-from typing import Any, NewType, Optional, Type, TypeVar
+from typing import Any, NewType, Optional, TypeVar
 
-from ..Foundation import (
+from Foundation import (
     NSUUID,
     NSArray,
     NSData,
@@ -10,7 +10,7 @@ from ..Foundation import (
     NSObject,
     NSString,
 )
-from ..libdispatch import dispatch_queue_t
+from libdispatch import dispatch_queue_t
 
 class CBManager(NSObject):
     def state(self) -> CBManagerState: ...

--- a/typings/objc/__init__.pyi
+++ b/typings/objc/__init__.pyi
@@ -4,14 +4,9 @@ from Foundation import NSObject
 
 T = TypeVar("T")
 
-
 def super(cls: type[T], self: T) -> T: ...
-
-
 def macos_available(major: int, minor: int, patch: int = 0) -> bool: ...
-
 
 class WeakRef:
     def __init__(self, object: NSObject) -> None: ...
-
     def __call__(self) -> Optional[NSObject]: ...


### PR DESCRIPTION
More general typing improvements.

The main feature here is that there is a new `bleak.args` sub-package that lets us import the backend-specific public argument types. Previously, these had to be guarded by `if TYPE_CHECKING` because they lived in platform-specific modules that would fail to import on other platforms.