### PR TITLE
Raise exception when writing descriptor 0x2902 (CCCD)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Added
 Changed
 -------
 * Changed start/stop scanning on CoreBluetooth so that the ``isScanning`` property is not checked anymore.
+* Changed ``BleakClient.write_gatt_descriptor()`` to raise ``ValueError`` when attempting to write to the descriptor 0x2902 (Client Characteristic Configuration Descriptor, CCCD). Use ``start_notify()`` and ``stop_notify()`` instead.
+
 
 Fixed
 -----


### PR DESCRIPTION
The descriptor 0x2902 (Client Characteristic Configuration Descriptor, CCCD) should not be written, as this happens via `start_notify()` and `stop_notify()`. Under BlueZ and CoreBluetooth, this already causes an error from the OS. It works under WinRT, but it doesn't make sense there either.

To ensure a consistent approach and a meaningful error message, an exception is now thrown for all backends.

The following errors are currently shown without this PR:

BlueZ Backend (BlueZ v5.85):

```
reply = <Message ERROR serial=448 reply_serial=24 sender=:1.0 destination=:1.22 path=None interface=None member=None error_name=org.bluez.Error.NotPermitted signature=s body=['Write not permitted']>

    def assert_reply(reply: Message) -> None:
        """Checks that a D-Bus message is a valid reply.
    
        Raises:
            BleakDBusError: if the message type is ``MessageType.ERROR``
            AssertionError: if the message type is not ``MessageType.METHOD_RETURN``
        """
        if reply.message_type == MessageType.ERROR:
            assert reply.error_name
>           raise BleakDBusError(reply.error_name, reply.body)
E           bleak.exc.BleakDBusError: [org.bluez.Error.NotPermitted] Write not permitted
```


CoreBluetooth Backend (macOS Sequoia 15.5):

```
self = <bleak.backends.corebluetooth.PeripheralDelegate.PeripheralDelegate object at 0x1038e4e30>
descriptor = <CBDescriptor: 0x128f0cd30, UUID = Client Characteristic Configuration, value = (null)>
value = {length = 2, bytes = 0x0200}

    async def write_descriptor(self, descriptor: CBDescriptor, value: NSData) -> None:
        future = self.event_loop.create_future()
    
        self._descriptor_write_futures[descriptor.handle()] = future
        try:
>           self.peripheral.writeValue_forDescriptor_(value, descriptor)
E           objc.error: NSInternalInconsistencyException - Client Characteristic Configuration descriptors must be configured using setNotifyValue:forCharacteristic:
```