### PR TITLE
Integration tests: Fix out of memory error

### DIFF
--- a/.github/alpine-vm/start-alpine-vm.sh
+++ b/.github/alpine-vm/start-alpine-vm.sh
@@ -159,7 +159,7 @@ boot_vm() {
     
     # Start QEMU with serial console output to file and 9p filesystem sharing
     qemu-system-x86_64 \
-        -m 512 \
+        -m 2G \
         -smp 2 \
         $KVM_FLAGS \
         -display none \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -89,7 +89,7 @@ jobs:
             export FORCE_COLOR=1
             export CI=true
             export GITHUB_ACTIONS=true
-            uv run --python ${{ matrix.python-version }} pytest -v tests --bleak-bluez-vhci -v --cov-report=xml --junitxml=junit.xml -o junit_family=legacy -o cache_dir=../.pytest_cache
+            uv run --python ${{ matrix.python-version }} pytest -v tests --bleak-bluez-vhci -v --cov-report=xml --cov-report=html:../.htmlcov --junitxml=junit.xml -o junit_family=legacy -o cache_dir=../.pytest_cache
           '
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
This will hopefully fix the out of memory error. I ran the pipeline 10x in Github Actions in my bleak fork repo without any problems.


```
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/_pytest/main.py", line 289, in wrap_session
INTERNALERROR>     session.exitstatus = doit(config, session) or 0
INTERNALERROR>                          ~~~~^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/_pytest/main.py", line 343, in _main
INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pluggy/_hooks.py", line 512, in __call__
INTERNALERROR>     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
INTERNALERROR>            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     raise exception
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>     ~~~~~~~~~~~~~~^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/_pytest/logging.py", line 801, in pytest_runtestloop
INTERNALERROR>     return (yield)  # Run all the tests.
INTERNALERROR>             ^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     teardown.throw(exception)
INTERNALERROR>     ~~~~~~~~~~~~~~^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/_pytest/terminal.py", line 688, in pytest_runtestloop
INTERNALERROR>     result = yield
INTERNALERROR>              ^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pluggy/_callers.py", line 152, in _multicall
INTERNALERROR>     teardown.send(result)
INTERNALERROR>     ~~~~~~~~~~~~~^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pytest_cov/plugin.py", line 359, in pytest_runtestloop
INTERNALERROR>     self.cov_total = self.cov_controller.summary(self.cov_report)
INTERNALERROR>                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pytest_cov/engine.py", line 55, in ensure_topdir_wrapper
INTERNALERROR>     return meth(self, *args, **kwargs)
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/pytest_cov/engine.py", line 207, in summary
INTERNALERROR>     total = self.cov.html_report(ignore_errors=True, directory=output)
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/coverage/control.py", line 1259, in html_report
INTERNALERROR>     return reporter.report(morfs)
INTERNALERROR>            ~~~~~~~~~~~~~~~^^^^^^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/coverage/html.py", line 381, in report
INTERNALERROR>     self.make_directory()
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~^^
INTERNALERROR>   File "/home/builder/.venv/lib/python3.14/site-packages/coverage/html.py", line 416, in make_directory
INTERNALERROR>     if not os.listdir(self.directory):
INTERNALERROR>            ~~~~~~~~~~^^^^^^^^^^^^^^^^
INTERNALERROR> OSError: [Errno 12] Out of memory: 'htmlcov'
```