### PR TITLE
backends/bluezdbus: Enable type checking.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,3 +41,14 @@ jobs:
                     path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
                 # Use always() to always run this step to publish test results when there are test failures
                 if: ${{ always() }}
+            -   name: Type checking
+                # We don't do this in the lint job because we have conditionals
+                # on both the platform and the Python version in the code, so we
+                # need to check each matrix combination.
+                run: |
+                    pipx run poetry run pip install pyright
+                    pipx run poetry run pyright
+                    pipx run mypy --version
+                    pipx run mypy -p bleak -p tests -p examples
+                # TODO: fix typing issues on macOS and Windows and remove this condition
+                if: matrix.os == 'ubuntu-latest'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
       "isort.importStrategy": "fromEnvironment",
       "isort.args":["--profile", "black"],
     "flake8.importStrategy": "fromEnvironment",
-    "python.analysis.typeCheckingMode": "strict",
     "python-envs.defaultEnvManager": "ms-python.python:poetry",
     "python-envs.defaultPackageManager": "ms-python.python:poetry",
     "python-envs.pythonProjects": []

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -236,6 +236,10 @@ class BleakScanner:
         Used to override the automatically selected backend (i.e. for a
             custom backend).
         """
+        adapter: str | None
+        """
+        Name of adapter to use (BlueZ specific), e.g. hci0.
+        """
 
     @overload
     @classmethod
@@ -835,7 +839,7 @@ class BleakClient:
                 task.add_done_callback(_background_tasks.discard)
 
         else:
-            wrapped_callback = functools.partial(callback, characteristic)
+            wrapped_callback = functools.partial(callback, characteristic)  # type: ignore
 
         await self._backend.start_notify(
             characteristic, wrapped_callback, cb=cb, **kwargs

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -214,34 +214,40 @@ def get_platform_client_backend_type() -> tuple[type[BaseBleakClient], BleakBack
     backend = get_default_backend()
     match backend:
         case BleakBackend.P4ANDROID:
-            from bleak.backends.p4android.client import BleakClientP4Android
+            from bleak.backends.p4android.client import (
+                BleakClientP4Android,  # type: ignore
+            )
 
-            return (BleakClientP4Android, backend)
+            return (BleakClientP4Android, backend)  # type: ignore
 
         case BleakBackend.BLUEZ_DBUS:
-            from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
+            from bleak.backends.bluezdbus.client import (
+                BleakClientBlueZDBus,  # type: ignore
+            )
 
-            return (BleakClientBlueZDBus, backend)
+            return (BleakClientBlueZDBus, backend)  # type: ignore
 
         case BleakBackend.PYTHONISTA_CB:
             try:
-                from bleak_pythonista import BleakClientPythonistaCB
+                from bleak_pythonista import BleakClientPythonistaCB  # type: ignore
 
-                return (BleakClientPythonistaCB, backend)
+                return (BleakClientPythonistaCB, backend)  # type: ignore
             except ImportError as e:
                 raise ImportError(
                     "Ensure you have `bleak-pythonista` package installed."
                 ) from e
 
         case BleakBackend.CORE_BLUETOOTH:
-            from bleak.backends.corebluetooth.client import BleakClientCoreBluetooth
+            from bleak.backends.corebluetooth.client import (
+                BleakClientCoreBluetooth,  # type: ignore
+            )
 
-            return (BleakClientCoreBluetooth, backend)
+            return (BleakClientCoreBluetooth, backend)  # type: ignore
 
         case BleakBackend.WIN_RT:
-            from bleak.backends.winrt.client import BleakClientWinRT
+            from bleak.backends.winrt.client import BleakClientWinRT  # type: ignore
 
-            return (BleakClientWinRT, backend)
+            return (BleakClientWinRT, backend)  # type: ignore
 
         case _:
             raise BleakError(f"Unsupported backend: {backend}")

--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -176,7 +176,7 @@ class BaseBleakScanner(abc.ABC):
                 task.add_done_callback(_background_tasks.discard)
 
         else:
-            detection_callback = callback
+            detection_callback = callback  # type: ignore
 
         token = object()
 
@@ -287,9 +287,11 @@ def get_platform_scanner_backend_type() -> tuple[type[BaseBleakScanner], BleakBa
     backend = get_default_backend()
     match backend:
         case BleakBackend.P4ANDROID:
-            from bleak.backends.p4android.scanner import BleakScannerP4Android
+            from bleak.backends.p4android.scanner import (
+                BleakScannerP4Android,  # type: ignore
+            )
 
-            return (BleakScannerP4Android, backend)
+            return (BleakScannerP4Android, backend)  # type: ignore
 
         case BleakBackend.BLUEZ_DBUS:
             from bleak.backends.bluezdbus.scanner import BleakScannerBlueZDBus
@@ -298,23 +300,25 @@ def get_platform_scanner_backend_type() -> tuple[type[BaseBleakScanner], BleakBa
 
         case BleakBackend.PYTHONISTA_CB:
             try:
-                from bleak_pythonista import BleakScannerPythonistaCB
+                from bleak_pythonista import BleakScannerPythonistaCB  # type: ignore
 
-                return (BleakScannerPythonistaCB, backend)
+                return (BleakScannerPythonistaCB, backend)  # type: ignore
             except ImportError as e:
                 raise ImportError(
                     "Ensure you have `bleak-pythonista` package installed."
                 ) from e
 
         case BleakBackend.CORE_BLUETOOTH:
-            from bleak.backends.corebluetooth.scanner import BleakScannerCoreBluetooth
+            from bleak.backends.corebluetooth.scanner import (
+                BleakScannerCoreBluetooth,  # type: ignore
+            )
 
-            return (BleakScannerCoreBluetooth, backend)
+            return (BleakScannerCoreBluetooth, backend)  # type: ignore
 
         case BleakBackend.WIN_RT:
-            from bleak.backends.winrt.scanner import BleakScannerWinRT
+            from bleak.backends.winrt.scanner import BleakScannerWinRT  # type: ignore
 
-            return (BleakScannerWinRT, backend)
+            return (BleakScannerWinRT, backend)  # type: ignore
 
         case _:
             raise BleakError(f"Unsupported backend: {backend}")

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -14,7 +14,7 @@ import logging
 import uuid
 from collections.abc import Callable
 from contextvars import Context
-from ctypes import WinError
+from ctypes import WinError  # type: ignore[attr-defined]
 from typing import Any, Generic, Optional, Protocol, Sequence, TypeVar, Union, cast
 from warnings import warn
 

--- a/bleak/backends/winrt/util.py
+++ b/bleak/backends/winrt/util.py
@@ -25,7 +25,7 @@ def _check_result(result: int, func, args):
     return args
 
 
-def _check_hresult(result: int, func, args):
+def check_hresult(result: int, func, args):
     if result:
         raise ctypes.WinError(result)
 
@@ -78,7 +78,7 @@ _CO_GET_APARTMENT_TYPE_PARAM_FLAGS = (
 _CoGetApartmentType = _CO_GET_APARTMENT_TYPE_PROTOTYPE(
     ("CoGetApartmentType", ctypes.windll.ole32), _CO_GET_APARTMENT_TYPE_PARAM_FLAGS
 )
-_CoGetApartmentType.errcheck = _check_hresult
+_CoGetApartmentType.errcheck = check_hresult
 
 _CO_E_NOTINITIALIZED = -2147221008
 
@@ -186,7 +186,7 @@ async def assert_mta() -> None:
         _KillTimer(None, timer)
 
 
-def allow_sta():
+def allow_sta() -> None:
     """
     Suppress check for MTA thread type and allow STA.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,11 @@ import os
 import pathlib
 import sys
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    # tell type checkers to ignore this file if using Python 3.10
+    assert False
 
 PROJECT_ROOT_DIR = pathlib.Path(__file__).parent.parent.resolve()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,8 @@ extend_skip = [".buildozer", "docs"]
 [tool.mypy]
 python_version = "3.10"
 disable_error_code = ["import-not-found"]
+exclude = "(.venv|kivy|recipes)/"
+
+[tool.pyright]
+typeCheckingMode = "strict"
+exclude = [".venv/**", "**/kivy/**", "**/recipes/**"]

--- a/tests/backends/bluezdbus/test_version.py
+++ b/tests/backends/bluezdbus/test_version.py
@@ -2,9 +2,14 @@
 
 """Tests for `bleak.backends.bluezdbus.version` package."""
 
-from unittest.mock import AsyncMock, Mock
+import sys
 
 import pytest
+
+if sys.platform != "linux":
+    pytest.skip("skipping linux-only tests", allow_module_level=True)
+
+from unittest.mock import AsyncMock, Mock
 
 from bleak.backends.bluezdbus.version import BlueZFeatures
 

--- a/tests/backends/winrt/test_utils.py
+++ b/tests/backends/winrt/test_utils.py
@@ -6,15 +6,17 @@ import sys
 
 import pytest
 
-if not sys.platform.startswith("win"):
+if sys.platform != "win32":
     pytest.skip("skipping windows-only tests", allow_module_level=True)
+    # HACK: work around pyright bug
+    allow_sta: object
 
-from ctypes import windll, wintypes
+from ctypes import windll, wintypes  # type: ignore[attr-defined]
 
 from bleak.backends.winrt.util import (
-    _check_hresult,
     allow_sta,
     assert_mta,
+    check_hresult,
     uninitialize_sta,
 )
 from bleak.exc import BleakError
@@ -27,7 +29,7 @@ COINIT_APARTMENTTHREADED = 0x2
 _CoInitializeEx = windll.ole32.CoInitializeEx
 _CoInitializeEx.restype = wintypes.LONG
 _CoInitializeEx.argtypes = [wintypes.LPVOID, wintypes.DWORD]
-_CoInitializeEx.errcheck = _check_hresult
+_CoInitializeEx.errcheck = check_hresult
 
 # https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-couninitialize
 _CoUninitialize = windll.ole32.CoUninitialize


### PR DESCRIPTION
Fix/ignore remaining type issues in the BlueZ backend and the core code and enable type checking in CI on Linux. Windows and macOS will come later.
