### PR TITLE
tests/integration: fix controller logging

### DIFF
--- a/tests/integration/bluez_controller.py
+++ b/tests/integration/bluez_controller.py
@@ -29,6 +29,8 @@ else:
 
 BLEAK_TEST_MANUFACTURER_ID = 0xB1EA
 
+logger = logging.getLogger(__name__)
+
 
 @contextlib.asynccontextmanager
 async def open_message_bus() -> AsyncGenerator[MessageBus, None]:
@@ -69,7 +71,7 @@ async def power_on_controller(
                 assert_reply(reply)
                 return
             except Exception as e:
-                logging.warning(f"Failed to power on adapter at {adapter_path}: {e}")
+                logger.debug("Failed to power on adapter at %s: %s", adapter_path, e)
                 await asyncio.sleep(0.1)
 
 


### PR DESCRIPTION
Replace logging.warning() with logger.debug() in bluez_controller.py

Calling logging.warning() will set up a default logger if none exists, which can lead to unwanted log messages in certain contexts.

Also, this exception is expected to happen, so debug level is more appropriate.
