### PR TITLE
backends/winrt/client: call disconnect callback on disconnect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Added
 Fixed
 -----
 - Fixed ``BleakClient.connect()`` on Android when service characteristics have descriptors. Fixes #1803.
+- Fixed disconnect callback not called on Windows when Bleak initiates disconnection.
 
 `1.0.1`_ (2025-06-30)
 =====================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -475,6 +475,17 @@ class BleakClientWinRT(BaseBleakClient):
             gatt_char.remove_value_changed(event_handler_token)
         self._notification_callbacks.clear()
 
+        # Since we can't wait for the session close event (it may never come)
+        # we need to synthesize the disconnect event
+        if self._session and self._session_status_changed_token:
+            self._session.remove_session_status_changed(
+                self._session_status_changed_token
+            )
+            self._session_status_changed_token = None
+
+            if self._disconnected_callback:
+                self._disconnected_callback()
+
         # Dispose all service components that we have requested and created.
         if self.services:
             # HACK: sometimes GattDeviceService.Close() hangs forever, so we


### PR DESCRIPTION
Since commit 689f21e ("backends: winrt: don't wait for disconnect"), we no longer wait for the disconnect event before returning from the disconnect() method. However, some applications may be expecting the disconnect callback to be called on disconnect. So we need to call the disconnect callback manually in the disconnect() method. The event is removed after this to prevent double calls. However, there is still the possibility that the event handler could be in the asyncio event loop queue, so we might need to reconsider how we handle this in the future.
