### PR TITLE
bleak/backends: remove super().__init__()

### DIFF
--- a/bleak/backends/scanner.py
+++ b/bleak/backends/scanner.py
@@ -124,8 +124,6 @@ class BaseBleakScanner(abc.ABC):
         detection_callback: Optional[AdvertisementDataCallback],
         service_uuids: Optional[list[str]],
     ):
-        super().__init__()
-
         self._ad_callbacks: dict[
             Hashable, Callable[[BLEDevice, AdvertisementData], None]
         ] = {}


### PR DESCRIPTION
Remove `super().__init__()`. This was just calling the default `object.__init__()`, which does nothing.
