### PR TITLE
backends/bluezdbus: allow forcing StartNotify over AcquireNotify

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 
 Added
 -----
+* Added ``bluez`` parameter to ``BleakClient.start_notify()`` to allow forcing using "StartNotify" instead of "AcquireNotify" on BlueZ backend. Fixes #1885.
 * Added ``bleak.args.SizedBuffer`` type for better type hinting of buffer protocol parameters.
 
 Fixed

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -25,7 +25,7 @@ else:
     from asyncio import timeout as async_timeout
     from typing import Never, Self, Unpack, assert_never
 
-from bleak.args.bluez import BlueZScannerArgs
+from bleak.args.bluez import BlueZNotifyArgs, BlueZScannerArgs
 from bleak.args.corebluetooth import CBScannerArgs, CBStartNotifyArgs
 from bleak.args.winrt import WinRTClientArgs
 from bleak.backends import BleakBackend
@@ -785,6 +785,7 @@ class BleakClient:
             [BleakGATTCharacteristic, bytearray], Union[None, Awaitable[None]]
         ],
         *,
+        bluez: BlueZNotifyArgs = {},
         cb: CBStartNotifyArgs = {},
         **kwargs: Any,
     ) -> None:
@@ -809,8 +810,10 @@ class BleakClient:
             callback:
                 The function to be called on notification. Can be regular
                 function or async function.
+            bluez:
+                BlueZ backend-specific arguments.
             cb:
-                CoreBluetooth specific arguments.
+                CoreBluetooth backend-specific arguments.
 
         Raises:
             BleakCharacteristicNotFoundError: if a characteristic with the
@@ -820,8 +823,12 @@ class BleakClient:
         .. versionchanged:: 0.18
             The first argument of the callback is now a :class:`BleakGATTCharacteristic`
             instead of an ``int``.
+
         .. versionchanged:: 1.0
             Added the ``cb`` parameter.
+
+        .. versionchanged:: unreleased
+            Added the ``bluez`` parameter.
         """
         if not self.is_connected:
             raise BleakError("Not connected")
@@ -839,7 +846,7 @@ class BleakClient:
             wrapped_callback = functools.partial(callback, characteristic)  # type: ignore
 
         await self._backend.start_notify(
-            characteristic, wrapped_callback, cb=cb, **kwargs
+            characteristic, wrapped_callback, bluez=bluez, cb=cb, **kwargs
         )
 
     async def stop_notify(

--- a/bleak/args/bluez.py
+++ b/bleak/args/bluez.py
@@ -97,3 +97,23 @@ class BlueZScannerArgs(TypedDict, total=False):
 
     Only used for passive scanning.
     """
+
+
+class BlueZNotifyArgs(TypedDict, total=False):
+    """
+    :meth:`bleak.BleakClient.start_notify` method args that are specific to the
+    BlueZ backend.
+
+    .. versionadded:: unreleased
+    """
+
+    use_start_notify: bool
+    """
+    If true, use the "StartNotify" D-Bus method instead of "AcquireNotify" to
+    when subscribing to notifications.
+
+    This is needed in rare cases to work around BlueZ quirks. For example, some
+    peripherals may send notifications immediately after writing to the CCCD
+    descriptor, before the write response is sent. In this case, "AcquireNotify"
+    will miss the notification, whereas "StartNotify" will work correctly.
+    """

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -5,6 +5,8 @@ BLE Client for BlueZ on Linux
 import sys
 from typing import TYPE_CHECKING
 
+from bleak.args.bluez import BlueZNotifyArgs
+
 if TYPE_CHECKING:
     if sys.platform != "linux":
         assert False, "This backend is only available on Linux"
@@ -916,6 +918,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """
         Activate notifications/indications on a characteristic.
         """
+
+        bluez: BlueZNotifyArgs = kwargs["bluez"]
+        force_use_start_notify = bluez.get("use_start_notify", False)
+
         assert self._bus is not None
 
         # If using StartNotify and calling a read on the same
@@ -925,7 +931,9 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # However, using the preferred AcquireNotify requires that devices
         # correctly indicate "notify" and/or "indicate" properties. If they
         # don't, we fall back to StartNotify.
-        use_notify_acquire = "NotifyAcquired" in characteristic.obj[1]
+        use_notify_acquire = (
+            not force_use_start_notify and "NotifyAcquired" in characteristic.obj[1]
+        )
         logger.debug(
             'using "%s" for notifications on characteristic %d',
             "AcquireNotify" if use_notify_acquire else "StartNotify",

--- a/tests/integration/test_issue_1885.py
+++ b/tests/integration/test_issue_1885.py
@@ -1,0 +1,88 @@
+import asyncio
+
+from bumble.att import Attribute, AttributeValue
+from bumble.device import Connection, Device
+from bumble.gatt import (
+    GATT_CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR,
+    Characteristic,
+    Descriptor,
+    Service,
+)
+
+from bleak import BleakClient, BleakScanner
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from tests.integration.conftest import add_default_advertising_data
+
+TEST_SERVICE_UUID = "9d513f40-5c89-42dc-9688-2cfa30f2d9e7"
+TEST_CHARACTERISTIC_UUID = "e809cb2f-34e3-42a1-ba92-22db2495cd6a"
+
+
+async def test_notification_sent_before_write_response(
+    bumble_peripheral: Device,
+) -> None:
+    """
+    Regression test for <https://github.com/hbldh/bleak/issues/1885>.
+    """
+
+    notifications_enabled = False
+
+    def on_cccd_read(connection: Connection) -> bytes:
+        return b"\x01\x00" if notifications_enabled else b"\x00\x00"
+
+    async def on_cccd_write(connection: Connection, value: bytes) -> None:
+        nonlocal notifications_enabled
+        notifications_enabled = value == b"\x01\x00"
+
+        # This is simulating an unusual peripheral that sends a notification
+        # immediately upon receiving the CCCD write, before sending the write
+        # response.
+
+        # TODO: Type hints in bumble need to be fixed to be able to remove the pyright ignore
+        await bumble_peripheral.notify_subscribers(  # pyright: ignore[reportUnknownMemberType]
+            test_characteristic, b"test", force=True
+        )
+
+    cccd_value = AttributeValue[bytes](on_cccd_read, on_cccd_write)
+
+    test_characteristic = Characteristic[bytes](
+        TEST_CHARACTERISTIC_UUID,
+        Characteristic.Properties.NOTIFY,
+        Attribute.Permissions(0),
+        descriptors=[
+            Descriptor(
+                GATT_CLIENT_CHARACTERISTIC_CONFIGURATION_DESCRIPTOR,
+                Attribute.Permissions.WRITEABLE | Attribute.Permissions.READABLE,
+                cccd_value,
+            )
+        ],
+    )
+
+    bumble_peripheral.add_default_services()
+    bumble_peripheral.add_service(Service(TEST_SERVICE_UUID, [test_characteristic]))
+
+    add_default_advertising_data(bumble_peripheral)
+    await bumble_peripheral.power_on()
+    await bumble_peripheral.start_advertising()
+
+    device = await BleakScanner.find_device_by_address(
+        bumble_peripheral.static_address.to_string(), cb={"use_bdaddr": True}
+    )
+
+    assert device is not None, "Could not find bumble peripheral device"
+
+    async with BleakClient(device) as client:
+        notification_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        def on_notification(_: BleakGATTCharacteristic, data: bytearray) -> None:
+            notification_queue.put_nowait(bytes(data))
+
+        await client.start_notify(
+            TEST_CHARACTERISTIC_UUID, on_notification, bluez={"use_start_notify": True}
+        )
+
+        # In BlueZ, the notification is not received when using "AcquireNotify"
+        # causing this to timeout.
+
+        data = await asyncio.wait_for(notification_queue.get(), timeout=3)
+
+        assert data == b"test"


### PR DESCRIPTION
Add a `bluez` parameter to `BleakClient.start_notify()` to allow forcing using "StartNotify" instead of "AcquireNotify" on BlueZ backend. This is needed for some peripherals with a quirk where they send notifications before sending the write response for the CCC descriptor write. BlueZ has a quirk that it ignores these notifications when using "AcquireNotify", but not when using "StartNotify".

Fixes: https://github.com/hbldh/bleak/issues/1885
