### PR TITLE
backends/p4android/client: initialize __callbacks to None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+- Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
+
+
 `1.1.0`_ (2025-08-10)
 =====================
 

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -61,6 +61,8 @@ class BleakClientP4Android(BaseBleakClient):
         self.__gatt = None
         self.__mtu = 23
 
+        self.__callbacks = None
+
     # Connectivity methods
 
     @override


### PR DESCRIPTION
Initialize __callbacks to None in the __init__ method. This avoids an AttributeError when reading the is_connected property before the client connects.

Fixes: https://github.com/hbldh/bleak/issues/1791
