### PR TITLE
docs: update troubleshooting guide for macOS 26.2

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -374,10 +374,14 @@ You will need to sign up for an Apple Developer account to obtain this software.
     logging profile from the Apple develop `Profiles and Logs`_ page. Follow the
     instruction provided in the link, then continue with the steps below.
 
-    .. tip:: After installing the ``Bluetooth_macOS.mobileconfig`` file, the
-             profile can be found in *System Settings* under *Privacy and Security*
-             > *Others* > *Profiles*. You have to go there to actually install
-             the profile. Then reboot your computer.
+    .. tip:: After installing the ``Bluetooth_macOS.mobileconfig`` file, 
+            the profile can be found in *System Settings* under *Device
+            Management* > *Downloaded*. There you can double-click to review
+            and install it. You have to go there to actually install the profile.
+            Then reboot your computer.
+            
+            If you are on macOS 14.x, the profile can be found on *System Settings*
+            under *Privacy and Security* > *Others* > *Profiles*.
 
     If you have an older version of macOS, you can skip this step.
 


### PR DESCRIPTION
Hi,

I was reading the troubleshooting and following "Capture Bluetooth Traffic" for macOS, I discovered that at least on my macOS 26.2, once the profile is downloaded and "installed", the place in which it appears is "Device Management" instead of "Privacy and Security", so I added a tip for locating it.

<img width="1402" height="574" alt="image" src="https://github.com/user-attachments/assets/e4804825-0667-4e97-a3d3-3b4f420d3cf0" />

It is my first contributing to this repository, so feel free to tell me whatever I need to do before continuing with this PR or if it is preferable another format for the tip. Whatever!

Regards
