### PR TITLE
backends/bluez: change default to use StartNotify

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Changed
+-------
+* Changed default value of ``BlueZNotifyArgs.use_start_notify`` to ``False``. Fixes #1951.
+
 `3.0.1`_ (2026-03-25)
 =====================
 

--- a/bleak/args/bluez.py
+++ b/bleak/args/bluez.py
@@ -139,11 +139,9 @@ class BlueZNotifyArgs(TypedDict, total=False):
 
     use_start_notify: bool
     """
-    If true, use the "StartNotify" D-Bus method instead of "AcquireNotify" to
-    subscribe to notifications.
+    If false, use the "AcquireNotify" D-Bus method instead of "StartNotify" to
+    subscribe to notifications. The default is to use "StartNotify" for better
+    compatibility with most BLE devices.
 
-    This is needed in rare cases to work around BlueZ quirks. For example, some
-    peripherals may send notifications immediately after writing to the CCCD
-    descriptor, before the write response is sent. In this case, "AcquireNotify"
-    will miss the notification, whereas "StartNotify" will work correctly.
+    see :ref:`linux-start-notify` for more details.
     """

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -702,9 +702,11 @@ class BleakClientBlueZDBus(BaseBleakClient):
         if not self.is_connected:
             raise BleakError("Not connected")
 
+        char_path = characteristic.obj[0]
+
         if use_cached:
             manager = await get_global_bluez_manager()
-            return bytearray(manager.get_char_value(characteristic.obj[0]))
+            return bytearray(manager.get_char_value(char_path))
 
         while True:
             assert self._bus
@@ -712,7 +714,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             reply = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,
-                    path=characteristic.obj[0],
+                    path=char_path,
                     interface=defs.GATT_CHARACTERISTIC_INTERFACE,
                     member="ReadValue",
                     signature="a{sv}",
@@ -735,7 +737,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         logger.debug(
             "Read Characteristic %s | %s: %r",
             characteristic.uuid,
-            characteristic.obj[0],
+            char_path,
             value,
         )
 
@@ -803,13 +805,15 @@ class BleakClientBlueZDBus(BaseBleakClient):
         if not self.is_connected:
             raise BleakError("Not connected")
 
+        char_path = characteristic.obj[0]
+
         while True:
             assert self._bus
 
             reply = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,
-                    path=characteristic.obj[0],
+                    path=char_path,
                     interface=defs.GATT_CHARACTERISTIC_INTERFACE,
                     member="WriteValue",
                     signature="aya{sv}",
@@ -833,7 +837,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         logger.debug(
             "Write Characteristic %s | %s: %s",
             characteristic.uuid,
-            characteristic.obj[0],
+            char_path,
             data,
         )
 
@@ -938,6 +942,8 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         assert self._bus is not None
 
+        char_path: str = characteristic.obj[0]
+
         # If using StartNotify and calling a read on the same characteristic,
         # BlueZ will return the response as both a notification and read,
         # duplicating the message. Using AcquireNotify on supported
@@ -957,7 +963,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             reply = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,
-                    path=characteristic.obj[0],
+                    path=char_path,
                     interface=defs.GATT_CHARACTERISTIC_INTERFACE,
                     member="AcquireNotify",
                     body=[{}],
@@ -967,14 +973,14 @@ class BleakClientBlueZDBus(BaseBleakClient):
             assert_gatt_reply(reply)
 
             unix_fd = reply.unix_fds[0]
-            self._notification_fds[characteristic.obj[0]] = unix_fd
-            self._register_notify_fd_reader(characteristic.obj[0], unix_fd, callback)
+            self._notification_fds[char_path] = unix_fd
+            self._register_notify_fd_reader(char_path, unix_fd, callback)
         else:
-            self._notification_callbacks[characteristic.obj[0]] = callback
+            self._notification_callbacks[char_path] = callback
             reply = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,
-                    path=characteristic.obj[0],
+                    path=char_path,
                     interface=defs.GATT_CHARACTERISTIC_INTERFACE,
                     member="StartNotify",
                 )
@@ -994,10 +1000,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         assert self._bus is not None
 
+        char_path: str = characteristic.obj[0]
+
         # If we have a notification fd for this characteristic, then we know we
         # used AcquireNotify, otherwise we used StartNotify.
 
-        if (fd := self._notification_fds.get(characteristic.obj[0])) is not None:
+        if (fd := self._notification_fds.get(char_path)) is not None:
             logger.debug(
                 "Closing notification fd for characteristic %d", characteristic.handle
             )
@@ -1013,7 +1021,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             except OSError as e:
                 logger.debug("Failed to remove file descriptor %d: %s", fd, e)
 
-            self._notification_fds.pop(characteristic.obj[0], None)
+            self._notification_fds.pop(char_path, None)
 
         else:
             logger.debug(
@@ -1022,10 +1030,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
             reply = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,
-                    path=characteristic.obj[0],
+                    path=char_path,
                     interface=defs.GATT_CHARACTERISTIC_INTERFACE,
                     member="StopNotify",
                 )
             )
             assert_reply(reply)
-            self._notification_callbacks.pop(characteristic.obj[0], None)
+            self._notification_callbacks.pop(char_path, None)

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -994,28 +994,27 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         assert self._bus is not None
 
-        if "NotifyAcquired" in characteristic.obj[1]:
+        # If we have a notification fd for this characteristic, then we know we
+        # used AcquireNotify, otherwise we used StartNotify.
+
+        if (fd := self._notification_fds.get(characteristic.obj[0])) is not None:
             logger.debug(
                 "Closing notification fd for characteristic %d", characteristic.handle
             )
-            fd = self._notification_fds.pop(characteristic.obj[0], None)
 
-            if fd is None:
-                logger.debug(
-                    "No notification fd found for characteristic %d",
-                    characteristic.handle,
-                )
-            else:
-                loop = asyncio.get_running_loop()
-                try:
-                    loop.remove_reader(fd)
-                except RuntimeError:
-                    # Run loop is closed
-                    pass
-                try:
-                    os.close(fd)
-                except OSError as e:
-                    logger.debug("Failed to remove file descriptor %d: %s", fd, e)
+            loop = asyncio.get_running_loop()
+            try:
+                loop.remove_reader(fd)
+            except RuntimeError:
+                # Run loop is closed
+                pass
+            try:
+                os.close(fd)
+            except OSError as e:
+                logger.debug("Failed to remove file descriptor %d: %s", fd, e)
+
+            self._notification_fds.pop(characteristic.obj[0], None)
+
         else:
             logger.debug(
                 "Calling StopNotify for characteristic %d", characteristic.handle

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -923,25 +923,28 @@ class BleakClientBlueZDBus(BaseBleakClient):
         Activate notifications/indications on a characteristic.
 
         Args:
-            characteristic (BleakGATTCharacteristic): The characteristic to activate notification/indication on.
-            callback (NotifyCallback): The callback to call when a notification/indication is received.
+            characteristic: The characteristic to activate notification/indication on.
+            callback: The callback to call when a notification/indication is received.
 
         Keyword Args:
-            bluez (dict): dictionary of additional parameters, see :ref:`linux-start-notify` for more details.
+            bluez (BlueZNotifyArgs): dictionary of additional parameters.
         """
 
         bluez: BlueZNotifyArgs = kwargs["bluez"]
-        force_use_start_notify = bluez.get("use_start_notify", False)
+        # A number of devices have issues with AcquireNotify, so we use StartNotify
+        # by default. For cases where AcquireNotify does work, users can set
+        # "use_start_notify" to False.
+        force_use_start_notify = bluez.get("use_start_notify", True)
 
         assert self._bus is not None
 
-        # If using StartNotify and calling a read on the same
-        # characteristic, BlueZ will return the response as
-        # both a notification and read, duplicating the message.
-        # Using AcquireNotify on supported characteristics avoids this.
-        # However, using the preferred AcquireNotify requires that devices
-        # correctly indicate "notify" and/or "indicate" properties. If they
-        # don't, we fall back to StartNotify.
+        # If using StartNotify and calling a read on the same characteristic,
+        # BlueZ will return the response as both a notification and read,
+        # duplicating the message. Using AcquireNotify on supported
+        # characteristics avoids this. However, using the preferred
+        # AcquireNotify requires that devices correctly indicate "notify"
+        # and/or "indicate" properties. If they don't, we fall back to
+        # StartNotify anyway.
         use_notify_acquire = (
             not force_use_start_notify and "NotifyAcquired" in characteristic.obj[1]
         )

--- a/docs/backends/linux.rst
+++ b/docs/backends/linux.rst
@@ -23,12 +23,19 @@ services immediately, but don't want to wait for them to be resolved again.
 
 Enabling notification/indication with ``start_notify``
 ------------------------------------------------------
-Calling ``start_notify`` will by default adhere to the properties reported by
-the device assuming it correctly indicates "notify" and/or "indicate" properties.
-Some devices do not properly support AcquireNotify although reported. In such
-cases, you can force using StartNotify instead of AcquireNotify for notifications,
-even if AcquireNotify is supported by the characteristic. You can do so, by setting
-``{"use_start_notify": True}`` to the ``bluez`` parameter.
+BlueZ has two different methods of subscribing to notifications/indications:
+"StartNotify" and "AcquireNotify". For best compatibility, Bleak defaults to
+using "StartNotify". However, in cases where there is a characteristic that
+needs to be read after the notification is received to get the full data, using
+"AcquireNotify" is recommended to avoid receiving notifications for the both
+the notification and the read operation. To do this, pass ``bluez={"use_start_notify": False}``.
+to ``start_notify``.
+
+Briefly, in Bleak v3.0.0 and v3.0.1, "AcquireNotify" was used by default, but
+this caused issues with a number of devices, so the default was changed back to
+"StartNotify". If you have an affected device and need to support these versions
+of Bleak, you can set ``bluez={"use_start_notify": True}`` to make it work on
+all versions of Bleak.
 
 
 Parallel Access

--- a/tests/integration/test_issue_1885.py
+++ b/tests/integration/test_issue_1885.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import pytest
 from bumble.att import Attribute, AttributeValue
 from bumble.device import Connection, Device
 from bumble.gatt import (
@@ -20,7 +21,9 @@ TEST_SERVICE_UUID = "9d513f40-5c89-42dc-9688-2cfa30f2d9e7"
 TEST_CHARACTERISTIC_UUID = "e809cb2f-34e3-42a1-ba92-22db2495cd6a"
 
 
+@pytest.mark.parametrize("use_start_notify", [True, False])
 async def test_notification_sent_before_write_response(
+    use_start_notify: bool,
     bumble_peripheral: Device,
 ) -> None:
     """
@@ -73,12 +76,18 @@ async def test_notification_sent_before_write_response(
             notification_queue.put_nowait(bytes(data))
 
         await client.start_notify(
-            TEST_CHARACTERISTIC_UUID, on_notification, bluez={"use_start_notify": True}
+            TEST_CHARACTERISTIC_UUID,
+            on_notification,
+            bluez={"use_start_notify": use_start_notify},
         )
 
         # In BlueZ, the notification is not received when using "AcquireNotify"
         # causing this to timeout.
 
-        data = await asyncio.wait_for(notification_queue.get(), timeout=3)
+        if use_start_notify:
+            data = await asyncio.wait_for(notification_queue.get(), timeout=3)
 
-        assert data == b"test"
+            assert data == b"test"
+        else:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(notification_queue.get(), timeout=3)

--- a/tests/integration/test_issue_1885.py
+++ b/tests/integration/test_issue_1885.py
@@ -91,3 +91,8 @@ async def test_notification_sent_before_write_response(
         else:
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(notification_queue.get(), timeout=3)
+
+        # Normally we don't bother with calling stop_notify() but we are doing
+        # it here just to get code coverage since this is the only test where
+        # we are setting use_start_notify.
+        await client.stop_notify(TEST_CHARACTERISTIC_UUID)


### PR DESCRIPTION
In commit 9b559c52 ("backends/bluezdbus: allow forcing StartNotify over AcquireNotify"), we change the default behavior for the BlueZ backend to use "AcquireNotify" instead of "StartNotify". In practice, this caused issues with a number of devices, so we are changing the default back to "StartNotify". The parameter still exists to allow users to use "AcquireNotify" if needed, but it is now opt-in instead of the default, so users will need to update their code if they want to use "AcquireNotify" from now on.

It also turns out there was an additional bug that if you did opt into using "StartNotify" and tried to call `client.stop_notify()`, it would silently do nothing and not actually stop notifications. A second commit has been added to fix that.

FYI: @lkempf, @patman15, @Raupinger

Closes: https://github.com/hbldh/bleak/issues/1951
