### PR TITLE
ci: a failing pyright run now also lets the CI job fail on windows.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,21 +45,23 @@ jobs:
           flags: ${{ matrix.os }}-py${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Type checking
-        # We don't do this in the lint job because we have conditionals
-        # on both the platform and the Python version in the code, so we
-        # need to check each matrix combination.
-        #
-        # We want always the latest version of pyright and mypy, to catch
-        # any breakage as soon as we can. That is why they are not dev
-        # dependencies in the pyproject.toml, because that would lock them to
-        # a specific version. Instead we install the latest version as tool.
+      # We don't do type checking in the lint job because we have conditionals
+      # on both the platform and the Python version in the code, so we
+      # need to check each matrix combination.
+      #
+      # We want always the latest version of pyright and mypy, to catch
+      # any breakage as soon as we can. That is why they are not dev
+      # dependencies in the pyproject.toml, because that would lock them to
+      # a specific version. Instead we install the latest version as tool.
+      - name: Type checking (pyright)
         run: |
           uv tool install pyright
           uv run pyright
+
+      - name: Type checking (mypy)
+        run: |
           uv tool install mypy
           uv run mypy -p bleak -p tests -p examples
-
 
   integration_tests_bluez:
     name: "BlueZ integration tests"


### PR DESCRIPTION
On windows a PowerShell is used instead of a bash. On a PowerShell only the last exit code is checked, so if pyright fails and mypy passes the CI is not failing.

I noticed this while working on https://github.com/hbldh/bleak/pull/1944.
