### PR TITLE
Update `pyproject.toml` to use more modern configuration

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2991,4 +2991,4 @@ pythonista = ["bleak-pythonista"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "277cf286ef89e354f3f0506e61fcf4803da6b83f06d5305445cb2c0373aea9dd"
+content-hash = "4d9c2eb023dd55ae4e62aa281223d093d57a770e58589176296fb9fe74e0c257"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,23 +42,22 @@ Issues = "https://github.com/hbldh/bleak/issues"
 [project.optional-dependencies]
 pythonista = ["bleak-pythonista>=0.1.1"]
 
-[tool.poetry.group.docs]
-optional = true
-
-[tool.poetry.group.docs.dependencies]
-Sphinx = { version = ">=8.2.3", python = ">=3.11" }
-sphinx-rtd-theme = { version = ">=3.0.2", python = ">=3.11" }
-
-[tool.poetry.group.lint.dependencies]
-black = ">=24.3,<25.0"
-flake8 = "^7.1.1"
-isort = "^5.13.2"
-
-[tool.poetry.group.test.dependencies]
-pytest = "^8.2.1"
-pytest-asyncio = "^1.2.0"
-pytest-cov = "^7.0.0 "
-bumble = "^0.0.220"
+[dependency-groups]
+docs = [
+    "Sphinx>=8.2.3; python_version>='3.11'",
+    "sphinx-rtd-theme>=3.0.2; python_version>='3.11'",
+]
+lint = [
+    "black>=24.3,<25.0",
+    "flake8>=7.1.1,<8.0.0",
+    "isort>=5.13.2,<6.0.0",
+]
+test = [
+    "pytest>=8.2.1,<9.0.0",
+    "pytest-asyncio>=1.2.0,<2.0.0",
+    "pytest-cov>=7.0.0,<8.0.0",
+    "bumble>=0.0.220,<0.1.0",
+]
 
 [build-system]
 requires = ["poetry-core>=2.0.0"]


### PR DESCRIPTION
This PR switches to the more modern configuration from [PEP621](https://peps.python.org/pep-0621) and [PEP735](https://peps.python.org/pep-0735). The poetry-specific sections are no longer needed.

The only functional change is that

```
[tool.poetry.group.docs]
optional = true
```

is now omitted, as there is no standard for this. This means that `docs` are also installed with `poetry install`. But I can't think of any reason why this optional is needed in practice.