### PR TITLE
backends: set BluetoothLEAdvertisementWatcher.AllowExtendedAdvertisements  when availalble only

### DIFF
--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -269,7 +269,12 @@ class BleakScannerWinRT(BaseBleakScanner):
         self.watcher = BluetoothLEAdvertisementWatcher()
         self.watcher.scanning_mode = self._scanning_mode
         # BlueZ and CoreBluetooth don't allow controlling this and always enabled it, so do the same here
-        self.watcher.allow_extended_advertisements = True
+        try:
+            self.watcher.allow_extended_advertisements = True
+        except AttributeError:
+            logger.warning(
+                "Extended advertisements are not available in this OS Version."
+            )
 
         event_loop = asyncio.get_running_loop()
         self._stopped_event = asyncio.Event()


### PR DESCRIPTION
Set allow_extended_advertisements when available only. Older windows version before 19041 do not support the option. In this case Bleak fails with "property is not available in this version of Windows".

https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementwatcher.allowextendedadvertisements
