### PR TITLE
bleak: add BleakClient.name property

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,12 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Added
+-----
+- Added ``BleakClient.name`` property for getting the peripheral's name. Fixes #1802.
+
 Fixed
 -----
-
 - Fixed ``BleakClient.connect()`` on Android when service characteristics have descriptors. Fixes #1803.
 
 `1.0.1`_ (2025-06-30)

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -513,6 +513,20 @@ class BleakClient:
     # device info
 
     @property
+    def name(self) -> str:
+        """
+        Gets a human-readable name for the peripheral device.
+
+        The name can be somewhat OS-dependent. It is usually the name provided
+        by the standard Device Name characteristic, if present or the name
+        provided by the advertising data. If neither is available, it will be
+        a Bluetooth address separated with dashes (``-``) instead of colons
+        (``:``) (or a UUID on Apple devices). It may also be possible to override
+        the device name using the OS's Bluetooth settings.
+        """
+        return self._backend.name
+
+    @property
     def address(self) -> str:
         """
         Gets the Bluetooth address of this device (UUID on macOS).

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -79,6 +79,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # kwarg "device" is for backwards compatibility
         self._adapter: Optional[str] = kwargs.get("adapter", kwargs.get("device"))
 
+        self._device_info: Optional[dict[str, Any]]
+
         # Backend specific, D-Bus objects and data
         if isinstance(address_or_ble_device, BLEDevice):
             self._device_path = address_or_ble_device.details["path"]
@@ -665,6 +667,14 @@ class BleakClientBlueZDBus(BaseBleakClient):
         adapter_path = await self._get_adapter_path()
         bluez_address = self.address.upper().replace(":", "_")
         return f"{adapter_path}/dev_{bluez_address}"
+
+    @property
+    @override
+    def name(self) -> str:
+        """See :meth:`bleak.BleakClient.name`."""
+        if self._device_info is None:
+            raise BleakError("Not connected")
+        return self._device_info["Alias"]
 
     @property
     @override

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -52,6 +52,13 @@ class BaseBleakClient(abc.ABC):
             "disconnected_callback"
         )
 
+    # NB: this is not marked as @abc.abstractmethod because that would break
+    # 3rd-party backends. We might change this in the future to make it required.
+    @property
+    def name(self) -> str:
+        """See :meth:`bleak.BleakClient.name`."""
+        raise NotImplementedError
+
     @property
     @abc.abstractmethod
     def mtu_size(self) -> int:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -165,6 +165,14 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
     @property
     @override
+    def name(self) -> str:
+        """Get the name of the connected peripheral"""
+        if self._peripheral is None:
+            raise BleakError("Not connected")
+        return self._peripheral.name()
+
+    @property
+    @override
     def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
         # Use type CBCharacteristicWriteWithoutResponse to get maximum write

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -511,6 +511,14 @@ class BleakClientWinRT(BaseBleakClient):
 
     @property
     @override
+    def name(self) -> str:
+        """See :meth:`bleak.BleakClient.name`."""
+        if self._requester is None:
+            raise BleakError("Not connected")
+        return self._requester.name
+
+    @property
+    @override
     def mtu_size(self) -> int:
         """Get ATT MTU size for active connection"""
         return self._session.max_pdu_size

--- a/examples/service_explorer.py
+++ b/examples/service_explorer.py
@@ -57,7 +57,7 @@ async def main(args: Args):
         # Give the user plenty of time to enter a PIN code if paring is required.
         timeout=90 if args.pair else 10,
     ) as client:
-        logger.info("connected")
+        logger.info("connected to %s (%s)", client.name, client.address)
 
         for service in client.services:
             logger.info("[Service] %s", service)


### PR DESCRIPTION
Add a name property to the BleakClient class to retrieve the name of the connected BLE peripheral. Some OSes don't allow accessing the Device Name characteristic, so this property is useful for getting the name in a cross-platform way.

Closes: https://github.com/hbldh/bleak/issues/1802
