### PR TITLE
tests/integration: remove add_default_services()

### DIFF
--- a/tests/integration/test_issue_1885.py
+++ b/tests/integration/test_issue_1885.py
@@ -57,7 +57,6 @@ async def test_notification_sent_before_write_response(
         ],
     )
 
-    bumble_peripheral.add_default_services()
     bumble_peripheral.add_service(Service(TEST_SERVICE_UUID, [test_characteristic]))
 
     add_default_advertising_data(bumble_peripheral)


### PR DESCRIPTION
Remove call to `add_default_services()` in `test_issue_1885.py`, as it adds duplicate services. Bumble already calls this internally.
