### PR TITLE
Add BleakUUIDNonUnique exception

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+- Added new exception ``BleakUUIDNonUnique`` which is raised when a service or characteristic UUID is not unique.
+
 `1.0.1`_ (2025-06-30)
 =====================
 

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.descriptor import BleakGATTDescriptor
-from bleak.exc import BleakError
+from bleak.exc import BleakError, BleakUUIDNonUnique
 from bleak.uuids import normalize_uuid_str, uuidstr_to_str
 
 logger = logging.getLogger(__name__)
@@ -142,7 +142,7 @@ class BleakGATTServiceCollection:
         if isinstance(specifier, int):
             return self.services.get(specifier)
 
-        uuid = normalize_uuid_str(str(specifier))
+        uuid: str = normalize_uuid_str(str(specifier))
 
         x = list(
             filter(
@@ -152,9 +152,7 @@ class BleakGATTServiceCollection:
         )
 
         if len(x) > 1:
-            raise BleakError(
-                "Multiple Services with this UUID, refer to your desired service by the `handle` attribute instead."
-            )
+            raise BleakUUIDNonUnique(uuid)
 
         return x[0] if x else None
 
@@ -181,7 +179,7 @@ class BleakGATTServiceCollection:
         if isinstance(specifier, int):
             return self.characteristics.get(specifier)
 
-        uuid = normalize_uuid_str(str(specifier))
+        uuid: str = normalize_uuid_str(str(specifier))
 
         # Assume uuid usage.
         x = list(
@@ -192,9 +190,7 @@ class BleakGATTServiceCollection:
         )
 
         if len(x) > 1:
-            raise BleakError(
-                "Multiple Characteristics with this UUID, refer to your desired characteristic by the `handle` attribute instead."
-            )
+            raise BleakUUIDNonUnique(uuid)
 
         return x[0] if x else None
 

--- a/bleak/exc.py
+++ b/bleak/exc.py
@@ -21,10 +21,30 @@ class BleakCharacteristicNotFoundError(BleakError):
     def __init__(self, char_specifier: Union[int, str, uuid.UUID]) -> None:
         """
         Args:
-            characteristic (str): handle or UUID of the characteristic which was not found
+            char_specifier (int | str | UUID): handle or UUID of the characteristic which was not found
         """
         super().__init__(f"Characteristic {char_specifier} was not found!")
         self.char_specifier = char_specifier
+
+
+class BleakUUIDNonUnique(BleakError):
+    """
+    Exception which is raised if a device does not support a characteristic.
+
+    .. versionadded: 1.0.2
+    """
+
+    specifier: Union[str, uuid.UUID]
+
+    def __init__(self, specifier: Union[str, uuid.UUID]) -> None:
+        """
+        Args:
+            specifier (str | UUID): UUID of the characteristic or service which is not unique
+        """
+        super().__init__(
+            f"Multiple elements with UUID {specifier}, refer to your desired characteristic by the `handle` attribute instead."
+        )
+        self.char_specifier = specifier
 
 
 class BleakDeviceNotFoundError(BleakError):


### PR DESCRIPTION
In addition to #1795 this fix makes it possible to detect non-unique `UUIDs` and handle them if necessary. I think this could be useful for some cases. Alternative would be to strongly recommend to use the `BleakGATTService.get_characteristic` function instead.