### PR TITLE
tests/integration: Speedup characteristic and descriptor tests by a module level peripheral

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import sys
 import threading
@@ -20,6 +21,15 @@ from bleak.backends.device import BLEDevice
 
 @pytest.fixture
 async def hci_transport(
+    request: pytest.FixtureRequest,
+) -> AsyncGenerator[Transport, None]:
+    """Create a bumble HCI Transport."""
+    async with create_hci_transport(request) as hci_transport:
+        yield hci_transport
+
+
+@contextlib.asynccontextmanager
+async def create_hci_transport(
     request: pytest.FixtureRequest,
 ) -> AsyncGenerator[Transport, None]:
     """Create a bumble HCI Transport."""
@@ -47,10 +57,13 @@ async def hci_transport(
 
 
 @pytest.fixture
-def bumble_peripheral(hci_transport: Transport) -> Device:
-    """
-    Create a BLE peripheral device with bumble.
-    """
+async def bumble_peripheral(hci_transport: Transport) -> Device:
+    """Create a BLE peripheral device with bumble."""
+    return create_bumble_peripheral(hci_transport)
+
+
+def create_bumble_peripheral(hci_transport: Transport) -> Device:
+    """Create a BLE peripheral device with bumble."""
     config = DeviceConfiguration(
         name="Bleak",
         # use random static address to avoid device caching issues, when characteristics change between test runs

--- a/tests/integration/test_client_characteristics.py
+++ b/tests/integration/test_client_characteristics.py
@@ -1,182 +1,219 @@
 import asyncio
+import dataclasses
+from collections.abc import AsyncGenerator
 
 import pytest
+import pytest_asyncio
 from bumble.device import Connection, Device
 from bumble.gatt import Characteristic, CharacteristicValue, Service
+from bumble.transport.common import Transport
 
 from bleak import BleakClient
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from tests.integration.conftest import (
     configure_and_power_on_bumble_peripheral,
+    create_bumble_peripheral,
+    create_hci_transport,
     find_ble_device,
 )
 
 
-async def test_read_gatt_char(bumble_peripheral: Device):
-    """Reading a GATT characteristic is possible."""
-    READ_SERVICE_UUID = "2908f536-3fab-43c9-a7b2-80b6fdaae99b"
-    READ_CHARACTERISITC_UUID = "1a1af049-9c23-4b69-b763-e1096674ed18"
-    virtual_characteristic = Characteristic(
-        READ_CHARACTERISITC_UUID,
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def hci_transport(
+    request: pytest.FixtureRequest,
+) -> AsyncGenerator[Transport, None]:
+    """Create a bumble HCI Transport."""
+    async with create_hci_transport(request) as hci_transport:
+        yield hci_transport
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def bumble_peripheral(hci_transport: Transport) -> Device:
+    """Create a BLE peripheral device with bumble."""
+    return create_bumble_peripheral(hci_transport)
+
+
+CHAR_TEST_SERVICE_UUID = "2908f536-3fab-43c9-a7b2-80b6fdaae99b"
+
+READ_CHAR_UUID = "1a1af049-9c23-4b69-b763-e1096674ed18"
+WRITE_WITH_RESPONSE_CHAR_UUID = "79a92bad-31b4-4a70-885c-e704ae2c6363"
+WRITE_WITHOUT_RESPONSE_CHAR_UUID = "2a07f6ea-6401-45d7-838c-0f459a7edb7f"
+NOTIFY_CHAR_UUID = "d4c6dad3-76f1-4034-8871-0a6345be6cfc"
+
+
+@dataclasses.dataclass
+class CharTestPeripheral:
+    bleak_client: BleakClient
+    bumble_peripheral: Device
+    read_characteristic: Characteristic[bytes]
+    write_characteristic: Characteristic[bytes]
+    write_without_response_characteristic: Characteristic[bytes]
+    notify_characteristic: Characteristic[bytes]
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def char_test_peripheral(
+    bumble_peripheral: Device,
+) -> AsyncGenerator[CharTestPeripheral, None]:
+    read_characteristic = Characteristic[bytes](
+        READ_CHAR_UUID,
         Characteristic.Properties.READ,
         Characteristic.Permissions.READABLE,
         b"DATA",
     )
-    await configure_and_power_on_bumble_peripheral(
-        bumble_peripheral,
-        services=[Service(READ_SERVICE_UUID, [virtual_characteristic])],
-    )
-
-    device = await find_ble_device(bumble_peripheral)
-
-    async with BleakClient(device, services=[READ_SERVICE_UUID]) as client:
-        data = await client.read_gatt_char(READ_CHARACTERISITC_UUID)
-        assert data == b"DATA"
-
-
-async def test_read_gatt_char_use_cached(bumble_peripheral: Device):
-    """Reading a cached GATT characteristic is possible."""
-    READ_SERVICE_UUID = "2908f536-3fab-43c9-a7b2-80b6fdaae99b"
-    READ_CHARACTERISITC_UUID = "1a1af049-9c23-4b69-b763-e1096674ed18"
-    virtual_characteristic = Characteristic(
-        READ_CHARACTERISITC_UUID,
-        Characteristic.Properties.READ,
-        Characteristic.Permissions.READABLE,
-        b"DATA",
-    )
-    await configure_and_power_on_bumble_peripheral(
-        bumble_peripheral,
-        services=[Service(READ_SERVICE_UUID, [virtual_characteristic])],
-    )
-
-    device = await find_ble_device(bumble_peripheral)
-
-    async with BleakClient(device) as client:
-        await client.read_gatt_char(READ_CHARACTERISITC_UUID)
-        virtual_characteristic.value = b"ASDF"
-
-        data = await client.read_gatt_char(READ_CHARACTERISITC_UUID, use_cached=True)
-
-        # The data has to be the old value since we are using the cached value.
-        assert data == b"DATA"
-
-
-async def test_write_gatt_char_with_response(bumble_peripheral: Device):
-    """Writing a GATT characteristic is possible."""
-    WRITE_WITH_RESPONSE_SERVICE_UUID = "79a92bad-31b4-4a70-885c-e704ae2c6363"
-    WRITE_WITH_RESPONSE_CHARACTERISITC_UUID = "2a07f6ea-6401-45d7-838c-0f459a7edb7f"
-    virtual_characteristic = Characteristic(
-        WRITE_WITH_RESPONSE_CHARACTERISITC_UUID,
+    write_characteristic = Characteristic[bytes](
+        WRITE_WITH_RESPONSE_CHAR_UUID,
         Characteristic.Properties.WRITE,
         Characteristic.WRITEABLE,
         b"----",
     )
-    await configure_and_power_on_bumble_peripheral(
-        bumble_peripheral,
-        services=[Service(WRITE_WITH_RESPONSE_SERVICE_UUID, [virtual_characteristic])],
-    )
-
-    device = await find_ble_device(bumble_peripheral)
-
-    async with BleakClient(
-        device, services=[WRITE_WITH_RESPONSE_SERVICE_UUID]
-    ) as client:
-        await client.write_gatt_char(
-            WRITE_WITH_RESPONSE_CHARACTERISITC_UUID, b"DATA", response=True
-        )
-        assert virtual_characteristic.value == b"DATA"
-
-
-async def test_write_gatt_char_no_response(bumble_peripheral: Device):
-    """Writing a GATT characteristic is possible."""
-    WRITE_WITHOUT_RESPONSE_SERVICE_UUID = "79a92bad-31b4-4a70-885c-e704ae2c6363"
-    WRITE_WITHOUT_RESPONSE_CHARACTERISITC_UUID = "2a07f6ea-6401-45d7-838c-0f459a7edb7f"
-
-    peripheral_write_callback_called: asyncio.Future[bytes] = asyncio.Future()
-
-    def peripheral_write_callback(connection: Connection, value: bytes):
-        peripheral_write_callback_called.set_result(value)
-
-    virtual_characteristic = Characteristic[bytes](
-        WRITE_WITHOUT_RESPONSE_CHARACTERISITC_UUID,
+    write_without_response_characteristic = Characteristic[bytes](
+        WRITE_WITHOUT_RESPONSE_CHAR_UUID,
         Characteristic.Properties.WRITE_WITHOUT_RESPONSE,
         Characteristic.WRITEABLE,
-        CharacteristicValue(write=peripheral_write_callback),
+        None,
     )
+    notify_characteristic = Characteristic[bytes](
+        NOTIFY_CHAR_UUID,
+        Characteristic.Properties.READ | Characteristic.Properties.NOTIFY,
+        Characteristic.Permissions.READABLE,
+        b"----",
+    )
+
     await configure_and_power_on_bumble_peripheral(
         bumble_peripheral,
         services=[
-            Service(WRITE_WITHOUT_RESPONSE_SERVICE_UUID, [virtual_characteristic])
+            Service(
+                CHAR_TEST_SERVICE_UUID,
+                [
+                    read_characteristic,
+                    write_characteristic,
+                    write_without_response_characteristic,
+                    notify_characteristic,
+                ],
+            ),
         ],
     )
 
     device = await find_ble_device(bumble_peripheral)
 
-    async with BleakClient(
-        device, services=[WRITE_WITHOUT_RESPONSE_SERVICE_UUID]
-    ) as client:
-        await client.write_gatt_char(
-            WRITE_WITHOUT_RESPONSE_CHARACTERISITC_UUID, b"DATA", response=False
+    async with BleakClient(device, services=[CHAR_TEST_SERVICE_UUID]) as client:
+        yield CharTestPeripheral(
+            bumble_peripheral=bumble_peripheral,
+            bleak_client=client,
+            read_characteristic=read_characteristic,
+            write_characteristic=write_characteristic,
+            write_without_response_characteristic=write_without_response_characteristic,
+            notify_characteristic=notify_characteristic,
         )
-        written_value = await asyncio.wait_for(
-            peripheral_write_callback_called, timeout=1
-        )
-        assert written_value == b"DATA"
 
 
-async def test_notify_gatt_char(bumble_peripheral: Device):
+@pytest.mark.asyncio(loop_scope="module")
+async def test_read_gatt_char(
+    char_test_peripheral: CharTestPeripheral,
+):
+    """Reading a GATT characteristic is possible."""
+
+    # Set data to a known value
+    char_test_peripheral.read_characteristic.value = b"DATA"
+    data = await char_test_peripheral.bleak_client.read_gatt_char(READ_CHAR_UUID)
+
+    # Verify the data is as expected
+    assert data == b"DATA"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_read_gatt_char_use_cached(char_test_peripheral: CharTestPeripheral):
+    """Reading a cached GATT characteristic is possible."""
+
+    # Set data to a known value
+    char_test_peripheral.read_characteristic.value = b"ORIGINAL"
+    await char_test_peripheral.bleak_client.read_gatt_char(READ_CHAR_UUID)
+
+    # Change the data to a different value
+    char_test_peripheral.read_characteristic.value = b"CHANGED"
+
+    data = await char_test_peripheral.bleak_client.read_gatt_char(
+        READ_CHAR_UUID, use_cached=True
+    )
+
+    # The data has to be the old value since we are using the cached value.
+    assert data == b"ORIGINAL"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_write_gatt_char_with_response(char_test_peripheral: CharTestPeripheral):
     """Writing a GATT characteristic is possible."""
-    NOTIFY_SERVICE_UUID = "e405a09d-7c8e-4ac5-adcf-ba808e7f2d18"
-    NOTIFY_CHARACTERISITC_UUID = "d4c6dad3-76f1-4034-8871-0a6345be6cfc"
-    virtual_characteristic = Characteristic(
-        NOTIFY_CHARACTERISITC_UUID,
-        Characteristic.Properties.READ | Characteristic.Properties.NOTIFY,
-        Characteristic.Permissions.READABLE,
-        b"----",
-    )
-    await configure_and_power_on_bumble_peripheral(
-        bumble_peripheral,
-        services=[Service(NOTIFY_SERVICE_UUID, [virtual_characteristic])],
+
+    # Set data to a known value
+    char_test_peripheral.write_characteristic.value = b"----"
+
+    await char_test_peripheral.bleak_client.write_gatt_char(
+        WRITE_WITH_RESPONSE_CHAR_UUID, b"DATA", response=True
     )
 
-    device = await find_ble_device(bumble_peripheral)
+    # Verify the new data was written correctly
+    assert char_test_peripheral.write_characteristic.value == b"DATA"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_write_gatt_char_no_response(char_test_peripheral: CharTestPeripheral):
+    """Writing a GATT characteristic is possible."""
+    peripheral_write_callback_called: asyncio.Future[bytes] = asyncio.Future()
+
+    def peripheral_write_callback(connection: Connection, value: bytes):
+        peripheral_write_callback_called.set_result(value)
+
+    char_test_peripheral.write_without_response_characteristic.value = (
+        CharacteristicValue(write=peripheral_write_callback)
+    )
+
+    await char_test_peripheral.bleak_client.write_gatt_char(
+        WRITE_WITHOUT_RESPONSE_CHAR_UUID, b"DATA", response=False
+    )
+    written_value = await asyncio.wait_for(peripheral_write_callback_called, timeout=1)
+    assert written_value == b"DATA"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_notify_gatt_char(char_test_peripheral: CharTestPeripheral):
+    """Writing a GATT characteristic is possible."""
 
     notified_data: asyncio.Queue[bytes] = asyncio.Queue()
 
     def notify_callback(characteristic: BleakGATTCharacteristic, data: bytearray):
-        assert characteristic.uuid.lower() == NOTIFY_CHARACTERISITC_UUID
+        assert characteristic.uuid.lower() == NOTIFY_CHAR_UUID
         notified_data.put_nowait(bytes(data))
 
-    async with BleakClient(device, services=[NOTIFY_SERVICE_UUID]) as client:
-        await client.start_notify(
-            NOTIFY_CHARACTERISITC_UUID,
-            notify_callback,
-        )
-        assert notified_data.empty()
+    await char_test_peripheral.bleak_client.start_notify(
+        NOTIFY_CHAR_UUID,
+        notify_callback,
+    )
+    assert notified_data.empty()
 
-        await bumble_peripheral.notify_subscribers(  # type: ignore  # (missing type hints in bumble)
-            virtual_characteristic,
-            b"1234",
-        )
+    await char_test_peripheral.bumble_peripheral.notify_subscribers(  # type: ignore  # (missing type hints in bumble)
+        char_test_peripheral.notify_characteristic,
+        b"1234",
+    )
 
-        data = await asyncio.wait_for(notified_data.get(), timeout=1)
-        assert data == b"1234"
+    data = await asyncio.wait_for(notified_data.get(), timeout=1)
+    assert data == b"1234"
 
-        await bumble_peripheral.notify_subscribers(  # type: ignore  # (missing type hints in bumble)
-            virtual_characteristic,
-            b"2345",
-        )
+    await char_test_peripheral.bumble_peripheral.notify_subscribers(  # type: ignore  # (missing type hints in bumble)
+        char_test_peripheral.notify_characteristic,
+        b"2345",
+    )
 
-        data = await asyncio.wait_for(notified_data.get(), timeout=1)
-        assert data == b"2345"
+    data = await asyncio.wait_for(notified_data.get(), timeout=1)
+    assert data == b"2345"
 
-        await client.stop_notify(NOTIFY_CHARACTERISITC_UUID)
+    await char_test_peripheral.bleak_client.stop_notify(NOTIFY_CHAR_UUID)
 
-        await bumble_peripheral.notify_subscribers(  # type: ignore  # (missing type hints in bumble)
-            virtual_characteristic,
-            b"2345",
-        )
+    await char_test_peripheral.bumble_peripheral.notify_subscribers(  # type: ignore  # (missing type hints in bumble)
+        char_test_peripheral.notify_characteristic,
+        b"2345",
+    )
 
-        # Verify no notification was received
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(notified_data.get(), timeout=1)
+    # Verify no notification was received
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(notified_data.get(), timeout=1)

--- a/tests/integration/test_client_descriptors.py
+++ b/tests/integration/test_client_descriptors.py
@@ -1,3 +1,8 @@
+import dataclasses
+from collections.abc import AsyncGenerator
+
+import pytest
+import pytest_asyncio
 from bumble.device import Device
 from bumble.gatt import (
     GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR,
@@ -5,135 +10,165 @@ from bumble.gatt import (
     Descriptor,
     Service,
 )
+from bumble.transport.common import Transport
 
 from bleak import BleakClient
 from tests.integration.conftest import (
     configure_and_power_on_bumble_peripheral,
+    create_bumble_peripheral,
+    create_hci_transport,
     find_ble_device,
 )
 
 
-async def test_read_gatt_descriptor(bumble_peripheral: Device):
-    """Reading a GATT descriptor is possible."""
-    READABLE_DESCRIPTOR_SERVICE_UUID = "0d15eded-4e68-4718-bedf-736847b68e72"
-    READABLE_DESCRIPTOR_CHARACTERISITC_UUID = "25c614ab-1560-46da-94bc-c146addfc359"
-    virtual_descriptor = Descriptor(
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def hci_transport(
+    request: pytest.FixtureRequest,
+) -> AsyncGenerator[Transport, None]:
+    """Create a bumble HCI Transport."""
+    async with create_hci_transport(request) as hci_transport:
+        yield hci_transport
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def bumble_peripheral(hci_transport: Transport) -> Device:
+    """Create a BLE peripheral device with bumble."""
+    return create_bumble_peripheral(hci_transport)
+
+
+DESCR_TEST_SERVICE_UUID = "0d15eded-4e68-4718-bedf-736847b68e72"
+
+READABLE_DESCR_CHAR_UUID = "25c614ab-1560-46da-94bc-c146addfc359"
+WRITABLE_DESCR_CHAR_UUID = "822afd2f-c2b2-4302-9edb-09850a93b707"
+
+
+@dataclasses.dataclass
+class DescrTestPeripheral:
+    bleak_client: BleakClient
+    bumble_peripheral: Device
+    readable_descr: Descriptor
+    writable_descr: Descriptor
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def descr_test_peripheral(
+    bumble_peripheral: Device,
+) -> AsyncGenerator[DescrTestPeripheral, None]:
+
+    readable_descr = Descriptor(
         GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR,
         Descriptor.READABLE,
         "Description".encode(),
     )
-    virtual_characteristic = Characteristic(
-        READABLE_DESCRIPTOR_CHARACTERISITC_UUID,
+    readable_descr_char = Characteristic(
+        READABLE_DESCR_CHAR_UUID,
         Characteristic.Properties.READ,
         Characteristic.Permissions.READABLE,
         b"",
-        [virtual_descriptor],
-    )
-    await configure_and_power_on_bumble_peripheral(
-        bumble_peripheral,
-        services=[Service(READABLE_DESCRIPTOR_SERVICE_UUID, [virtual_characteristic])],
+        [readable_descr],
     )
 
-    device = await find_ble_device(bumble_peripheral)
-
-    async with BleakClient(
-        device, services=[READABLE_DESCRIPTOR_SERVICE_UUID]
-    ) as client:
-        characteristic = client.services.get_characteristic(
-            READABLE_DESCRIPTOR_CHARACTERISITC_UUID
-        )
-        assert characteristic
-
-        descriptor = characteristic.get_descriptor(
-            GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR.to_hex_str()
-        )
-        assert descriptor
-
-        data = await client.read_gatt_descriptor(descriptor)
-        assert data == b"Description"
-
-
-async def test_read_gatt_descriptor_use_cached(bumble_peripheral: Device):
-    """Reading a cached GATT descriptor is possible."""
-    READABLE_DESCRIPTOR_SERVICE_UUID = "0d15eded-4e68-4718-bedf-736847b68e72"
-    READABLE_DESCRIPTOR_CHARACTERISITC_UUID = "25c614ab-1560-46da-94bc-c146addfc359"
-    virtual_descriptor = Descriptor(
-        GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR,
-        Descriptor.READABLE,
-        "Description".encode(),
-    )
-    virtual_characteristic = Characteristic(
-        READABLE_DESCRIPTOR_CHARACTERISITC_UUID,
-        Characteristic.Properties.READ,
-        Characteristic.Permissions.READABLE,
-        b"",
-        [virtual_descriptor],
-    )
-    await configure_and_power_on_bumble_peripheral(
-        bumble_peripheral,
-        services=[Service(READABLE_DESCRIPTOR_SERVICE_UUID, [virtual_characteristic])],
-    )
-
-    device = await find_ble_device(bumble_peripheral)
-
-    async with BleakClient(
-        device, services=[READABLE_DESCRIPTOR_SERVICE_UUID]
-    ) as client:
-        characteristic = client.services.get_characteristic(
-            READABLE_DESCRIPTOR_CHARACTERISITC_UUID
-        )
-        assert characteristic
-
-        descriptor = characteristic.get_descriptor(
-            GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR.to_hex_str()
-        )
-        assert descriptor
-
-        await client.read_gatt_descriptor(descriptor)
-
-        virtual_descriptor.value = b"Changed"
-
-        data = await client.read_gatt_descriptor(descriptor, use_cached=True)
-
-        # The data has to be the old value since we are using the cached value.
-        assert data == b"Description"
-
-
-async def test_write_gatt_descriptor(bumble_peripheral: Device):
-    """Writing a GATT descriptor is possible."""
-    WRITABLE_DESCRIPTOR_SERVICE_UUID = "bef6dc41-8986-4c32-b746-6e2b10ca06e0"
-    WRITABLE_DESCRIPTOR_CHARACTERISITC_UUID = "822afd2f-c2b2-4302-9edb-09850a93b707"
-    virtual_descriptor = Descriptor(
+    writable_descr = Descriptor(
         GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR,
         Descriptor.WRITEABLE,
         b"-----------",
     )
-    virtual_characteristic = Characteristic(
-        WRITABLE_DESCRIPTOR_CHARACTERISITC_UUID,
+    writable_descr_char = Characteristic(
+        WRITABLE_DESCR_CHAR_UUID,
         Characteristic.Properties.READ,
         Characteristic.Permissions.READABLE,
         b"",
-        [virtual_descriptor],
+        [writable_descr],
     )
+
     await configure_and_power_on_bumble_peripheral(
         bumble_peripheral,
-        services=[Service(WRITABLE_DESCRIPTOR_SERVICE_UUID, [virtual_characteristic])],
+        services=[
+            Service(
+                DESCR_TEST_SERVICE_UUID,
+                [
+                    readable_descr_char,
+                    writable_descr_char,
+                ],
+            ),
+        ],
     )
 
     device = await find_ble_device(bumble_peripheral)
 
-    async with BleakClient(
-        device, services=[WRITABLE_DESCRIPTOR_SERVICE_UUID]
-    ) as client:
-        characteristic = client.services.get_characteristic(
-            WRITABLE_DESCRIPTOR_CHARACTERISITC_UUID
+    async with BleakClient(device, services=[DESCR_TEST_SERVICE_UUID]) as client:
+        yield DescrTestPeripheral(
+            bumble_peripheral=bumble_peripheral,
+            bleak_client=client,
+            readable_descr=readable_descr,
+            writable_descr=writable_descr,
         )
-        assert characteristic
 
-        descriptor = characteristic.get_descriptor(
-            GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR.to_hex_str()
-        )
-        assert descriptor
 
-        await client.write_gatt_descriptor(descriptor, b"Description")
-        assert virtual_descriptor.value == b"Description"  # type: ignore  # (missing type hints in bumble)
+@pytest.mark.asyncio(loop_scope="module")
+async def test_read_gatt_descriptor(descr_test_peripheral: DescrTestPeripheral):
+    """Reading a GATT descriptor is possible."""
+
+    characteristic = descr_test_peripheral.bleak_client.services.get_characteristic(
+        READABLE_DESCR_CHAR_UUID
+    )
+    assert characteristic
+
+    descriptor = characteristic.get_descriptor(
+        GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR.to_hex_str()
+    )
+    assert descriptor
+
+    descr_test_peripheral.readable_descr.value = b"Description"
+    data = await descr_test_peripheral.bleak_client.read_gatt_descriptor(descriptor)
+    assert data == b"Description"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_read_gatt_descriptor_use_cached(
+    descr_test_peripheral: DescrTestPeripheral,
+):
+    """Reading a cached GATT descriptor is possible."""
+    characteristic = descr_test_peripheral.bleak_client.services.get_characteristic(
+        READABLE_DESCR_CHAR_UUID
+    )
+    assert characteristic
+
+    descriptor = characteristic.get_descriptor(
+        GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR.to_hex_str()
+    )
+    assert descriptor
+
+    descr_test_peripheral.readable_descr.value = b"Original"
+    data = await descr_test_peripheral.bleak_client.read_gatt_descriptor(descriptor)
+    assert data == b"Original"
+
+    descr_test_peripheral.readable_descr.value = b"Changed"
+    data = await descr_test_peripheral.bleak_client.read_gatt_descriptor(
+        descriptor, use_cached=True
+    )
+
+    # The data has to be the old value since we are using the cached value.
+    assert data == b"Original"
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_write_gatt_descriptor(descr_test_peripheral: DescrTestPeripheral):
+    """Writing a GATT descriptor is possible."""
+
+    characteristic = descr_test_peripheral.bleak_client.services.get_characteristic(
+        WRITABLE_DESCR_CHAR_UUID
+    )
+    assert characteristic
+
+    descriptor = characteristic.get_descriptor(
+        GATT_CHARACTERISTIC_USER_DESCRIPTION_DESCRIPTOR.to_hex_str()
+    )
+    assert descriptor
+
+    descr_test_peripheral.writable_descr.value = b"Original"
+
+    await descr_test_peripheral.bleak_client.write_gatt_descriptor(
+        descriptor, b"Changed"
+    )
+    assert descr_test_peripheral.writable_descr.value == b"Changed"  # type: ignore  # (missing type hints in bumble)


### PR DESCRIPTION
The integration tests are slow, because every time a new peripheral is created and connected to. But for some tests like characteristic and descriptor tests it is not necessary to always create a new peripheral. So to speed things up a module level peripheral fixture is created to share a connected BleakClient/BumblePeripheral between the tests.