### PR TITLE
tests/integration: work around Bumble-Linux timeout

### DIFF
--- a/tests/integration/bluez_controller.py
+++ b/tests/integration/bluez_controller.py
@@ -125,6 +125,12 @@ async def wait_for_new_adapter() -> (
             bus.remove_message_handler(_on_interfaces_added)
 
 
+def _clear_bit(flags: bytes, bit_pos: int) -> bytes:
+    int_flags = int.from_bytes(flags, byteorder="little")
+    int_flags &= ~(1 << bit_pos)
+    return int_flags.to_bytes(len(flags), byteorder="little")
+
+
 @contextlib.asynccontextmanager
 async def open_bluez_bluetooth_controller_link(
     hci_transport_name: str,
@@ -148,6 +154,36 @@ async def open_bluez_bluetooth_controller_link(
                 link=link,
             )
             bluez_controller.manufacturer_name = BLEAK_TEST_MANUFACTURER_ID
+
+            # HACK: Work around Bumble missing feature combined with Linux kernel
+            # requirement. https://github.com/google/bumble/issues/841
+            #
+            # According to the Bluetooth spec:
+            #
+            #   C24: [HCI_LE_Enhanced_Connection_Complete event is] Mandatory if
+            #   the LE Controller supports Connection State and either LE Feature (LL
+            #   Privacy) or LE Feature (Extended Advertising) is supported, otherwise optional if
+            #   the LE Controller supports Connection State, otherwise excluded.
+            #
+            # And the Linux kernel enforces this in hci_le_create_conn_sync().
+            # It will get a timeout if one of these features is enabled and the
+            # Enhanced Connection Complete event is not sent.
+            #
+            # However, Bumble (as of 0.0.220) always sends HCI_LE_Connection_Complete_Event
+            # in response to HCI_LE_Create_Connection_Command even when it should
+            # be sending HCI_LE_Enhanced_Connection_Complete_Event.
+            #
+            # For now, we can work around the issue by disabling LL Privacy and
+            # Extended Advertising features in the BlueZ controller.
+            #
+            # Ideally, this should be fixed in Bumble.
+
+            bluez_controller.le_features = _clear_bit(
+                bluez_controller.le_features, 6  # LL Privacy
+            )
+            bluez_controller.le_features = _clear_bit(
+                bluez_controller.le_features, 12  # Extended Advertising
+            )
 
             # Wait up to 5 seconds for the new adapter to appear via InterfacesAdded
             adapter_path = await asyncio.wait_for(adapter_path_future, timeout=5.0)


### PR DESCRIPTION
Add a hack to work around a Bumble missing feature that causes a timeout in the Linux kernel.

Before this change, tests that made a connection to a peripheral would have a 20 second delay before disconnecting. After this fix, the delay is only 2 seconds (due to a different delay in bluetoothd).

FYI, @timrid 