### PR TITLE
backends/bluezdbus/manager: Release resources on bus restart

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 
 Fixed
 -----
+* Fixed file handle leak in BlueZ backend when D-Bus connection is lost and re-established.
 * Fixed crash in CoreBluetooth backend if an ObjC delegate callback is called after the asyncio run loop stops.
 * Fixed possible deadlock when starting scanning on Windows when Bluetooth is turned off.
 * Fixed "Bluetooth device is turned off" Exception on macOS, when a Bluetooth permission request popup is shown to the user by the OS.

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -361,6 +361,11 @@ class BlueZManager:
                 bus.disconnect()
                 raise
 
+            if self._bus:
+                # Even if we are disconnected, still need to call this to
+                # release file handles.
+                self._bus.disconnect()
+
             # Everything is setup, so save the bus
             self._bus = bus
 


### PR DESCRIPTION
Call disconnect() on the old bus object if we have to reconnect to the D-Bus system bus. This ensures that file handles are released and we don't leak them.
