### PR TITLE
backends/corebluetooth: fix remaining type checking issues

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,5 +53,3 @@ jobs:
           pipx run poetry run pyright
           pipx run poetry run pip install mypy
           pipx run poetry run mypy -p bleak -p tests -p examples
-        # TODO: fix typing issues on macOS and remove this condition
-        if: matrix.os != 'macos-latest'

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -72,7 +72,7 @@ class ObjcCentralManagerDelegate(NSObject, protocols=[CBCentralManagerDelegate])
         self, py_delegate: CentralManagerDelegate
     ) -> Optional[Self]:
         """macOS init function for NSObject"""
-        self = objc.super(ObjcCentralManagerDelegate, self).init()
+        self = objc.super(ObjcCentralManagerDelegate, self).init()  # type: ignore[assignment]
 
         if self is None:
             return None

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -58,7 +58,7 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
 
     def initWithPyDelegate_(self, py_delegate: PeripheralDelegate) -> Optional[Self]:
         """macOS init function for NSObject"""
-        self = objc.super(ObjcPeripheralDelegate, self).init()
+        self = objc.super(ObjcPeripheralDelegate, self).init()  # type: ignore[assignment]
 
         if self is None:
             return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ extend_skip = [".buildozer", "docs"]
 python_version = "3.10"
 disable_error_code = ["import-not-found"]
 exclude = "(.venv|kivy|recipes)/"
+mypy_path = "typings"
 
 [tool.pyright]
 typeCheckingMode = "strict"


### PR DESCRIPTION
Fix/ignore remaining type checking issues in the CoreBluetooth backend and enable type checking in CI.
