### PR TITLE
Restore deprecated imports

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
                 run: pipx run poetry install --only main,test
             -   name: Test with pytest
                 run: |
-                    pipx run poetry run pytest tests --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html
+                    pipx run poetry run pytest -v tests --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=com --cov-report=xml --cov-report=html
             -   name: Upload pytest test results
                 uses: actions/upload-artifact@v4
                 with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,10 +10,16 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+- Added deprecation warnings for importing ``bleak.args.*`` types from ``bleak.backends.*``.
+
 Fixed
 -----
 
 - Restored ``**kwargs`` in ``BLEDevice()`` constructor. Fixes #1783.
+- Restored importing ``OrPattern`` from ``bleak.backends.bluezdbus.advertisement_monitor``.
+
 
 `1.0.0`_ (2025-06-28)
 =====================

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -15,15 +15,33 @@ if TYPE_CHECKING:
 
 import logging
 from collections.abc import Iterable
-from typing import no_type_check
+from typing import Any, no_type_check
+from warnings import warn
 
 from dbus_fast import PropertyAccess
 from dbus_fast.service import ServiceInterface, dbus_property, method
 
-from bleak.args.bluez import OrPatternLike
+from bleak.args.bluez import OrPattern as _OrPattern
+from bleak.args.bluez import OrPatternLike as _OrPatternLike
 from bleak.backends.bluezdbus import defs
 
 logger = logging.getLogger(__name__)
+
+_DEPRECATED: dict[str, Any] = {
+    "OrPattern": _OrPattern,
+    "OrPatternLike": _OrPatternLike,
+}
+
+
+def __getattr__(name: str):
+    if value := _DEPRECATED.get(name):
+        warn(
+            f"importing {name} from bleak.backends.bluezdbus.advertisement_monitor is deprecated, use bleak.args.bluez instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class AdvertisementMonitor(ServiceInterface):
@@ -42,7 +60,7 @@ class AdvertisementMonitor(ServiceInterface):
 
     def __init__(
         self,
-        or_patterns: Iterable[OrPatternLike],
+        or_patterns: Iterable[_OrPatternLike],
     ):
         """
         Args:

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -25,11 +25,9 @@ from weakref import WeakKeyDictionary
 from dbus_fast import BusType, Message, MessageType, Variant, unpack_variants
 from dbus_fast.aio.message_bus import MessageBus
 
+from bleak.args.bluez import OrPatternLike
 from bleak.backends.bluezdbus import defs
-from bleak.backends.bluezdbus.advertisement_monitor import (
-    AdvertisementMonitor,
-    OrPatternLike,
-)
+from bleak.backends.bluezdbus.advertisement_monitor import AdvertisementMonitor
 from bleak.backends.bluezdbus.defs import (
     Device1,
     GattCharacteristic1,

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -4,7 +4,7 @@ BLE Client for CoreBluetooth on macOS
 """
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     if sys.platform != "darwin":
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 import asyncio
 import logging
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer, override

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -7,6 +7,7 @@ if TYPE_CHECKING:
 
 import logging
 from typing import Any, Literal, Optional
+from warnings import warn
 
 if sys.version_info < (3, 12):
     from typing_extensions import override
@@ -17,7 +18,7 @@ import objc
 from CoreBluetooth import CBPeripheral
 from Foundation import NSBundle, NSDictionary
 
-from bleak.args.corebluetooth import CBScannerArgs
+from bleak.args.corebluetooth import CBScannerArgs as _CBScannerArgs
 from bleak.backends.corebluetooth.CentralManagerDelegate import CentralManagerDelegate
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str
 from bleak.backends.scanner import (
@@ -28,6 +29,17 @@ from bleak.backends.scanner import (
 from bleak.exc import BleakError
 
 logger = logging.getLogger(__name__)
+
+
+def __getattr__(name: str):
+    if name == "CBScannerArgs":
+        warn(
+            "importing CBScannerArgs from bleak.backends.corebluetooth.scanner is deprecated, use bleak.args.corebluetooth instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _CBScannerArgs
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class BleakScannerCoreBluetooth(BaseBleakScanner):
@@ -64,7 +76,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         service_uuids: Optional[list[str]],
         scanning_mode: Literal["active", "passive"],
         *,
-        cb: CBScannerArgs,
+        cb: _CBScannerArgs,
         **kwargs: Any,
     ):
         super(BleakScannerCoreBluetooth, self).__init__(

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -5,7 +5,6 @@ BLE Client for Windows 10 systems, implemented with WinRT.
 """
 import sys
 from typing import TYPE_CHECKING
-from warnings import warn
 
 if TYPE_CHECKING:
     if sys.platform != "win32":
@@ -18,6 +17,7 @@ from collections.abc import Callable
 from contextvars import Context
 from ctypes import WinError
 from typing import Any, Generic, Optional, Protocol, Sequence, TypeVar, Union, cast
+from warnings import warn
 
 if sys.version_info < (3, 12):
     from typing_extensions import Buffer, override
@@ -69,7 +69,7 @@ from winrt.windows.foundation import (
 from winrt.windows.storage.streams import Buffer as WinBuffer
 
 from bleak import BleakScanner
-from bleak.args.winrt import WinRTClientArgs
+from bleak.args.winrt import WinRTClientArgs as _WinRTClientArgs
 from bleak.assigned_numbers import gatt_char_props_to_strs
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback
@@ -80,6 +80,17 @@ from bleak.backends.winrt.scanner import BleakScannerWinRT, RawAdvData
 from bleak.exc import PROTOCOL_ERROR_CODES, BleakDeviceNotFoundError, BleakError
 
 logger = logging.getLogger(__name__)
+
+
+def __getattr__(name: str):
+    if name == "WinRTClientArgs":
+        warn(
+            "importing WinRTClientArgs from bleak.backends.winrt.client is deprecated, use bleak.args.winrt instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _WinRTClientArgs
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class _Result(Protocol):
@@ -152,7 +163,7 @@ class BleakClientWinRT(BaseBleakClient):
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
         *,
-        winrt: WinRTClientArgs,
+        winrt: _WinRTClientArgs,
         **kwargs: Any,
     ):
         super(BleakClientWinRT, self).__init__(address_or_ble_device, **kwargs)

--- a/tests/bleak/backends/bluezdbus/test_deprecated_imports.py
+++ b/tests/bleak/backends/bluezdbus/test_deprecated_imports.py
@@ -1,0 +1,55 @@
+import sys
+
+import pytest
+
+# isort: off
+
+if not sys.platform.startswith("linux"):
+    pytest.skip("backend only available on Linux", allow_module_level=True)
+
+
+def test_deprecated_OrPattern_import():
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing OrPattern from bleak.backends.bluezdbus.advertisement_monitor is deprecated",
+    ) as recorder:
+        from bleak.backends.bluezdbus.advertisement_monitor import (  # noqa: F401
+            OrPattern,  # type: ignore[unused-import]
+        )
+
+    assert recorder.list[0].filename == __file__
+
+
+def test_deprecated_OrPatternLike_import():
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing OrPatternLike from bleak.backends.bluezdbus.advertisement_monitor is deprecated",
+    ) as recorder:
+        from bleak.backends.bluezdbus.advertisement_monitor import (  # noqa: F401
+            OrPatternLike,  # type: ignore[unused-import]
+        )
+
+    assert recorder.list[0].filename == __file__
+
+
+def test_deprecated_BlueZDiscoveryFilters_import():
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing BlueZDiscoveryFilters from bleak.backends.bluezdbus.scanner is deprecated",
+    ) as recorder:
+        from bleak.backends.bluezdbus.scanner import (  # noqa: F401
+            BlueZDiscoveryFilters,  # type: ignore[unused-import]
+        )
+    assert recorder.list[0].filename == __file__
+
+
+def test_deprecated_BlueZScannerArgs_import():
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing BlueZScannerArgs from bleak.backends.bluezdbus.scanner is deprecated",
+    ) as recorder:
+        from bleak.backends.bluezdbus.scanner import (  # noqa: F401
+            BlueZScannerArgs,  # type: ignore[unused-import]
+        )
+
+    assert recorder.list[0].filename == __file__

--- a/tests/bleak/backends/winrt/test_deprecated_imports.py
+++ b/tests/bleak/backends/winrt/test_deprecated_imports.py
@@ -1,0 +1,20 @@
+import sys
+
+import pytest
+
+# isort: off
+
+if not sys.platform.startswith("win"):
+    pytest.skip("backend only available on windows", allow_module_level=True)
+
+
+def test_deprecated_WinRTClientArgs_import():
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing WinRTClientArgs from bleak.backends.winrt.client is deprecated, use bleak.args.winrt instead",
+    ) as recorder:
+        from bleak.backends.winrt.client import (  # noqa: F401
+            WinRTClientArgs,  # type: ignore[unused-import]
+        )
+
+    assert recorder.list[0].filename == __file__

--- a/tests/bleak/corebluetooth/test_deprecated_imports.py
+++ b/tests/bleak/corebluetooth/test_deprecated_imports.py
@@ -1,0 +1,20 @@
+import sys
+
+import pytest
+
+# isort: off
+
+if not sys.platform.startswith("darwin"):
+    pytest.skip("backend only available on macOS", allow_module_level=True)
+
+
+def test_deprecated_CBScannerArgs_import():
+    with pytest.warns(
+        DeprecationWarning,
+        match="importing CBScannerArgs from bleak.backends.corebluetooth.scanner is deprecated, use bleak.args.corebluetooth instead",
+    ) as recorder:
+        from bleak.backends.corebluetooth.scanner import (  # noqa: F401
+            CBScannerArgs,  # type: ignore[unused-import]
+        )
+
+    assert recorder.list[0].filename == __file__


### PR DESCRIPTION
There were some imports that were moved to `bleak.args.bluez` in v1.0 without a proper deprecation period. Restore these imports and add the proper deprecation warnings.

https://github.com/hbldh/bleak/issues/1783#issuecomment-3019828790

TODO: need to do the same for windows and corebluetooth


