### PR TITLE
android / p4android: fix BleakClient connect() broken when service characteristics have descriptors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+
+- Fixed ``BleakClient.connect()`` on Android when service characteristics have descriptors. Fixes #1803.
+
 `1.0.1`_ (2025-06-30)
 =====================
 

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -281,7 +281,7 @@ class BleakClientP4Android(BaseBleakClient):
                     descriptor = BleakGATTDescriptor(
                         java_descriptor,
                         characteristic.handle + 1 + descriptor_index,
-                        self.obj.getUuid().toString(),
+                        java_descriptor.getUuid().toString(),
                         characteristic,
                     )
                     services.add_descriptor(descriptor)


### PR DESCRIPTION
Fixes #1803.