### PR TITLE
CoreBluetooth: refactor catching closed event loop errors in delegates

### DIFF
--- a/bleak/_compat.py
+++ b/bleak/_compat.py
@@ -10,12 +10,14 @@ if sys.version_info < (3, 11):
     from async_timeout import timeout as timeout
     from typing_extensions import Never as Never
     from typing_extensions import Self as Self
+    from typing_extensions import TypeVarTuple as TypeVarTuple
     from typing_extensions import Unpack as Unpack
     from typing_extensions import assert_never as assert_never
 else:
     from asyncio import timeout as timeout  # noqa: F401
     from typing import Never as Never  # noqa: F401
     from typing import Self as Self  # noqa: F401
+    from typing import TypeVarTuple as TypeVarTuple  # noqa: F401
     from typing import Unpack as Unpack  # noqa: F401
     from typing import assert_never as assert_never  # noqa: F401
 

--- a/bleak/backends/_utils.py
+++ b/bleak/backends/_utils.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from bleak._compat import TypeVarTuple, Unpack
+
+_Ts = TypeVarTuple("_Ts")
+
+
+logger = logging.getLogger(__name__)
+
+
+def try_call_soon_threadsafe(
+    event_loop: asyncio.AbstractEventLoop,
+    callback: Callable[[Unpack[_Ts]], Any],
+    *args: Unpack[_Ts],
+) -> None:
+    """Call a callback on the event loop thread, handling closed loop errors gracefully."""
+    try:
+        event_loop.call_soon_threadsafe(callback, *args)
+    except RuntimeError:
+        # Likely caused by loop being closed
+        logger.debug("unraisable exception", exc_info=True)

--- a/bleak/backends/corebluetooth/CentralManagerDelegate.py
+++ b/bleak/backends/corebluetooth/CentralManagerDelegate.py
@@ -48,6 +48,7 @@ from libdispatch import DISPATCH_QUEUE_SERIAL, dispatch_queue_create
 
 from bleak._compat import Self
 from bleak._compat import timeout as async_timeout
+from bleak.backends._utils import try_call_soon_threadsafe
 from bleak.exc import (
     BleakBluetoothNotAvailableError,
     BleakBluetoothNotAvailableReason,
@@ -105,13 +106,11 @@ class ObjcCentralManagerDelegate(NSObject, protocols=[CBCentralManagerDelegate])
             return
 
         is_scanning = bool(change[NSKeyValueChangeNewKey])
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.changed_is_scanning, is_scanning
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.changed_is_scanning,
+            is_scanning,
+        )
 
     # Protocol Functions
 
@@ -130,13 +129,10 @@ class ObjcCentralManagerDelegate(NSObject, protocols=[CBCentralManagerDelegate])
         elif centralManager.state() == CBManagerStatePoweredOn:
             logger.debug("Bluetooth powered on")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_update_state_event.set
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_update_state_event.set,
+        )
 
     def centralManager_didDiscoverPeripheral_advertisementData_RSSI_(
         self,
@@ -147,32 +143,26 @@ class ObjcCentralManagerDelegate(NSObject, protocols=[CBCentralManagerDelegate])
     ) -> None:
         logger.debug("centralManager_didDiscoverPeripheral_advertisementData_RSSI_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_discover_peripheral,
-                central,
-                peripheral,
-                advertisementData,
-                RSSI,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_discover_peripheral,
+            central,
+            peripheral,
+            advertisementData,
+            RSSI,
+        )
 
     def centralManager_didConnectPeripheral_(
         self, central: CBCentralManager, peripheral: CBPeripheral
     ) -> None:
         logger.debug("centralManager_didConnectPeripheral_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_connect_peripheral,
-                central,
-                peripheral,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_connect_peripheral,
+            central,
+            peripheral,
+        )
 
     def centralManager_didFailToConnectPeripheral_error_(
         self,
@@ -182,16 +172,13 @@ class ObjcCentralManagerDelegate(NSObject, protocols=[CBCentralManagerDelegate])
     ) -> None:
         logger.debug("centralManager_didFailToConnectPeripheral_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_fail_to_connect_peripheral,
-                centralManager,
-                peripheral,
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_fail_to_connect_peripheral,
+            centralManager,
+            peripheral,
+            error,
+        )
 
     def centralManager_didDisconnectPeripheral_error_(
         self,
@@ -201,16 +188,13 @@ class ObjcCentralManagerDelegate(NSObject, protocols=[CBCentralManagerDelegate])
     ) -> None:
         logger.debug("centralManager_didDisconnectPeripheral_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_disconnect_peripheral,
-                central,
-                peripheral,
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_disconnect_peripheral,
+            central,
+            peripheral,
+            error,
+        )
 
 
 class CentralManagerDelegate:

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -36,6 +36,7 @@ from Foundation import NSUUID, NSArray, NSData, NSError, NSNumber, NSObject
 from bleak._compat import Self
 from bleak._compat import timeout as async_timeout
 from bleak.args.corebluetooth import NotificationDiscriminator
+from bleak.backends._utils import try_call_soon_threadsafe
 from bleak.backends.client import NotifyCallback
 from bleak.exc import BleakError
 
@@ -68,16 +69,13 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didDiscoverServices_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_discover_services,
-                peripheral,
-                peripheral.services(),
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_discover_services,
+            peripheral,
+            peripheral.services(),
+            error,
+        )
 
     def peripheral_didDiscoverIncludedServicesForService_error_(
         self, peripheral: CBPeripheral, service: CBService, error: Optional[NSError]
@@ -90,17 +88,14 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didDiscoverCharacteristicsForService_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_discover_characteristics_for_service,
-                peripheral,
-                service,
-                service.characteristics(),
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_discover_characteristics_for_service,
+            peripheral,
+            service,
+            service.characteristics(),
+            error,
+        )
 
     def peripheral_didDiscoverDescriptorsForCharacteristic_error_(
         self,
@@ -110,16 +105,13 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didDiscoverDescriptorsForCharacteristic_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_discover_descriptors_for_characteristic,
-                peripheral,
-                characteristic,
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_discover_descriptors_for_characteristic,
+            peripheral,
+            characteristic,
+            error,
+        )
 
     def peripheral_didUpdateValueForCharacteristic_error_(
         self,
@@ -129,17 +121,14 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didUpdateValueForCharacteristic_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_update_value_for_characteristic,
-                peripheral,
-                characteristic,
-                characteristic.value(),
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_update_value_for_characteristic,
+            peripheral,
+            characteristic,
+            characteristic.value(),
+            error,
+        )
 
     def peripheral_didUpdateValueForDescriptor_error_(
         self,
@@ -149,17 +138,14 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didUpdateValueForDescriptor_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_update_value_for_descriptor,
-                peripheral,
-                descriptor,
-                descriptor.value(),
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_update_value_for_descriptor,
+            peripheral,
+            descriptor,
+            descriptor.value(),
+            error,
+        )
 
     def peripheral_didWriteValueForCharacteristic_error_(
         self,
@@ -169,16 +155,13 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didWriteValueForCharacteristic_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_write_value_for_characteristic,
-                peripheral,
-                characteristic,
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_write_value_for_characteristic,
+            peripheral,
+            characteristic,
+            error,
+        )
 
     def peripheral_didWriteValueForDescriptor_error_(
         self,
@@ -188,16 +171,13 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didWriteValueForDescriptor_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_write_value_for_descriptor,
-                peripheral,
-                descriptor,
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_write_value_for_descriptor,
+            peripheral,
+            descriptor,
+            error,
+        )
 
     def peripheralIsReadyToSendWriteWithoutResponse_(
         self, peripheral: CBPeripheral
@@ -213,16 +193,13 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didUpdateNotificationStateForCharacteristic_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_update_notification_for_characteristic,
-                peripheral,
-                characteristic,
-                error,
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_update_notification_for_characteristic,
+            peripheral,
+            characteristic,
+            error,
+        )
 
     def peripheral_didReadRSSI_error_(
         self,
@@ -232,39 +209,37 @@ class ObjcPeripheralDelegate(NSObject, protocols=[CBPeripheralDelegate]):
     ) -> None:
         logger.debug("peripheral_didReadRSSI_error_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_read_rssi, peripheral, int(rssi), error
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_read_rssi,
+            peripheral,
+            int(rssi),
+            error,
+        )
 
     # Bleak currently doesn't use the callbacks below other than for debug logging
 
     def peripheralDidUpdateName_(self, peripheral: CBPeripheral) -> None:
         logger.debug("peripheralDidUpdateName_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_update_name, peripheral, peripheral.name()
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_update_name,
+            peripheral,
+            peripheral.name(),
+        )
 
     def peripheral_didModifyServices_(
         self, peripheral: CBPeripheral, invalidatedServices: NSArray[CBService]
     ) -> None:
         logger.debug("peripheral_didModifyServices_")
 
-        try:
-            self.py_delegate.event_loop.call_soon_threadsafe(
-                self.py_delegate.did_modify_services, peripheral, invalidatedServices
-            )
-        except RuntimeError as e:
-            # Likely caused by loop being closed
-            logger.debug("unraisable exception", exc_info=e)
+        try_call_soon_threadsafe(
+            self.py_delegate.event_loop,
+            self.py_delegate.did_modify_services,
+            peripheral,
+            invalidatedServices,
+        )
 
 
 class PeripheralDelegate:


### PR DESCRIPTION
This is a small refactoring of the CoreBluetooth implementation of catching runtime errors in the delegates. It removes duplicated code.

This will also simplify the integration tests to get a 100% code coverage of the CoreBluetooth implementation.