### PR TITLE
backend/CoreBluetooth: Remove `isScanning` check after start/stop scanning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Added
 * Added type hints and documentation for ``use_cached`` kwarg for ``read_gatt_char()`` and ``read_gatt_descriptor()`` methods in ``BleakClient``.
 * Added support for ``"use_cached"`` kwarg to ``read_gatt_char()`` and ``read_gatt_descriptor()`` methods in BlueZ backend.
 
+Changed
+-------
+* Changed start/stop scanning on CoreBluetooth so that the ``isScanning`` property is not checked anymore.
+
+Fixed
+-----
+* Fixed a potential deadlock when turning off Bluetooth manually while starting scanning on CoreBluetooth.
+
 `2.1.1`_ (2025-12-31)
 =====================
 


### PR DESCRIPTION
When implementing integration tests for the `isScanning` observer in https://github.com/hbldh/bleak/pull/1912, the [question](https://github.com/hbldh/bleak/pull/1912#discussion_r2658619634) came up whether these are even needed.

So far, I have not been able to find a reason why this check was added. The first commit that inserts the `isScanning` check is https://github.com/hbldh/bleak/commit/9bb8275c9fd0ecad57affa0e6caa6a45b84ce579, with no explanation why. This was then revised in https://github.com/hbldh/bleak/pull/572, but again without any indication of whether it is actually necessary.

The only reason I can think of for the test is that starting/stopping scanning from macOS can somehow be delayed by macOS and is done via a worker thread.

**Analysis:**
To understand what was actually happening, I tried Ghidra my first time and decompiled CoreBluetooth. I am using the binaries from my macOS 15.5 (Sequoia). Here are my findings:

There is an undocumented function `setIsScanning` that is used internally in the CoreBluetooth library in four places:

1. In `CBCentralManager__scanForPeripheralsWithServices:options:`, `setIsScanning(1)` is called when a message (most likely to the Bluetooth daemon) was successfully sent.
<details>
<summary>CBCentralManager__scanForPeripheralsWithServices:options:</summary>

```

/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */

void -[CBCentralManager__scanForPeripheralsWithServices:options:]
               (undefined8 param_1,undefined8 param_2,long param_3,long param_4)

{
  int iVar1;
  undefined8 uVar2;
  undefined8 uVar3;
  undefined8 extraout_x1;
  undefined8 extraout_x1_00;
  undefined1 auVar4 [16];
  cfstringStruct *local_58;
  cfstringStruct *pcStack_50;
  long local_48;
  long lStack_40;
  long local_38;
  
  uVar3 = _DAT_1e80f8610;
  local_38 = *_DAT_1e8170d08;
  local_48 = _DAT_1e80f8820;
  if (param_3 != 0) {
    local_48 = param_3;
  }
  local_58 = &cfstringStruct_1f1632af8;
  pcStack_50 = &cfstringStruct_kCBMsgArgOptions;
  lStack_40 = _DAT_1e80f8840;
  if (param_4 != 0) {
    lStack_40 = param_4;
  }
  uVar2 = _objc_retain(param_4);
  auVar4 = _objc_retain(param_3);
  _objc_msgSend$dictionaryWithObjects:forKeys:count:(uVar3,auVar4._8_8_,&local_48,&local_58,2);
  uVar3 = _objc_retainAutoreleasedReturnValue();
  _objc_release(uVar2);
  _objc_release(auVar4._0_8_);
  iVar1 = _objc_msgSend$sendMsg:args:(param_1,extraout_x1,0x4d,uVar3);
  _objc_release(uVar3);
  if (iVar1 != 0) {
    _objc_msgSend$setIsScanning:(param_1,extraout_x1_00,1);
  }
  if (*_DAT_1e8170d08 == local_38) {
    return;
  }
                    /* WARNING: Subroutine does not return */
  ___stack_chk_fail();
}
```

</details>

 2. In `CBCentralManager_stopScan`, `setIsScanning(0)` is called when a message (also to the Bluetooth daemon) could be sent.
<details>
<summary>CBCentralManager_stopScan:</summary>

```
void -[CBCentralManager_stopScan](undefined8 param_1,undefined8 param_2)

{
  code *pcVar1;
  int iVar2;
  undefined8 extraout_x1;
  ulong unaff_x30;
  
  iVar2 = _objc_msgSend$sendMsg:args:(param_1,param_2,0x4e,0);
  if (iVar2 == 0) {
    return;
  }
  if (((unaff_x30 ^ unaff_x30 << 1) >> 0x3e & 1) != 0) {
                    /* WARNING: Does not return */
    pcVar1 = (code *)SoftwareBreakpoint(0xc471,0x196faa370);
    (*pcVar1)();
  }
  _objc_msgSend$setIsScanning:(param_1,extraout_x1,0);
  return;
}
```

</details>

 3. In `CBCentralManager_observeValueForKeyPath:ofObject:change:context:`, `setIsScanning(0)` is called when the `state` of the `CBCentralManager` changes to a state other than `CBManagerStatePoweredOn`. (This change in state can be triggered by simply turning Bluetooth on or off manually.)
<details>
<summary>CBCentralManager_observeValueForKeyPath:ofObject:change:context:</summary>

```
void -[CBCentralManager_observeValueForKeyPath:ofObject:change:context:]
               (long param_1,undefined8 param_2,undefined8 param_3,undefined8 param_4,
               undefined8 param_5,long param_6)

{
  int iVar1;
  uint uVar2;
  undefined8 uVar3;
  undefined8 uVar4;
  undefined8 uVar5;
  long lVar6;
  undefined8 uVar7;
  ulong uVar8;
  undefined8 extraout_x1;
  undefined8 extraout_x1_00;
  undefined1 auVar9 [16];
  long local_50;
  undefined8 uStack_48;
  
  uVar3 = _objc_retain(param_3);
  uVar4 = _objc_retain(param_4);
  uVar5 = _objc_retain(param_5);
  auVar9 = _objc_opt_class(DAT_1e8ab8510);
  if (auVar9._0_8_ == param_6) {
    iVar1 = _objc_msgSend$isEqualToString:(uVar3,auVar9._8_8_,&cfstringStruct_state);
    if (iVar1 == 0) {
      iVar1 = _objc_msgSend$isEqualToString:(uVar3,extraout_x1,&cfstringStruct_delegate);
      if (iVar1 == 0) goto LAB_196f9eef0;
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar2 = _objc_opt_respondsToSelector(uVar7,0x1fb3dd10d);
      lVar6 = (long)_OBJC_IVAR_$_CBCentralManager._delegateFlags;
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffffe | uVar2 & 1;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dd067);
      uVar2 = 2;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffffd | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dcfcd);
      uVar2 = 4;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffffb | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dd0a4);
      uVar2 = 8;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffff7 | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dcff2);
      uVar2 = 0x10;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffffef | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dd020);
      uVar2 = 0x20;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffffdf | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dd34);
      uVar2 = 0x40;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffffbf | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68daad);
      uVar2 = 0x80;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffff7f | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dad7);
      uVar2 = 0x100;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffeff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68db01);
      uVar2 = 0x200;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffdff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dbdb);
      uVar2 = 0x400;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffffbff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dcf97);
      uVar2 = 0x800;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffff7ff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dba7);
      uVar2 = 0x1000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffefff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68db22);
      uVar2 = 0x2000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffdfff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68da57);
      uVar2 = 0x4000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffffbfff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb3dd0d5);
      uVar2 = 0x8000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffff7fff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68d9f0);
      uVar2 = 0x10000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffeffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68da86);
      uVar2 = 0x20000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffdffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dc71);
      uVar2 = 0x40000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfffbffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dc2d);
      uVar2 = 0x80000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfff7ffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dd0a);
      uVar2 = 0x100000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffefffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dda0);
      uVar2 = 0x200000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffdfffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68de10);
      uVar2 = 0x400000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xffbfffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dd67);
      uVar2 = 0x800000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xff7fffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68da18);
      uVar2 = 0x1000000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfeffffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68ddec);
      uVar2 = 0x2000000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfdffffff | uVar2;
      _objc_release(uVar7);
      _objc_msgSend$delegate(param_1);
      uVar7 = _objc_retainAutoreleasedReturnValue();
      uVar8 = _objc_opt_respondsToSelector(uVar7,0x1fb68dcdf);
      uVar2 = 0x4000000;
      if ((uVar8 & 1) == 0) {
        uVar2 = 0;
      }
      *(uint *)(param_1 + lVar6) = *(uint *)(param_1 + lVar6) & 0xfbffffff | uVar2;
    }
    else {
      lVar6 = _objc_msgSend$state(param_1);
      if ((lVar6 != 5) && (auVar9 = _objc_msgSend$state(param_1), auVar9._0_8_ != 10)) {
        _objc_msgSend$setIsScanning:(param_1,auVar9._8_8_,0);
        _objc_msgSend$forEachPeripheral:(param_1,extraout_x1_00,&___block_literal_global.25);
        lVar6 = _objc_msgSend$state(param_1);
        if (lVar6 == 1) {
          _objc_msgSend$orphanPeripherals(param_1);
        }
      }
      _objc_msgSend$delegate(param_1);
      auVar9 = _objc_retainAutoreleasedReturnValue();
      uVar7 = auVar9._0_8_;
      _objc_msgSend$centralManagerDidUpdateState:(uVar7,auVar9._8_8_,param_1);
    }
    _objc_release(uVar7);
  }
  else {
    uStack_48 = DAT_1e8ac0c90;
    local_50 = param_1;
    _objc_msgSendSuper2(&local_50,0x1fb19f835,uVar3,uVar4,uVar5,param_6);
  }
LAB_196f9eef0:
  _objc_release(uVar5);
  _objc_release(uVar4);
  _objc_release(uVar3);
  return;
}
```

</details>

 4. In `CBCentralManager_handleRestoringState:`, `setIsScanning(1)` is called. I suspect that this is a case for iOS state restoration. However, to my knowledge, this does not exist for macOS and therefore cannot be triggered on macOS.
<details>
<summary>CBCentralManager_handleRestoringState:</summary>

```

/* WARNING: Globals starting with '_' overlap smaller symbols at the same address */

void -[CBCentralManager_handleRestoringState:](long param_1,undefined8 param_2,undefined8 param_3)

{
  int iVar1;
  undefined8 uVar2;
  undefined8 uVar3;
  long lVar4;
  undefined8 uVar5;
  undefined8 uVar6;
  undefined8 uVar7;
  undefined8 uVar8;
  undefined8 uVar9;
  undefined8 uVar10;
  long lVar11;
  undefined8 extraout_x1;
  undefined8 extraout_x1_00;
  undefined8 extraout_x1_01;
  undefined8 extraout_x1_02;
  undefined8 extraout_x1_03;
  undefined8 extraout_x1_04;
  undefined8 uVar12;
  undefined8 extraout_x1_05;
  undefined8 extraout_x1_06;
  undefined8 extraout_x1_07;
  undefined8 extraout_x1_08;
  undefined8 extraout_x1_09;
  undefined8 extraout_x1_10;
  undefined8 extraout_x1_11;
  undefined8 extraout_x1_12;
  undefined8 extraout_x1_13;
  undefined8 extraout_x1_14;
  undefined8 extraout_x1_15;
  undefined8 extraout_x1_16;
  long lVar13;
  long lVar14;
  long lVar15;
  undefined8 uVar16;
  long lVar17;
  undefined8 uVar18;
  undefined8 uVar19;
  undefined8 uVar20;
  undefined8 uVar21;
  long lVar22;
  long lVar23;
  long lVar24;
  long lVar25;
  undefined1 auVar26 [16];
  undefined1 auVar27 [16];
  undefined1 auVar28 [16];
  undefined1 auVar29 [16];
  long local_608;
  long local_5e0;
  long local_590;
  undefined8 local_580;
  undefined8 local_578;
  code *local_570;
  undefined *puStack_568;
  undefined8 local_560;
  undefined8 local_558;
  undefined8 local_550;
  long lStack_548;
  long *local_540;
  undefined8 uStack_538;
  undefined8 local_530;
  undefined8 uStack_528;
  undefined8 uStack_520;
  undefined8 uStack_518;
  undefined8 local_510;
  long lStack_508;
  long *local_500;
  undefined8 uStack_4f8;
  undefined8 local_4f0;
  undefined8 uStack_4e8;
  undefined8 uStack_4e0;
  undefined8 uStack_4d8;
  undefined8 local_4c8;
  undefined8 local_4c0;
  code *local_4b8;
  undefined *puStack_4b0;
  undefined8 local_4a8;
  undefined8 local_4a0;
  long lStack_498;
  long *local_490;
  undefined8 uStack_488;
  undefined8 local_480;
  undefined8 uStack_478;
  undefined8 uStack_470;
  undefined8 uStack_468;
  undefined8 local_460;
  long lStack_458;
  long *local_450;
  undefined8 uStack_448;
  undefined8 local_440;
  undefined8 uStack_438;
  undefined8 uStack_430;
  undefined8 uStack_428;
  undefined8 local_420;
  long lStack_418;
  long *local_410;
  undefined8 uStack_408;
  undefined8 local_400;
  undefined8 uStack_3f8;
  undefined8 uStack_3f0;
  undefined8 uStack_3e8;
  undefined8 local_3e0;
  long lStack_3d8;
  long *local_3d0;
  undefined8 uStack_3c8;
  undefined8 local_3c0;
  undefined8 uStack_3b8;
  undefined8 uStack_3b0;
  undefined8 uStack_3a8;
  undefined1 auStack_3a0 [128];
  undefined1 auStack_320 [128];
  undefined1 auStack_2a0 [128];
  cfstringStruct *local_220;
  cfstringStruct *local_218;
  undefined8 local_210;
  undefined8 local_208;
  undefined1 auStack_200 [128];
  undefined1 auStack_180 [128];
  undefined1 auStack_100 [128];
  long local_80;
  
  local_80 = *_DAT_1e8170d08;
  uVar2 = _objc_retain(param_3);
  if ((*(byte *)(param_1 + _OBJC_IVAR_$_CBCentralManager._delegateFlags) & 1) == 0) {
    -[CBCentralManager_handleRestoringState:].cold.1(param_2,param_1);
  }
  auVar26 = _objc_alloc_init(_DAT_1e80f8698);
  uVar3 = auVar26._0_8_;
  _objc_msgSend$objectForKeyedSubscript:(uVar2,auVar26._8_8_,&cfstringStruct_kCBMsgArgOptions);
  auVar26 = _objc_retainAutoreleasedReturnValue();
  lVar4 = auVar26._0_8_;
  if (lVar4 != 0) {
    _objc_msgSend$setIsScanning:(param_1,auVar26._8_8_,1);
    _objc_msgSend$objectForKeyedSubscript:(lVar4,extraout_x1,&cfstringStruct_1f1632af8);
    uVar5 = _objc_retainAutoreleasedReturnValue();
    auVar26 = _objc_msgSend$count();
    if (auVar26._0_8_ != 0) {
      _objc_msgSend$dataArrayToUUIDArray:(param_1,auVar26._8_8_,uVar5);
      auVar26 = _objc_retainAutoreleasedReturnValue();
      _objc_msgSend$setObject:forKeyedSubscript:(uVar3,auVar26._8_8_,auVar26._0_8_,0x1000007163a8d8)
      ;
      _objc_release(auVar26._0_8_);
    }
    auVar26 = _objc_alloc_init(_DAT_1e80f8698);
    uVar9 = auVar26._0_8_;
    _objc_msgSend$objectForKeyedSubscript:(lVar4,auVar26._8_8_,&cfstringStruct_1f1632f58);
    uVar6 = _objc_retainAutoreleasedReturnValue();
    auVar26 = _objc_msgSend$count();
    uVar7 = auVar26._8_8_;
    if (auVar26._0_8_ != 0) {
      _objc_msgSend$dataArrayToUUIDArray:(param_1,uVar7,uVar6);
      auVar26 = _objc_retainAutoreleasedReturnValue();
      _objc_msgSend$setObject:forKeyedSubscript:
                (uVar9,auVar26._8_8_,auVar26._0_8_,&cfstringStruct_1f1632f58);
      _objc_release(auVar26._0_8_);
      uVar7 = extraout_x1_00;
    }
    _objc_msgSend$objectForKeyedSubscript:(lVar4,uVar7,&cfstringStruct_1f1632f78);
    uVar7 = _objc_retainAutoreleasedReturnValue();
    iVar1 = _objc_msgSend$boolValue();
    _objc_release(uVar7);
    if (iVar1 != 0) {
      _objc_msgSend$setObject:forKeyedSubscript:
                (uVar9,extraout_x1_01,_DAT_1e80f8868,&cfstringStruct_1f1632f78);
    }
    auVar26 = _objc_msgSend$count(uVar9);
    if (auVar26._0_8_ != 0) {
      _objc_msgSend$setObject:forKeyedSubscript:(uVar3,auVar26._8_8_,uVar9,0x1000007163a8f8);
    }
    _objc_release(uVar6);
    _objc_release(uVar9);
    _objc_release(uVar5);
  }
  auVar26 = _objc_alloc_init(_DAT_1e80f8678);
  uVar5 = auVar26._0_8_;
  lStack_3d8 = 0;
  local_3e0 = 0;
  uStack_3c8 = 0;
  local_3d0 = (long *)0x0;
  uStack_3b8 = 0;
  local_3c0 = 0;
  uStack_3a8 = 0;
  uStack_3b0 = 0;
  _objc_msgSend$objectForKeyedSubscript:(uVar2,auVar26._8_8_,&cfstringStruct_1f1632b18);
  auVar26 = _objc_retainAutoreleasedReturnValue();
  uVar7 = auVar26._0_8_;
  auVar26 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                      (uVar7,auVar26._8_8_,&local_3e0,auStack_100,0x10);
  if (auVar26._0_8_ != 0) {
    lVar13 = *local_3d0;
    do {
      uVar9 = auVar26._8_8_;
      local_608 = auVar26._0_8_;
      lVar15 = 0;
      do {
        if (*local_3d0 != lVar13) {
          _objc_enumerationMutation(uVar7);
          uVar9 = extraout_x1_03;
        }
        uVar16 = *(undefined8 *)(lStack_3d8 + lVar15 * 8);
        _objc_msgSend$peripheralWithInfo:(param_1,uVar9,uVar16);
        auVar26 = _objc_retainAutoreleasedReturnValue();
        uVar6 = auVar26._0_8_;
        _objc_msgSend$objectForKeyedSubscript:(uVar16,auVar26._8_8_,&cfstringStruct_1f1631e58);
        uVar8 = _objc_retainAutoreleasedReturnValue();
        iVar1 = _objc_msgSend$boolValue();
        uVar9 = 1;
        if (iVar1 != 0) {
          uVar9 = 2;
        }
        _objc_msgSend$setState:(uVar6,extraout_x1_04,uVar9);
        _objc_release(uVar8);
        auVar26 = _objc_msgSend$state(uVar6);
        _objc_msgSend$setCanSendWriteWithoutResponse:(uVar6,auVar26._8_8_,auVar26._0_8_ == 2);
        uVar9 = _objc_alloc_init(_DAT_1e80f8678);
        auVar26 = _objc_alloc_init(_DAT_1e80f8678);
        _objc_msgSend$objectForKeyedSubscript:(uVar16,auVar26._8_8_,&cfstringStruct_1f1632f98);
        auVar27 = _objc_retainAutoreleasedReturnValue();
        lStack_418 = 0;
        local_420 = 0;
        uStack_408 = 0;
        local_410 = (long *)0x0;
        uStack_3f8 = 0;
        local_400 = 0;
        uStack_3e8 = 0;
        uStack_3f0 = 0;
        _objc_msgSend$objectForKeyedSubscript:(uVar16,auVar27._8_8_,&cfstringStruct_1f1632658);
        auVar28 = _objc_retainAutoreleasedReturnValue();
        uVar8 = auVar28._0_8_;
        local_5e0 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                              (uVar8,auVar28._8_8_,&local_420,auStack_180,0x10);
        if (local_5e0 != 0) {
          lVar14 = *local_410;
          do {
            lVar17 = 0;
            do {
              if (*local_410 != lVar14) {
                _objc_enumerationMutation(uVar8);
              }
              uVar18 = *(undefined8 *)(lStack_418 + lVar17 * 8);
              auVar28 = _objc_alloc(DAT_1e8ab8618);
              uVar16 = _objc_msgSend$initWithPeripheral:dictionary:
                                 (auVar28._0_8_,auVar28._8_8_,uVar6,uVar18);
              auVar28 = _objc_alloc_init(_DAT_1e80f8678);
              uVar20 = auVar28._0_8_;
              lStack_458 = 0;
              local_460 = 0;
              uStack_448 = 0;
              local_450 = (long *)0x0;
              uStack_438 = 0;
              local_440 = 0;
              uStack_428 = 0;
              uStack_430 = 0;
              _objc_msgSend$objectForKeyedSubscript:(uVar18,auVar28._8_8_,&cfstringStruct_1f1632fb8)
              ;
              auVar28 = _objc_retainAutoreleasedReturnValue();
              uVar12 = auVar28._0_8_;
              auVar28 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                  (uVar12,auVar28._8_8_,&local_460,auStack_200,0x10);
              if (auVar28._0_8_ != 0) {
                lVar22 = *local_450;
                do {
                  uVar10 = auVar28._8_8_;
                  lVar23 = 0;
                  do {
                    if (*local_450 != lVar22) {
                      _objc_enumerationMutation(uVar12);
                      uVar10 = extraout_x1_07;
                    }
                    local_208 = *(undefined8 *)(lStack_458 + lVar23 * 8);
                    local_220 = &cfstringStruct_1f1632fd8;
                    local_218 = &cfstringStruct_1f1632ff8;
                    local_210 = uVar16;
                    _objc_msgSend$dictionaryWithObjects:forKeys:count:
                              (_DAT_1e80f8610,uVar10,&local_210,&local_220,2);
                    auVar29 = _objc_retainAutoreleasedReturnValue();
                    _objc_msgSend$addObject:(auVar26._0_8_,auVar29._8_8_,auVar29._0_8_);
                    _objc_release(auVar29._0_8_);
                    lVar23 = lVar23 + 1;
                    uVar10 = extraout_x1_06;
                  } while (auVar28._0_8_ != lVar23);
                  auVar28 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                      (uVar12,extraout_x1_06,&local_460,auStack_200,0x10);
                } while (auVar28._0_8_ != 0);
              }
              _objc_release(uVar12);
              uStack_478 = 0;
              local_480 = 0;
              uStack_468 = 0;
              uStack_470 = 0;
              lStack_498 = 0;
              local_4a0 = 0;
              uStack_488 = 0;
              local_490 = (long *)0x0;
              _objc_msgSend$objectForKeyedSubscript:
                        (uVar18,extraout_x1_08,&cfstringStruct_1f1633018);
              auVar28 = _objc_retainAutoreleasedReturnValue();
              uVar12 = auVar28._0_8_;
              local_590 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                    (uVar12,auVar28._8_8_,&local_4a0,auStack_2a0,0x10);
              if (local_590 != 0) {
                lVar22 = *local_490;
                do {
                  lVar23 = 0;
                  do {
                    if (*local_490 != lVar22) {
                      _objc_enumerationMutation(uVar12);
                    }
                    uVar19 = *(undefined8 *)(lStack_498 + lVar23 * 8);
                    auVar28 = _objc_alloc(DAT_1e8ab8518);
                    uVar18 = _objc_msgSend$initWithService:dictionary:
                                       (auVar28._0_8_,auVar28._8_8_,uVar16,uVar19);
                    uVar10 = _objc_alloc_init(_DAT_1e80f8678);
                    local_4c8 = _DAT_1e8170ce8;
                    local_4c0 = 0xc2000000;
                    local_4b8 = ___41-[CBCentralManager_handleRestoringState:]_block_invoke;
                    puStack_4b0 = &___block_descriptor_40_e8_32s_e25_v32_?0_"NSNumber"8Q16^B24l;
                    auVar28 = _objc_retain(uVar18);
                    uVar18 = auVar28._0_8_;
                    local_4a8 = uVar18;
                    _objc_msgSend$enumerateObjectsUsingBlock:
                              (auVar27._0_8_,auVar28._8_8_,&local_4c8);
                    uStack_4e8 = 0;
                    local_4f0 = 0;
                    uStack_4d8 = 0;
                    uStack_4e0 = 0;
                    lStack_508 = 0;
                    local_510 = 0;
                    uStack_4f8 = 0;
                    local_500 = (long *)0x0;
                    _objc_msgSend$objectForKeyedSubscript:
                              (uVar19,extraout_x1_10,&cfstringStruct_1f1633038);
                    auVar28 = _objc_retainAutoreleasedReturnValue();
                    uVar19 = auVar28._0_8_;
                    lVar11 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                       (uVar19,auVar28._8_8_,&local_510,auStack_320,0x10);
                    if (lVar11 != 0) {
                      lVar25 = *local_500;
                      do {
                        lVar24 = 0;
                        do {
                          if (*local_500 != lVar25) {
                            _objc_enumerationMutation(uVar19);
                          }
                          uVar21 = *(undefined8 *)(lStack_508 + lVar24 * 8);
                          auVar28 = _objc_alloc(DAT_1e8ab8550);
                          auVar28 = _objc_msgSend$initWithCharacteristic:dictionary:
                                              (auVar28._0_8_,auVar28._8_8_,uVar18,uVar21);
                          uVar21 = auVar28._0_8_;
                          _objc_msgSend$addObject:(uVar10,auVar28._8_8_,uVar21);
                          _objc_msgSend$handle(uVar21);
                          auVar28 = _objc_retainAutoreleasedReturnValue();
                          _objc_msgSend$setAttribute:forHandle:
                                    (uVar6,auVar28._8_8_,uVar21,auVar28._0_8_);
                          _objc_release(auVar28._0_8_);
                          _objc_release(uVar21);
                          lVar24 = lVar24 + 1;
                        } while (lVar11 != lVar24);
                        lVar11 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                           (uVar19,extraout_x1_11,&local_510,auStack_320,0x10);
                      } while (lVar11 != 0);
                    }
                    _objc_release(uVar19);
                    auVar28 = _objc_msgSend$count(uVar10);
                    uVar19 = auVar28._8_8_;
                    if (auVar28._0_8_ != 0) {
                      _objc_msgSend$setDescriptors:(uVar18,uVar19,uVar10);
                      uVar19 = extraout_x1_12;
                    }
                    _objc_msgSend$addObject:(uVar20,uVar19,uVar18);
                    _objc_msgSend$handle(uVar18);
                    auVar28 = _objc_retainAutoreleasedReturnValue();
                    _objc_msgSend$setAttribute:forHandle:(uVar6,auVar28._8_8_,uVar18,auVar28._0_8_);
                    _objc_release(auVar28._0_8_);
                    _objc_msgSend$valueHandle(uVar18);
                    auVar28 = _objc_retainAutoreleasedReturnValue();
                    _objc_msgSend$setAttribute:forHandle:(uVar6,auVar28._8_8_,uVar18,auVar28._0_8_);
                    _objc_release(auVar28._0_8_);
                    _objc_release(local_4a8);
                    _objc_release(uVar10);
                    _objc_release(uVar18);
                    lVar23 = lVar23 + 1;
                  } while (lVar23 != local_590);
                  local_590 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                        (uVar12,extraout_x1_09,&local_4a0,auStack_2a0,0x10);
                } while (local_590 != 0);
              }
              _objc_release(uVar12);
              auVar28 = _objc_msgSend$count(uVar20);
              uVar12 = auVar28._8_8_;
              if (auVar28._0_8_ != 0) {
                _objc_msgSend$setCharacteristics:(uVar16,uVar12,uVar20);
                uVar12 = extraout_x1_13;
              }
              _objc_msgSend$addObject:(uVar9,uVar12,uVar16);
              _objc_msgSend$startHandle(uVar16);
              auVar28 = _objc_retainAutoreleasedReturnValue();
              _objc_msgSend$setAttribute:forHandle:(uVar6,auVar28._8_8_,uVar16,auVar28._0_8_);
              _objc_release(auVar28._0_8_);
              _objc_release(uVar20);
              _objc_release(uVar16);
              lVar17 = lVar17 + 1;
            } while (lVar17 != local_5e0);
            local_5e0 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                  (uVar8,extraout_x1_05,&local_420,auStack_180,0x10);
          } while (local_5e0 != 0);
        }
        _objc_release(uVar8);
        uStack_528 = 0;
        local_530 = 0;
        uStack_518 = 0;
        uStack_520 = 0;
        lStack_548 = 0;
        local_550 = 0;
        uStack_538 = 0;
        local_540 = (long *)0x0;
        auVar26 = _objc_retain(auVar26._0_8_);
        uVar8 = auVar26._0_8_;
        auVar26 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                            (uVar8,auVar26._8_8_,&local_550,auStack_3a0,0x10);
        if (auVar26._0_8_ != 0) {
          lVar14 = *local_540;
          do {
            uVar16 = auVar26._8_8_;
            lVar17 = 0;
            do {
              if (*local_540 != lVar14) {
                _objc_enumerationMutation(uVar8);
                uVar16 = extraout_x1_15;
              }
              uVar20 = *(undefined8 *)(lStack_548 + lVar17 * 8);
              _objc_msgSend$objectForKeyedSubscript:(uVar20,uVar16,&cfstringStruct_1f1632fd8);
              uVar16 = _objc_retainAutoreleasedReturnValue();
              auVar28 = _objc_alloc(DAT_1e8ab8618);
              _objc_msgSend$objectForKeyedSubscript:(uVar20,auVar28._8_8_,&cfstringStruct_1f1632ff8)
              ;
              auVar29 = _objc_retainAutoreleasedReturnValue();
              uVar20 = _objc_msgSend$initWithPeripheral:dictionary:
                                 (auVar28._0_8_,auVar29._8_8_,0,auVar29._0_8_);
              _objc_release(auVar29._0_8_);
              local_580 = _DAT_1e8170ce8;
              local_578 = 0xc2000000;
              local_570 = ___41-[CBCentralManager_handleRestoringState:]_block_invoke.286;
              puStack_568 = &___block_descriptor_48_e8_32s40s_e26_v32_?0_"CBService"8Q16^B24l;
              local_560 = uVar20;
              local_558 = uVar16;
              uVar16 = _objc_retain(uVar16);
              auVar28 = _objc_retain(uVar20);
              _objc_msgSend$enumerateObjectsUsingBlock:(uVar9,auVar28._8_8_,&local_580);
              _objc_release(local_558);
              _objc_release(local_560);
              _objc_release(uVar16);
              _objc_release(auVar28._0_8_);
              lVar17 = lVar17 + 1;
              uVar16 = extraout_x1_14;
            } while (auVar26._0_8_ != lVar17);
            auVar26 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                                (uVar8,extraout_x1_14,&local_550,auStack_3a0,0x10);
          } while (auVar26._0_8_ != 0);
        }
        _objc_release(uVar8);
        auVar26 = _objc_msgSend$count(uVar9);
        uVar16 = auVar26._8_8_;
        if (auVar26._0_8_ != 0) {
          _objc_msgSend$setServices:(uVar6,uVar16,uVar9);
          uVar16 = extraout_x1_16;
        }
        _objc_msgSend$addObject:(uVar5,uVar16,uVar6);
        _objc_release(auVar27._0_8_);
        _objc_release(uVar8);
        _objc_release(uVar9);
        _objc_release(uVar6);
        lVar15 = lVar15 + 1;
        uVar9 = extraout_x1_02;
      } while (lVar15 != local_608);
      auVar26 = _objc_msgSend$countByEnumeratingWithState:objects:count:
                          (uVar7,extraout_x1_02,&local_3e0,auStack_100,0x10);
    } while (auVar26._0_8_ != 0);
  }
  _objc_release(uVar7);
  auVar26 = _objc_msgSend$count(uVar5);
  if (auVar26._0_8_ != 0) {
    _objc_msgSend$setObject:forKeyedSubscript:(uVar3,auVar26._8_8_,uVar5,0x1000007163a8b8);
  }
  _objc_msgSend$delegate(param_1);
  auVar26 = _objc_retainAutoreleasedReturnValue();
  _objc_msgSend$centralManager:willRestoreState:(auVar26._0_8_,auVar26._8_8_,param_1,uVar3);
  _objc_release(auVar26._0_8_);
  _objc_release(uVar5);
  _objc_release(lVar4);
  _objc_release(uVar3);
  _objc_release(uVar2);
  if (*_DAT_1e8170d08 == local_80) {
    return;
  }
                    /* WARNING: Subroutine does not return */
  ___stack_chk_fail();
}
```

</details>


As I understand it, this means that there is no delayed switching on or off in the isScanning flag, as this is set directly in `scanForPeripheralsWithServices_options_()` or `stopScan()`. So the observer is not necessary and the `isScanning` check only verifies whether the message was successfully transmitted to the Bluetooth daemon.

The only reason I can think of why the message to the Bluetooth daemon would fail is that Bluetooth has been disabled by the user.

However, there is currently no callback function to detect when Bluetooth is deactivated during scanning, such as `bluetooth_deactivated` for the `BleakScanner`, to notify the user that Bluetooth has been deactivated. This check is currently only performed once in `wait_until_ready`. If Bluetooth is turned off later, you simply have to wait for the scan timeout.

Therefore, I would suggest removing the `isScanning()` check completely and only reintroducing it if necessary when there is a callback function such as `bluetooth_deactivated` in `BleakScanner`, if that is desired at all.

**Problem that is solved:**
The current implementation can actually cause a deadlock with the following sequence:

1. Turn on Bluetooth manually
2. Start the scan process and set a breakpoint at `scanForPeripheralsWithServices_options_`. The `wait_until_ready` method has already run and checked the Bluetooth status.
3. Turn off Bluetooth manually
4. `isScanning` returns false and we wait for the future. However, this is never set, which results in an deadlock. Turning Bluetooth back on does not help either, because after turning Bluetooth on you have to call `scanForPeripheralsWithServices_options_` again.

This can be easily reproduced using the breakpoint, but in reality, the error is unlikely to occur because the user has to hit a very, very short timeframe in which to disable Bluetooth.

**Open Points:**
However, my analysis is based only on macOS 15.5 (Sequoia) and I was unable to check it with the CoreBluetooth library of macOS 10.15 (Catalina) (the minimum supported version for bleak) because I do not have such a system and therefore could not extract the library for reverse engineering.
