### PR TITLE
bluezdbus: improve D-Bus connection error handling in manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 - Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
+- Fixed D-Bus connection leak on connection failure in BlueZ backend.
 
 
 `1.1.0`_ (2025-08-10)

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -244,9 +244,10 @@ class BlueZManager:
             # dbus-next will destroy the underlying file descriptors
             # when the previous one is closed in its finalizer.
             bus = MessageBus(bus_type=BusType.SYSTEM, auth=get_dbus_authenticator())
-            await bus.connect()
 
             try:
+                await bus.connect()
+
                 # Add signal listeners
 
                 bus.add_message_handler(self._parse_msg)

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -253,6 +253,8 @@ class BlueZManager:
             bus = MessageBus(bus_type=BusType.SYSTEM, auth=get_dbus_authenticator())
 
             try:
+                # We need to call bus.disconnect() even when bus.connect() fails in
+                # order to release the file handles created in the constructor.
                 await bus.connect()
 
                 # Add signal listeners


### PR DESCRIPTION
In the `BlueZManager.async_init` method, the call to `bus.connect()` was performed before the `try...except` block that handles initialization errors.

If `bus.connect()` itself were to fail, the exception would not be caught by the block, and the `bus.disconnect()` cleanup logic would not run.

This commit moves the `await bus.connect()` call inside the `try` block to ensure that any connection-related exceptions are properly handled and the bus is disconnected.