### PR TITLE
BlueZ: handle private resolvable address change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
 
 Fixed
 -----
+* Fixed resolvable private address not updated after connecting in BlueZ backend. Fixes #1737.
 * Fixed possible ``KeyError`` when getting services in BlueZ backend. Fixes #1435.
 * Fix D-Bus connection leak when connecting to a device fails in BlueZ backend. Fixes #1698.
 * Fixed possible deadlock when connecting on WinRT backend when device is already connected. Fixes #1757.

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -450,6 +450,10 @@ class BleakClient:
         **kwargs:
             Additional keyword arguments for backwards compatibility.
 
+    .. tip:: If you enable pairing with the ``pair`` argument, you will also
+        want to extend the timeout to allow enough time for the user to find
+        and enter the PIN code on the device, if required.
+
     .. warning:: Although example code frequently initializes :class:`BleakClient`
         with a Bluetooth address for simplicity, it is not recommended to do so
         for more complex use cases. There are several known issues with providing

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -292,7 +292,7 @@ class BleakScanner:
 
         .. versionadded:: 0.19
         """
-        return self._backend.seen_devices
+        return {d[0].address: d for d in self._backend.seen_devices.values()}
 
     @classmethod
     async def find_device_by_address(

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -753,6 +753,21 @@ class BlueZManager:
         """
         return self._get_device_property(device_path, defs.DEVICE_INTERFACE, "Name")
 
+    def get_device_address(self, device_path: str) -> str:
+        """
+        Gets the value of the "Address" property for a device.
+
+        Args:
+            device_path: The D-Bus object path of the device.
+
+        Returns:
+            The current property value.
+
+        Raises:
+            BleakError: if the device is not present in BlueZ
+        """
+        return self._get_device_property(device_path, defs.DEVICE_INTERFACE, "Address")
+
     def is_connected(self, device_path: str) -> bool:
         """
         Gets the value of the "Connected" property for a device.

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -19,7 +19,6 @@ from dbus_fast import Variant
 from bleak.args.bluez import BlueZScannerArgs
 from bleak.backends.bluezdbus.defs import Device1
 from bleak.backends.bluezdbus.manager import get_global_bluez_manager
-from bleak.backends.bluezdbus.utils import bdaddr_from_device_path
 from bleak.backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
@@ -199,6 +198,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         )
 
         device = self.create_or_update_device(
+            path,
             props["Address"],
             # BlueZ generates a name based on the address if no name is available.
             # To match other backends, we replace this with None.
@@ -218,8 +218,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         Handles a device being removed from BlueZ.
         """
         try:
-            bdaddr = bdaddr_from_device_path(device_path)
-            del self.seen_devices[bdaddr]
+            del self.seen_devices[device_path]
         except KeyError:
             # The device will not have been added to self.seen_devices if no
             # advertising data was received, so this is expected to happen

--- a/bleak/backends/bluezdbus/utils.py
+++ b/bleak/backends/bluezdbus/utils.py
@@ -35,19 +35,6 @@ def extract_service_handle_from_path(path: str) -> int:
         raise BleakError(f"Could not parse service handle from path: {path}") from e
 
 
-def bdaddr_from_device_path(device_path: str) -> str:
-    """
-    Scrape the Bluetooth address from a D-Bus device path.
-
-    Args:
-        device_path: The D-Bus object path of the device.
-
-    Returns:
-        A Bluetooth address as a string.
-    """
-    return ":".join(device_path[-17:].split("_"))
-
-
 def device_path_from_characteristic_path(characteristic_path: str) -> str:
     """
     Scrape the device path from a D-Bus characteristic path.

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -148,6 +148,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
                 address = p.identifier().UUIDString()
 
             device = self.create_or_update_device(
+                p.identifier().UUIDString(),
                 address,
                 p.name(),
                 (p, self._manager.central_manager.delegate()),

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -268,6 +268,7 @@ class BleakScannerP4Android(BaseBleakScanner):
 
         device = self.create_or_update_device(
             native_device.getAddress(),
+            native_device.getAddress(),
             native_device.getName(),
             native_device,
             advertisement,

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -115,6 +115,8 @@ class BaseBleakScanner(abc.ABC):
     """
     Map of device identifier to BLEDevice and most recent advertisement data.
 
+    The key is a backend-specific identifier for the device.
+
     This map must be cleared when scanning starts.
     """
 
@@ -236,12 +238,18 @@ class BaseBleakScanner(abc.ABC):
             callback(device, advertisement_data)
 
     def create_or_update_device(
-        self, address: str, name: Optional[str], details: Any, adv: AdvertisementData
+        self,
+        key: str,
+        address: str,
+        name: Optional[str],
+        details: Any,
+        adv: AdvertisementData,
     ) -> BLEDevice:
         """
         Creates or updates a device in :attr:`seen_devices`.
 
         Args:
+            key: A backend-specific identifier for the device.
             address: The Bluetooth address of the device (UUID on macOS).
             name: The OS display name for the device.
             details: The platform-specific handle for the device.
@@ -252,13 +260,13 @@ class BaseBleakScanner(abc.ABC):
         """
 
         try:
-            device, _ = self.seen_devices[address]
+            device, _ = self.seen_devices[key]
 
             device.name = name
         except KeyError:
             device = BLEDevice(address, name, details)
 
-        self.seen_devices[address] = (device, adv)
+        self.seen_devices[key] = (device, adv)
 
         return device
 

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -212,7 +212,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         )
 
         device = self.create_or_update_device(
-            bdaddr, local_name, raw_data, advertisement_data
+            bdaddr, bdaddr, local_name, raw_data, advertisement_data
         )
 
         self.call_detection_callbacks(device, advertisement_data)

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -54,6 +54,8 @@ async def main(args: Args):
         device,
         pair=args.pair,
         services=args.services,
+        # Give the user plenty of time to enter a PIN code if paring is required.
+        timeout=90 if args.pair else 10,
     ) as client:
         logger.info("connected")
 


### PR DESCRIPTION
Devices with resolvable private addresses will change their address after pairing in the BlueZ backend. So for the address property to return the "correct" value, we need to update the device's address after pairing.

Fixes #1737.