### PR TITLE
tree-wide: replace str.format with f-strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ Connect to a Bluetooth device and read its model number:
     async def main(address):
         async with BleakClient(address) as client:
             model_number = await client.read_gatt_char(MODEL_NBR_UUID)
-            print("Model Number: {0}".format("".join(map(chr, model_number))))
+            print(f"Model Number: {model_number.decode()}")
 
     asyncio.run(main(address))
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -740,10 +740,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
         value = bytearray(reply.body[0])
 
         logger.debug(
-            "Read Characteristic {0} | {1}: {2}".format(
-                characteristic.uuid, characteristic.obj[0], value
-            )
+            "Read Characteristic %s | %s: %r",
+            characteristic.uuid,
+            characteristic.obj[0],
+            value,
         )
+
         return value
 
     @override

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -180,7 +180,7 @@ class BleakScannerBlueZDBus(BaseBleakScanner):
             elif k == "Pattern":
                 self._filters[k] = Variant("s", v)
             else:
-                logger.warning("Filter '%s' is not currently supported." % k)
+                logger.warning("Filter '%s' is not currently supported.", k)
 
     # Helper methods
 

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -86,7 +86,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         )
 
     def __str__(self) -> str:
-        return "BleakClientCoreBluetooth ({})".format(self.address)
+        return f"BleakClientCoreBluetooth ({self.address})"
 
     @override
     async def connect(self, pair: bool, **kwargs: Any) -> None:
@@ -137,8 +137,8 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
         manager = self._central_manager_delegate
         assert manager is not None
-        logger.debug("CentralManagerDelegate  at {}".format(manager))
-        logger.debug("Connecting to BLE device @ {}".format(self.address))
+        logger.debug("CentralManagerDelegate at %r", manager)
+        logger.debug("Connecting to BLE device @ %s", self.address)
         assert self._peripheral is not None
         await manager.connect(self._peripheral, disconnect_callback, timeout=timeout)
 
@@ -244,16 +244,12 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             services.add_service(serv)
 
             serviceUUID = service.UUID().UUIDString()
-            logger.debug(
-                "Retrieving characteristics for service {}".format(serviceUUID)
-            )
+            logger.debug("Retrieving characteristics for service %s", serviceUUID)
             characteristics = await self._delegate.discover_characteristics(service)
 
             for characteristic in characteristics:
                 cUUID = characteristic.UUID().UUIDString()
-                logger.debug(
-                    "Retrieving descriptors for characteristic {}".format(cUUID)
-                )
+                logger.debug("Retrieving descriptors for characteristic %s", cUUID)
 
                 char = BleakGATTCharacteristic(
                     characteristic,
@@ -300,7 +296,7 @@ class BleakClientCoreBluetooth(BaseBleakClient):
             characteristic.obj, use_cached=kwargs.get("use_cached", False)
         )
         value = bytearray(output)
-        logger.debug("Read Characteristic {0} : {1}".format(characteristic.uuid, value))
+        logger.debug("Read Characteristic %s: %r", characteristic.uuid, value)
         return value
 
     @override

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,7 +25,7 @@ via the asynchronous context manager like this:
     async def main(address):
         async with BleakClient(address) as client:
             model_number = await client.read_gatt_char(MODEL_NBR_UUID)
-            print("Model Number: {0}".format("".join(map(chr, model_number))))
+            print(f"Model Number: {model_number.decode()}")
 
     asyncio.run(main(address))
 
@@ -44,7 +44,7 @@ or one can do it without the context manager like this:
         try:
             await client.connect()
             model_number = await client.read_gatt_char(MODEL_NBR_UUID)
-            print("Model Number: {0}".format("".join(map(chr, model_number))))
+            print(f"Model Number: {model_number.decode()}")
         except Exception as e:
             print(e)
         finally:

--- a/examples/sensortag.py
+++ b/examples/sensortag.py
@@ -87,35 +87,31 @@ async def main(address: str):
         print(f"Connected: {client.is_connected}")
 
         system_id = await client.read_gatt_char(SYSTEM_ID_UUID)
-        print(
-            "System ID: {0}".format(
-                ":".join(["{:02x}".format(x) for x in system_id[::-1]])
-            )
-        )
+        print(f"System ID: {system_id[::-1].hex(':')}")
 
         model_number = await client.read_gatt_char(MODEL_NBR_UUID)
-        print("Model Number: {0}".format("".join(map(chr, model_number))))
+        print(f"Model Number: {model_number.decode()}")
 
         try:
             device_name = await client.read_gatt_char(DEVICE_NAME_UUID)
-            print("Device Name: {0}".format("".join(map(chr, device_name))))
+            print(f"Device Name: {device_name.decode()}")
         except Exception:
             pass
 
         manufacturer_name = await client.read_gatt_char(MANUFACTURER_NAME_UUID)
-        print("Manufacturer Name: {0}".format("".join(map(chr, manufacturer_name))))
+        print(f"Manufacturer Name: {manufacturer_name.decode()}")
 
         firmware_revision = await client.read_gatt_char(FIRMWARE_REV_UUID)
-        print("Firmware Revision: {0}".format("".join(map(chr, firmware_revision))))
+        print(f"Firmware Revision: {firmware_revision.decode()}")
 
         hardware_revision = await client.read_gatt_char(HARDWARE_REV_UUID)
-        print("Hardware Revision: {0}".format("".join(map(chr, hardware_revision))))
+        print(f"Hardware Revision: {hardware_revision.decode()}")
 
         software_revision = await client.read_gatt_char(SOFTWARE_REV_UUID)
-        print("Software Revision: {0}".format("".join(map(chr, software_revision))))
+        print(f"Software Revision: {software_revision.decode()}")
 
         battery_level = await client.read_gatt_char(BATTERY_LEVEL_UUID)
-        print("Battery Level: {0}%".format(int(battery_level[0])))
+        print(f"Battery Level: {battery_level[0]}%")
 
         async def notification_handler(
             characteristic: BleakGATTCharacteristic, data: bytearray
@@ -125,22 +121,22 @@ async def main(address: str):
         # Turn on the red light on the Sensor Tag by writing to I/O Data and I/O Config.
         write_value = bytearray([0x01])
         value = await client.read_gatt_char(IO_DATA_CHAR_UUID)
-        print("I/O Data Pre-Write Value: {0}".format(value))
+        print(f"I/O Data Pre-Write Value: {value}")
 
         await client.write_gatt_char(IO_DATA_CHAR_UUID, write_value, response=True)
 
         value = await client.read_gatt_char(IO_DATA_CHAR_UUID)
-        print("I/O Data Post-Write Value: {0}".format(value))
+        print(f"I/O Data Post-Write Value: {value}")
         assert value == write_value
 
         write_value = bytearray([0x01])
         value = await client.read_gatt_char(IO_CONFIG_CHAR_UUID)
-        print("I/O Config Pre-Write Value: {0}".format(value))
+        print(f"I/O Config Pre-Write Value: {value}")
 
         await client.write_gatt_char(IO_CONFIG_CHAR_UUID, write_value, response=True)
 
         value = await client.read_gatt_char(IO_CONFIG_CHAR_UUID)
-        print("I/O Config Post-Write Value: {0}".format(value))
+        print(f"I/O Config Post-Write Value: {value}")
         assert value == write_value
 
         # Try notifications with key presses.


### PR DESCRIPTION
Clean up legacy code by replacing str.format() calls with f-strings (or other appropriate formatting, in the case of logging).

Also simplify some expressions where applicable.
