### PR TITLE
backends/device: restore **kwargs in BLEDevice constructor

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+
+- Restored ``**kwargs`` in ``BLEDevice()`` constructor. Fixes #1783.
+
 `1.0.0`_ (2025-06-28)
 =====================
 

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -7,6 +7,7 @@ Wrapper class for Bluetooth LE servers returned from calling
 
 
 from typing import Any, Optional
+from warnings import warn
 
 
 class BLEDevice:
@@ -16,7 +17,7 @@ class BLEDevice:
 
     __slots__ = ("address", "name", "details")
 
-    def __init__(self, address: str, name: Optional[str], details: Any):
+    def __init__(self, address: str, name: Optional[str], details: Any, **kwargs: Any):
         #: The Bluetooth address of the device on this machine (UUID on macOS).
         self.address = address
         #: The operating system name of the device (not necessarily the local name
@@ -24,6 +25,13 @@ class BLEDevice:
         self.name = name
         #: The OS native details required for connecting to the device.
         self.details = details
+
+        if kwargs:
+            warn(
+                "Passing additional arguments for BLEDevice is deprecated and has no effect.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
     def __str__(self):
         return f"{self.address}: {self.name}"


### PR DESCRIPTION
The `BLEDevice()` constructor technically isn't considered part of the public API, so a breaking change was made removing `rssi` and `**kwargs`. However, there are users that implement their own backends, so effectively this should be considered public and the breaking change reverted.

It looks like all users are passing `rssi` as a keyword argument, so just restoring `**kwargs` should be sufficient.

Cc: @cdce8p @balloob @bdraco 