### PR TITLE
Remove Python 2 remnants

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Top-level package for bleak."""
 
 from __future__ import annotations

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 BLE Client for BlueZ on Linux
 """
+
 import sys
 from typing import TYPE_CHECKING
 
@@ -75,7 +75,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         services: Optional[set[str]] = None,
         **kwargs: Any,
     ):
-        super(BleakClientBlueZDBus, self).__init__(address_or_ble_device, **kwargs)
+        super().__init__(address_or_ble_device, **kwargs)
         # kwarg "device" is for backwards compatibility
         self._adapter: Optional[str] = kwargs.get("adapter", kwargs.get("device"))
 

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from typing import Literal, TypedDict
 
 from bleak.assigned_numbers import CharacteristicPropertyName

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -80,7 +80,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
         bluez: _BlueZScannerArgs,
         **kwargs: Any,
     ):
-        super(BleakScannerBlueZDBus, self).__init__(detection_callback, service_uuids)
+        super().__init__(detection_callback, service_uuids)
 
         self._scanning_mode = scanning_mode
 

--- a/bleak/backends/bluezdbus/signals.py
+++ b/bleak/backends/bluezdbus/signals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import annotations
 
 import sys

--- a/bleak/backends/characteristic.py
+++ b/bleak/backends/characteristic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 Interface class for the Bleak representation of a GATT Characteristic

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2018-04-23 by hbldh <henrik.blidh@nedomkull.com>
 """
 Base class for backend clients.

--- a/bleak/backends/corebluetooth/__init__.py
+++ b/bleak/backends/corebluetooth/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2017-11-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 __init__.py

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -64,7 +64,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         services: Optional[set[str]] = None,
         **kwargs: Any,
     ):
-        super(BleakClientCoreBluetooth, self).__init__(address_or_ble_device, **kwargs)
+        super().__init__(address_or_ble_device, **kwargs)
 
         self._peripheral: Optional[CBPeripheral] = None
         self._delegate: Optional[PeripheralDelegate] = None

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -79,9 +79,7 @@ class BleakScannerCoreBluetooth(BaseBleakScanner):
         cb: _CBScannerArgs,
         **kwargs: Any,
     ):
-        super(BleakScannerCoreBluetooth, self).__init__(
-            detection_callback, service_uuids
-        )
+        super().__init__(detection_callback, service_uuids)
 
         self._use_bdaddr = cb.get("use_bdaddr", False)
 

--- a/bleak/backends/descriptor.py
+++ b/bleak/backends/descriptor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 Interface class for the Bleak representation of a GATT Descriptor

--- a/bleak/backends/device.py
+++ b/bleak/backends/device.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2018-04-23 by hbldh <henrik.blidh@nedomkull.com>
 """
 Wrapper class for Bluetooth LE servers returned from calling

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
 """
 BLE Client for python-for-android
 """
+
 import sys
 from typing import TYPE_CHECKING
 
@@ -52,7 +52,7 @@ class BleakClientP4Android(BaseBleakClient):
         services: Optional[set[uuid.UUID]],
         **kwargs,
     ):
-        super(BleakClientP4Android, self).__init__(address_or_ble_device, **kwargs)
+        super().__init__(address_or_ble_device, **kwargs)
         self._requested_services = (
             set(map(defs.UUID.fromString, services)) if services else None
         )
@@ -270,7 +270,7 @@ class BleakClientP4Android(BaseBleakClient):
                     java_characteristic,
                     java_characteristic.getInstanceId(),
                     java_characteristic.getUuid().toString(),
-                    gatt_char_props_to_strs((java_characteristic.getProperties())),
+                    gatt_char_props_to_strs(java_characteristic.getProperties()),
                     lambda: self.__mtu - 3,
                     service,
                 )

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -60,7 +60,7 @@ class BleakScannerP4Android(BaseBleakScanner):
         scanning_mode: Literal["active", "passive"],
         **kwargs,
     ):
-        super(BleakScannerP4Android, self).__init__(detection_callback, service_uuids)
+        super().__init__(detection_callback, service_uuids)
 
         if scanning_mode == "passive":
             self.__scan_mode = defs.ScanSettings.SCAN_MODE_OPPORTUNISTIC

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -124,7 +124,7 @@ class BaseBleakScanner(abc.ABC):
         detection_callback: Optional[AdvertisementDataCallback],
         service_uuids: Optional[list[str]],
     ):
-        super(BaseBleakScanner, self).__init__()
+        super().__init__()
 
         self._ad_callbacks: dict[
             Hashable, Callable[[BLEDevice, AdvertisementData], None]

--- a/bleak/backends/service.py
+++ b/bleak/backends/service.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2019-03-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 Gatt Service Collection class and interface class for the Bleak representation of a GATT Service.

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Created on 2020-08-19 by hbldh <henrik.blidh@nedomkull.com>
 """
 BLE Client for Windows 10 systems, implemented with WinRT.
@@ -166,7 +165,7 @@ class BleakClientWinRT(BaseBleakClient):
         winrt: _WinRTClientArgs,
         **kwargs: Any,
     ):
-        super(BleakClientWinRT, self).__init__(address_or_ble_device, **kwargs)
+        super().__init__(address_or_ble_device, **kwargs)
 
         # Backend specific. WinRT objects.
         if isinstance(address_or_ble_device, BLEDevice):

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -97,7 +97,7 @@ class BleakScannerWinRT(BaseBleakScanner):
         scanning_mode: Literal["active", "passive"],
         **kwargs: Any,
     ):
-        super(BleakScannerWinRT, self).__init__(detection_callback, service_uuids)
+        super().__init__(detection_callback, service_uuids)
 
         self.watcher: Optional[BluetoothLEAdvertisementWatcher] = None
         self._advertisement_pairs: dict[str, RawAdvData] = {}

--- a/bleak/exc.py
+++ b/bleak/exc.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import enum
 import uuid
 from typing import Any, Optional, Union

--- a/bleak/uuids.py
+++ b/bleak/uuids.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from uuid import UUID
 
 uuid16_dict: dict[int, str] = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # bleak documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul  9 22:26:36 2013.

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 __init__.py
 

--- a/examples/enable_notifications.py
+++ b/examples/enable_notifications.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Notifications
 -------------

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 TI CC2650 SensorTag
 -------------------
@@ -8,6 +7,7 @@ An example connecting to a TI CC2650 SensorTag.
 Created on 2018-01-10 by hbldh <henrik.blidh@nedomkull.com>
 
 """
+
 import asyncio
 import platform
 import sys

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 """Unit test package for bleak."""

--- a/tests/test_platform_detection.py
+++ b/tests/test_platform_detection.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """Tests for `bleak` package."""
 


### PR DESCRIPTION
1. There is no need to set file encoding unless its not utf-8 (See https://docs.python.org/3/reference/lexical_analysis.html#encoding-declarations)
2. Calls to super() may omit the class name in Python 3. On Python 2 these were required.

No change in functionality.
