### PR TITLE
tree-wide: clean up conditional imports

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -18,13 +18,8 @@ from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
 from types import TracebackType
 from typing import Any, Literal, Optional, TypedDict, Union, cast, overload
 
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-    from typing_extensions import Never, Self, Unpack, assert_never
-else:
-    from asyncio import timeout as async_timeout
-    from typing import Never, Self, Unpack, assert_never
-
+from bleak._compat import Never, Self, Unpack, assert_never
+from bleak._compat import timeout as async_timeout
 from bleak.args.bluez import BlueZNotifyArgs, BlueZScannerArgs
 from bleak.args.corebluetooth import CBScannerArgs, CBStartNotifyArgs
 from bleak.args.winrt import WinRTClientArgs

--- a/bleak/_compat.py
+++ b/bleak/_compat.py
@@ -1,0 +1,25 @@
+"""
+Python version compatibility imports.
+
+These will be removed when support for older Python versions is dropped.
+"""
+
+import sys
+
+if sys.version_info < (3, 11):
+    from async_timeout import timeout as timeout
+    from typing_extensions import Never as Never
+    from typing_extensions import Self as Self
+    from typing_extensions import Unpack as Unpack
+    from typing_extensions import assert_never as assert_never
+else:
+    from asyncio import timeout as timeout  # noqa: F401
+    from typing import Never as Never  # noqa: F401
+    from typing import Self as Self  # noqa: F401
+    from typing import Unpack as Unpack  # noqa: F401
+    from typing import assert_never as assert_never  # noqa: F401
+
+if sys.version_info < (3, 12):
+    from typing_extensions import override as override
+else:
+    from typing import override as override  # noqa: F401

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -19,22 +19,14 @@ from collections.abc import Callable
 from contextlib import AsyncExitStack
 from typing import Any, Optional, Union
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-else:
-    from asyncio import timeout as async_timeout
-
 from dbus_fast.aio import MessageBus
 from dbus_fast.constants import BusType, ErrorType, MessageType
 from dbus_fast.message import Message
 from dbus_fast.signature import Variant
 
 from bleak import BleakScanner
+from bleak._compat import override
+from bleak._compat import timeout as async_timeout
 from bleak.args import SizedBuffer
 from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.manager import get_global_bluez_manager

--- a/bleak/backends/bluezdbus/scanner.py
+++ b/bleak/backends/bluezdbus/scanner.py
@@ -10,13 +10,9 @@ from collections.abc import Callable, Coroutine
 from typing import Any, Literal, Optional
 from warnings import warn
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 from dbus_fast import Variant
 
+from bleak._compat import override
 from bleak.args.bluez import BlueZDiscoveryFilters as _BlueZDiscoveryFilters
 from bleak.args.bluez import BlueZScannerArgs as _BlueZScannerArgs
 from bleak.backends.bluezdbus.defs import Device1

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -18,13 +18,6 @@ import logging
 from collections.abc import Callable
 from typing import Any, Optional, TypedDict, cast
 
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-    from typing_extensions import Self
-else:
-    from asyncio import timeout as async_timeout
-    from typing import Self
-
 import objc
 from CoreBluetooth import (
     CBUUID,
@@ -53,6 +46,8 @@ from Foundation import (
 )
 from libdispatch import DISPATCH_QUEUE_SERIAL, dispatch_queue_create
 
+from bleak._compat import Self
+from bleak._compat import timeout as async_timeout
 from bleak.exc import (
     BleakBluetoothNotAvailableError,
     BleakBluetoothNotAvailableReason,

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -21,13 +21,6 @@ import logging
 from collections.abc import Iterable
 from typing import Any, Optional
 
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-    from typing_extensions import Self
-else:
-    from asyncio import timeout as async_timeout
-    from typing import Self
-
 import objc
 from CoreBluetooth import (
     CBUUID,
@@ -40,6 +33,8 @@ from CoreBluetooth import (
 )
 from Foundation import NSUUID, NSArray, NSData, NSError, NSNumber, NSObject
 
+from bleak._compat import Self
+from bleak._compat import timeout as async_timeout
 from bleak.args.corebluetooth import NotificationDiscriminator
 from bleak.backends.client import NotifyCallback
 from bleak.exc import BleakError

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -15,11 +15,6 @@ import asyncio
 import logging
 from typing import Any, Optional, Union
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 from CoreBluetooth import (
     CBUUID,
     CBCharacteristicWriteWithoutResponse,
@@ -30,6 +25,7 @@ from CoreBluetooth import (
 from Foundation import NSArray, NSData
 
 from bleak import BleakScanner
+from bleak._compat import override
 from bleak.args import SizedBuffer
 from bleak.args.corebluetooth import CBStartNotifyArgs
 from bleak.assigned_numbers import gatt_char_props_to_strs

--- a/bleak/backends/corebluetooth/scanner.py
+++ b/bleak/backends/corebluetooth/scanner.py
@@ -9,15 +9,11 @@ import logging
 from typing import Any, Literal, Optional, cast
 from warnings import warn
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 import objc
 from CoreBluetooth import CBPeripheral
 from Foundation import NSBundle, NSNumber
 
+from bleak._compat import override
 from bleak.args.corebluetooth import CBScannerArgs as _CBScannerArgs
 from bleak.backends.corebluetooth.CentralManagerDelegate import (
     CBAdvertisementData,

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -15,14 +15,10 @@ import uuid
 import warnings
 from typing import Any, Optional, Union
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 from android.broadcast import BroadcastReceiver
 from jnius import java_method
 
+from bleak._compat import override
 from bleak.assigned_numbers import gatt_char_props_to_strs
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback

--- a/bleak/backends/p4android/scanner.py
+++ b/bleak/backends/p4android/scanner.py
@@ -10,20 +10,12 @@ import logging
 import warnings
 from typing import Literal, Optional
 
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-else:
-    from asyncio import timeout as async_timeout
-
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 from android.broadcast import BroadcastReceiver
 from android.permissions import Permission, request_permissions
 from jnius import cast, java_method
 
+from bleak._compat import override
+from bleak._compat import timeout as async_timeout
 from bleak.backends.p4android import defs, utils
 from bleak.backends.scanner import (
     AdvertisementData,

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -18,18 +18,6 @@ from ctypes import WinError  # type: ignore[attr-defined]
 from typing import Any, Generic, Optional, Protocol, Sequence, TypeVar, Union, cast
 from warnings import warn
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-    from typing_extensions import Self, assert_never
-else:
-    from asyncio import timeout as async_timeout
-    from typing import Self, assert_never
-
 from winrt.system import Object
 from winrt.windows.devices.bluetooth import (
     BluetoothAddressType,
@@ -67,6 +55,8 @@ from winrt.windows.foundation import (
 from winrt.windows.storage.streams import Buffer
 
 from bleak import BleakScanner
+from bleak._compat import Self, assert_never, override
+from bleak._compat import timeout as async_timeout
 from bleak.args import SizedBuffer
 from bleak.args.winrt import WinRTClientArgs as _WinRTClientArgs
 from bleak.assigned_numbers import gatt_char_props_to_strs

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -10,11 +10,6 @@ import logging
 from typing import Literal, NamedTuple, Optional
 from uuid import UUID
 
-if sys.version_info < (3, 12):
-    from typing_extensions import override
-else:
-    from typing import override
-
 from winrt.windows.devices.bluetooth import BluetoothAdapter
 from winrt.windows.devices.bluetooth.advertisement import (
     BluetoothLEAdvertisementReceivedEventArgs,
@@ -27,6 +22,7 @@ from winrt.windows.devices.bluetooth.advertisement import (
 from winrt.windows.devices.radios import RadioState
 from winrt.windows.foundation import EventRegistrationToken
 
+from bleak._compat import override
 from bleak.assigned_numbers import AdvertisementDataType
 from bleak.backends.scanner import (
     AdvertisementData,

--- a/bleak/backends/winrt/util.py
+++ b/bleak/backends/winrt/util.py
@@ -10,12 +10,8 @@ import ctypes
 from ctypes import wintypes
 from enum import IntEnum
 
+from bleak._compat import timeout as async_timeout
 from bleak.exc import BleakError
-
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-else:
-    from asyncio import timeout as async_timeout
 
 
 def _check_result(result: int, func: Any, args: Any) -> Any:

--- a/tests/integration/bluez_controller.py
+++ b/tests/integration/bluez_controller.py
@@ -18,14 +18,10 @@ from bumble.transport.common import Transport
 from dbus_fast import BusType, Message, MessageType, Variant
 from dbus_fast.aio.message_bus import MessageBus
 
+from bleak._compat import timeout as async_timeout
 from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.signals import MatchRules, add_match
 from bleak.backends.bluezdbus.utils import assert_reply, get_dbus_authenticator
-
-if sys.version_info < (3, 11):
-    from async_timeout import timeout as async_timeout
-else:
-    from asyncio import timeout as async_timeout
 
 BLEAK_TEST_MANUFACTURER_ID = 0xB1EA
 


### PR DESCRIPTION
Replace most conditional imports based on Python version with unconditional imports from a new module bleak._compat that handles the version differences internally.

A few exceptions were intentionally left as-is.

Closes: https://github.com/hbldh/bleak/issues/1813
