### PR TITLE
Fix service_explorer.py for non-unique characteristics UUID

### DIFF
--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -65,7 +65,7 @@ async def main(args: Args):
             for char in service.characteristics:
                 if "read" in char.properties:
                     try:
-                        value = await client.read_gatt_char(char.uuid)
+                        value = await client.read_gatt_char(char.handle)
                         extra = f", Value: {value}"
                     except Exception as e:
                         extra = f", Error: {e}"


### PR DESCRIPTION
Simple fix to avoid
```
__main__ INFO: [Service] 0000fff0-0000-1000-8000-00805f9b34fb (Handle: 17): Vendor specific
__main__ INFO:   [Characteristic] 0000fff1-0000-1000-8000-00805f9b34fb (Handle: 18): Vendor specific (read,notify), Error: Multiple Characteristics with this UUID, refer to your desired characteristic by the `handle` attribute instead.
```
for devices where the `UUID` is not unique.