### PR TITLE
Release/v1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,11 +10,14 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+`1.1.1`_ (2025-09-07)
+=====================
+
 Fixed
 -----
 - Fixed D-Bus connection leak on connection failure in BlueZ backend.
+- Fixed characteristic's max write without response size using wrong characteristic's value. Fixes #1820.
 - Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
-- Fixed a bug causing a characteristic's max write without response size potentially being misrepresented. Fixes #1820.
 
 `1.1.0`_ (2025-08-10)
 =====================
@@ -1117,7 +1120,8 @@ Fixed
 * Bleak created.
 
 
-.. _Unreleased: https://github.com/hbldh/bleak/compare/v1.1.0...develop
+.. _Unreleased: https://github.com/hbldh/bleak/compare/v1.1.1...develop
+.. _1.1.1: https://github.com/hbldh/bleak/compare/v1.1.0...v1.1.1
 .. _1.1.0: https://github.com/hbldh/bleak/compare/v1.0.1...v1.1.0
 .. _1.0.1: https://github.com/hbldh/bleak/compare/v1.0.0...v1.0.1
 .. _1.0.0: https://github.com/hbldh/bleak/compare/v0.22.3...v1.0.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 Fixed
 -----
+- Fixed D-Bus connection leak on connection failure in BlueZ backend.
 - Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
 - Fixed a bug causing a characteristic's max write without response size potentially being misrepresented. Fixes #1820.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,11 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+- Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
+
+
 `1.1.0`_ (2025-08-10)
 =====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Fixed
 -----
 - Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
-
+- Fixed a bug causing a characteristic's max write without response size potentially being misrepresented. Fixes #1820.
 
 `1.1.0`_ (2025-08-10)
 =====================

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -123,6 +123,8 @@ class GattCharacteristic1(TypedDict):
     NotifyAcquired: bool
     Notifying: bool
     Flags: list[CharacteristicPropertyName]
+    # "MTU" property was added in BlueZ 5.62.
+    # It may missing when operating with an older stack.
     MTU: int
     # Handle is server-only and not available in Bleak
 

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -251,9 +251,12 @@ class BlueZManager:
             # dbus-next will destroy the underlying file descriptors
             # when the previous one is closed in its finalizer.
             bus = MessageBus(bus_type=BusType.SYSTEM, auth=get_dbus_authenticator())
-            await bus.connect()
 
             try:
+                # We need to call bus.disconnect() even when bus.connect() fails in
+                # order to release the file handles created in the constructor.
+                await bus.connect()
+
                 # Add signal listeners
 
                 bus.add_message_handler(self._parse_msg)

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -19,6 +19,7 @@ import logging
 import os
 from collections import defaultdict
 from collections.abc import Callable, Coroutine, MutableMapping
+from functools import partial
 from typing import Any, NamedTuple, Optional, cast
 from weakref import WeakKeyDictionary
 
@@ -152,6 +153,12 @@ _ADVERTISING_DATA_PROPERTIES = {
     "ServiceData",
     "UUIDs",
 }
+
+
+def get_max_write_without_response_size(char_props: GattCharacteristic1) -> int:
+    # "MTU" property was added in BlueZ 5.62, otherwise fall
+    # back to minimum MTU according to Bluetooth spec.
+    return char_props.get("MTU", 23) - 3
 
 
 class BlueZManager:
@@ -709,9 +716,11 @@ class BlueZManager:
                     extract_service_handle_from_path(char_path),
                     char_props["UUID"],
                     char_props["Flags"],
-                    # "MTU" property was added in BlueZ 5.62, otherwise fall
-                    # back to minimum MTU according to Bluetooth spec.
-                    lambda: char_props.get("MTU", 23) - 3,
+                    # Because `char_props` is a loop varialbe, we cannot
+                    # directly bind a closure (i.e. lambda) to it;
+                    # instead, we let `functools.partial` create a new
+                    # function frame to close over at each iteration.
+                    partial(get_max_write_without_response_size, char_props),
                     service,
                 )
 

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -61,6 +61,8 @@ class BleakClientP4Android(BaseBleakClient):
         self.__gatt = None
         self.__mtu = 23
 
+        self.__callbacks = None
+
     # Connectivity methods
 
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bleak"
-version = "1.1.0"
+version = "1.1.1"
 description = "Bluetooth Low Energy platform Agnostic Klient"
 authors = [{ name = "Henrik Blidh", email = "henrik.blidh@nedomkull.com" }]
 license = "MIT"


### PR DESCRIPTION

Fixed
-----
- Fixed D-Bus connection leak on connection failure in BlueZ backend.
- Fixed characteristic's max write without response size using wrong characteristic's value. Fixes #1820.
- Fixed ``AttributeError`` in Python4Android backend when accessing ``is_connected`` before connecting. Fixes #1791.
