### PR TITLE
backends/winrt/client: fix potential race condition for session status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Changed
 
 Fixed
 -----
+* Fixed potential race condition causing timeout while connecting in WinRT backend.
 * Fixed file handle leak in BlueZ backend when D-Bus connection is lost and re-established.
 * Fixed crash in CoreBluetooth backend if an ObjC delegate callback is called after the asyncio run loop stops.
 * Fixed possible deadlock when starting scanning on Windows when Bluetooth is turned off.

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -360,19 +360,19 @@ class BleakClientWinRT(BaseBleakClient):
                 )
             )
 
-            # If the session is already active, we need to set the event since
-            # the session_status_changed event won't fire. This happens, e.g.,
-            # when pairing before connecting which causes the device to already
-            # be connected.
-            if self._session.session_status == GattSessionStatus.ACTIVE:
-                event.set()
-
             self._max_pdu_size_changed_token = self._session.add_max_pdu_size_changed(
                 max_pdu_size_changed_handler
             )
 
             services_changed_event = asyncio.Event()
             self._services_changed_events.append(services_changed_event)
+
+            # If the session is already active, we need to set the event since
+            # the session_status_changed event won't fire. This happens, e.g.,
+            # when pairing before connecting which causes the device to already
+            # be connected.
+            if self._session.session_status == GattSessionStatus.ACTIVE:
+                event.set()
 
             try:
                 # Windows does not support explicitly connecting to a device.


### PR DESCRIPTION
We need to check the current session status *after* registering the event handler, otherwise we might miss the event if the session status changes between checking the status and registering the handler.
