### PR TITLE
backends: consolidate platform detection functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+- Changed internal backend detection to use a single common function.
+
 `1.1.1`_ (2025-09-07)
 =====================
 

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -33,8 +33,9 @@ else:
 from bleak.args.bluez import BlueZScannerArgs
 from bleak.args.corebluetooth import CBScannerArgs, CBStartNotifyArgs
 from bleak.args.winrt import WinRTClientArgs
+from bleak.backends import get_backend
 from bleak.backends.characteristic import BleakGATTCharacteristic
-from bleak.backends.client import BaseBleakClient, get_platform_client_backend_type
+from bleak.backends.client import BaseBleakClient
 from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import (
@@ -42,7 +43,6 @@ from bleak.backends.scanner import (
     AdvertisementDataCallback,
     AdvertisementDataFilter,
     BaseBleakScanner,
-    get_platform_scanner_backend_type,
 )
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakCharacteristicNotFoundError, BleakError
@@ -124,7 +124,7 @@ class BleakScanner:
         **kwargs: Any,
     ) -> None:
         PlatformBleakScanner = (
-            get_platform_scanner_backend_type() if backend is None else backend
+            get_backend().scanner_type if backend is None else backend
         )
 
         self._backend = PlatformBleakScanner(
@@ -490,9 +490,7 @@ class BleakClient:
         backend: Optional[type[BaseBleakClient]] = None,
         **kwargs: Any,
     ) -> None:
-        PlatformBleakClient = (
-            get_platform_client_backend_type() if backend is None else backend
-        )
+        PlatformBleakClient = get_backend().client_type if backend is None else backend
 
         self._backend = PlatformBleakClient(
             address_or_ble_device,

--- a/bleak/backends/__init__.py
+++ b/bleak/backends/__init__.py
@@ -1,5 +1,76 @@
-# -*- coding: utf-8 -*-
-# Created on 2017-11-19 by hbldh <henrik.blidh@nedomkull.com>
-"""
-__init__.py
-"""
+import os
+import platform
+import sys
+from dataclasses import dataclass
+
+from bleak.backends.client import BaseBleakClient
+from bleak.backends.scanner import BaseBleakScanner
+from bleak.exc import BleakError
+
+
+@dataclass(frozen=True)
+class BleakBackendProvider:
+    client_type: type[BaseBleakClient]
+    scanner_type: type[BaseBleakScanner]
+
+
+def get_backend() -> BleakBackendProvider:
+    """
+    Gets the platform-specific backend provider.
+    """
+    if sys.platform == "android" and os.environ.get("P4A_BOOTSTRAP") is not None:
+        from bleak.backends.p4android.client import BleakClientP4Android
+        from bleak.backends.p4android.scanner import BleakScannerP4Android
+
+        return BleakBackendProvider(
+            client_type=BleakClientP4Android,
+            scanner_type=BleakScannerP4Android,
+        )
+
+    if sys.platform == "linux":
+        from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
+        from bleak.backends.bluezdbus.scanner import BleakScannerBlueZDBus
+
+        return BleakBackendProvider(
+            client_type=BleakClientBlueZDBus,
+            scanner_type=BleakScannerBlueZDBus,
+        )
+
+    if sys.platform == "ios" and "Pythonista3.app" in sys.executable:
+        # Must be resolved before checking for "Darwin" (macOS),
+        # as both the Pythonista app for iOS and macOS
+        # return "Darwin" from platform.system()
+        try:
+            from bleak_pythonista import (
+                BleakClientPythonistaCB,
+                BleakScannerPythonistaCB,
+            )
+
+            return BleakBackendProvider(
+                client_type=BleakClientPythonistaCB,
+                scanner_type=BleakScannerPythonistaCB,
+            )
+        except ImportError as e:
+            raise ImportError(
+                "Ensure you have `bleak-pythonista` package installed."
+            ) from e
+
+    if sys.platform == "darwin":
+        from bleak.backends.corebluetooth.client import BleakClientCoreBluetooth
+        from bleak.backends.corebluetooth.scanner import BleakScannerCoreBluetooth
+
+        return BleakBackendProvider(
+            client_type=BleakClientCoreBluetooth,
+            scanner_type=BleakScannerCoreBluetooth,
+        )
+
+    if sys.platform == "win32":
+        from bleak.backends.winrt.client import BleakClientWinRT
+        from bleak.backends.winrt.scanner import BleakScannerWinRT
+
+        return BleakBackendProvider(
+            client_type=BleakClientWinRT,
+            scanner_type=BleakScannerWinRT,
+        )
+
+    raise BleakError(f"Unsupported platform: {platform.system()}")

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -4,8 +4,6 @@
 Base class for backend clients.
 """
 import abc
-import os
-import platform
 import sys
 from collections.abc import Callable
 from typing import Any, Optional, Union
@@ -207,43 +205,3 @@ class BaseBleakClient(abc.ABC):
 
         """
         raise NotImplementedError()
-
-
-def get_platform_client_backend_type() -> type[BaseBleakClient]:
-    """
-    Gets the platform-specific :class:`BaseBleakClient` type.
-    """
-    if os.environ.get("P4A_BOOTSTRAP") is not None:
-        from bleak.backends.p4android.client import BleakClientP4Android
-
-        return BleakClientP4Android
-
-    if platform.system() == "Linux":
-        from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
-
-        return BleakClientBlueZDBus
-
-    if sys.platform == "ios" and "Pythonista3.app" in sys.executable:
-        # Must be resolved before checking for "Darwin" (macOS),
-        # as both the Pythonista app for iOS and macOS
-        # return "Darwin" from platform.system()
-        try:
-            from bleak_pythonista import BleakClientPythonistaCB
-
-            return BleakClientPythonistaCB
-        except ImportError as e:
-            raise ImportError(
-                "Ensure you have `bleak-pythonista` package installed."
-            ) from e
-
-    if platform.system() == "Darwin":
-        from bleak.backends.corebluetooth.client import BleakClientCoreBluetooth
-
-        return BleakClientCoreBluetooth
-
-    if platform.system() == "Windows":
-        from bleak.backends.winrt.client import BleakClientWinRT
-
-        return BleakClientWinRT
-
-    raise BleakError(f"Unsupported platform: {platform.system()}")

--- a/tests/test_platform_detection.py
+++ b/tests/test_platform_detection.py
@@ -5,15 +5,14 @@
 
 import platform
 
-from bleak.backends.client import get_platform_client_backend_type
-from bleak.backends.scanner import get_platform_scanner_backend_type
+from bleak.backends import get_backend
 
 
 def test_platform_detection():
     """Test by importing the client and assert correct client by OS."""
 
-    client_backend_type = get_platform_client_backend_type()
-    scanner_backend_type = get_platform_scanner_backend_type()
+    client_backend_type = get_backend().client_type
+    scanner_backend_type = get_backend().scanner_type
 
     if platform.system() == "Linux":
         assert client_backend_type.__name__ == "BleakClientBlueZDBus"


### PR DESCRIPTION
Consolidate get_platform_client_backend_type() and get_platform_scanner_backend_type() into a single get_backend() function that returns both types. This reduces code duplication and makes it easier to maintain platform detection logic in one place.

Alternative to #1840 