### PR TITLE
Fixed typehint for BleakScanner.__aexit__().

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Fixed
 * Fixed a potential deadlock when turning off Bluetooth manually while starting scanning on CoreBluetooth.
 * Fixed reading descriptors 0x2900, 0x2902 and 0x2903 on CoreBluetooth backend.
 * Fixed cyclic references problem in CoreBluetooth backend causing memory leaks.
+* Fixed typehint for ``BleakScanner.__aexit__()``.
 
 `2.1.1`_ (2025-12-31)
 =====================

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -148,9 +148,9 @@ class BleakScanner:
 
     async def __aexit__(
         self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
+        exc_type: Optional[type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
     ) -> None:
         await self.stop()
 


### PR DESCRIPTION
The three arguments to __aexit__ are all set to None in case there is no exception. So the typehint should say Optional. This is how ``BleakClient.__aexit__()`` does it.
