### PR TITLE
backends: winrt: don't wait for disconnect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -514,7 +514,7 @@ Changed
 * Replaced usage of deprecated ``@abc.abstractproperty``.
 * Use ``asyncio.get_running_loop()`` instead of ``asyncio.get_event_loop()``.
 * Changed "service is already present" exception to logged error in BlueZ backend. Merged #622.
-* WinRT backend no longer wait for GATT session to close on disconnect. Fixes #1759.
+* WinRT backend no longer waits for GATT session to close on disconnect. Fixes #1759.
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -514,6 +514,7 @@ Changed
 * Replaced usage of deprecated ``@abc.abstractproperty``.
 * Use ``asyncio.get_running_loop()`` instead of ``asyncio.get_event_loop()``.
 * Changed "service is already present" exception to logged error in BlueZ backend. Merged #622.
+* WinRT backend no longer wait for GATT session to close on disconnect. Fixes #1759.
 
 Removed
 -------


### PR DESCRIPTION
We have found that if another app is also connected to the same BLE device, we never get the GATT session close event. This causes the `disconnect()` method to hang forever.

Instead, just close the GATT session and return immediately (and hope for the best).

Fixes: https://github.com/hbldh/bleak/issues/1759
