### PR TITLE
Winrt pair args

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 * Changed return type of ``connect()``, ``disconnect()``, ``pair()`` and ``unpair()`` methods to ``None``.
 * Moved backend-specific arg types to new ``bleak.args`` sub-package.
 * ``BLEDevice.name`` will now return ``None`` instead of the address when the name is not available.
+* Deprecated ``protection_level`` kwarg for pairing in WinRT backend.
 
 Fixed
 -----

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -5,6 +5,7 @@ BLE Client for Windows 10 systems, implemented with WinRT.
 """
 import sys
 from typing import TYPE_CHECKING
+from warnings import warn
 
 if TYPE_CHECKING:
     if sys.platform != "win32":
@@ -516,7 +517,12 @@ class BleakClientWinRT(BaseBleakClient):
                 1. None - Pair the device using no levels of protection.
                 2. Encryption - Pair the device using encryption.
                 3. EncryptionAndAuthentication - Pair the device using
-                   encryption and authentication. (This will not work in Bleak...)
+                   encryption and authentication.
+
+                .. versionchanged:: unreleased
+                    Issues :class:`DeprecationWarning` if used. The default
+                    behavior has changed and this argument should no longer
+                    be needed.
         """
         assert self._requester
 
@@ -548,6 +554,11 @@ class BleakClientWinRT(BaseBleakClient):
 
         try:
             if protection_level is not None:
+                warn(
+                    "protection_level is deprecated and will be removed in a future version. The default protection level has changed, so it should be safe to omit this argument.",
+                    DeprecationWarning,
+                    2,
+                )
                 pairing_result = await custom_pairing.pair_with_protection_level_async(
                     ceremony, protection_level
                 )

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -506,7 +506,6 @@ class BleakClientWinRT(BaseBleakClient):
     @override
     async def pair(
         self,
-        protection_level: Optional[DevicePairingProtectionLevel] = None,
         **kwargs: Any,
     ) -> None:
         """Attempts to pair with the device.
@@ -532,6 +531,8 @@ class BleakClientWinRT(BaseBleakClient):
         if device_information.pairing.is_paired:
             logging.debug("Device is already paired. Skipping pairing.")
             return
+
+        protection_level = kwargs.get("protection_level")
 
         # Currently only supporting Just Works solutions...
         ceremony = DevicePairingKinds.CONFIRM_ONLY

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -525,12 +525,12 @@ class BleakClientWinRT(BaseBleakClient):
             self._requester.device_information.id
         )
 
-        if not device_information.pairing.can_pair:
-            raise BleakError("Device does not support pairing")
-
         if device_information.pairing.is_paired:
             logging.debug("Device is already paired. Skipping pairing.")
             return
+
+        if not device_information.pairing.can_pair:
+            raise BleakError("Device does not support pairing")
 
         protection_level = kwargs.get("protection_level")
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -563,7 +563,9 @@ class BleakClientWinRT(BaseBleakClient):
             DevicePairingResultStatus.PAIRED,
             DevicePairingResultStatus.ALREADY_PAIRED,
         ):
-            raise BleakError(f"Could not pair with device: {pairing_result.status}")
+            raise BleakError(
+                f"Could not pair with device: {pairing_result.status.name}"
+            )
 
         logger.debug(
             "Paired to device with protection level %r.",

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -567,10 +567,18 @@ class BleakClientWinRT(BaseBleakClient):
                 f"Could not pair with device: {pairing_result.status.name}"
             )
 
-        logger.debug(
-            "Paired to device with protection level %r.",
-            pairing_result.protection_level_used,
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            # pairing_result.protection_level_used doesn't seem to return
+            # accurate information if we don't update the DeviceInformation
+            # first.
+            device_information = await DeviceInformation.create_from_id_async(
+                self._requester.device_information.id
+            )
+
+            logger.debug(
+                "Paired to device with protection level %s.",
+                pairing_result.protection_level_used.name,
+            )
 
     @override
     async def unpair(self) -> None:

--- a/examples/philips_hue.py
+++ b/examples/philips_hue.py
@@ -49,7 +49,7 @@ async def main(address: str):
     async with BleakClient(address) as client:
         print(f"Connected: {client.is_connected}")
 
-        await client.pair(protection_level=2)
+        await client.pair()
         print("Paired:")
 
         print("Turning Light off...")


### PR DESCRIPTION
This reworks pairing on WinRT backend so that hopefully we no longer need the platform-specific `protection_level` argument.

Instead, the highest possible level is tried by default.

Also fixes a few minor bugs noticed while testing.