### PR TITLE
ci: fix pyright error that was introduces with pyright v1.1.409

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,7 @@ async def create_hci_transport(
 ) -> AsyncGenerator[Transport, None]:
     """Create a bumble HCI Transport."""
     hci_transport_name: str | None = request.config.getoption("--bleak-hci-transport")
-    bluez_vhci_enabled: bool = request.config.getoption("--bleak-bluez-vhci")
+    bluez_vhci_enabled: bool | None = request.config.getoption("--bleak-bluez-vhci")
 
     if hci_transport_name is not None and bluez_vhci_enabled:
         raise pytest.UsageError(


### PR DESCRIPTION
pyright v1.1.409 was published a few days ago an that creates an CI error.

```
/...bleak/tests/integration/conftest.py
  /.../bleak/tests/integration/conftest.py:37:32 - error: Type "Any | None" is not assignable to declared type "bool"
    Type "Any | None" is not assignable to type "bool"
      "None" is not assignable to "bool" (reportAssignmentType)
1 error, 0 warnings, 0 informations
```