### PR TITLE
backends/bluezdbus/client: move D-Bus bus disconnect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed
 
 Fixed
 -----
+* Fixed occasional ``EOFError`` when disconnecting in BlueZ backend. Fixes #1921.
 * Fixed a potential deadlock when turning off Bluetooth manually while starting scanning on CoreBluetooth.
 * Fixed reading descriptors 0x2900, 0x2902 and 0x2903 on CoreBluetooth backend.
 


### PR DESCRIPTION
Move the D-Bus bus disconnect from `_cleanup_all()` to the `disconnect()` method. `_cleanup_all()` can be called when the peripheral initiates the disconnection, which can happen at any time. This can cause other in-progress calls to fail with an ``EOFError`` while they are waiting for a response from D-Bus.

To avoid this, we now only disconnect the D-Bus bus when the client `disconnect()` method is called. Users will still need to be careful about synchronization if they are using multiple concurrent tasks with the same client.

Closes: https://github.com/hbldh/bleak/issues/1921
