### PR TITLE
backends/bluez: don't disconnect devices we did not connect

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,6 +25,7 @@ Contributors
 * JP Hutchins <jphutchins@gmail.com>
 * Bram Duvigneau <bram@bramd.nl>
 * Dmytro Yaroshenko <thehelixpg@gmail.com>
+* Kirill Rudovski <kirill.r@wearabledevices.co.il>
 
 And many others who did not wish to be named here.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 `Unreleased`_
 =============
 
+Fixed
+-----
+* ``BleakClientBlueZDBus.disconnect()`` no longer disconnects from the device after "connecting" to an already connected device. Merged #1975.
+
 `3.0.2`_ (2026-05-02)
 =====================
 

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -102,6 +102,12 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # used to override mtu_size property
         self._mtu_size: Optional[int] = None
 
+        # True if this BleakClient instance initiated the BlueZ connection.
+        # When False, the device was already connected at the time connect()
+        # was called, so disconnect() will not call BlueZ Disconnect.
+        # See https://github.com/bluez/bluez/issues/89
+        self._owns_connection = False
+
     # Connectivity methods
 
     @override
@@ -210,7 +216,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
                         # if connection was successful but _get_services() raises (e.g.
                         # because task was cancelled), then we still need to disconnect
                         # before passing on the exception.
-                        if self._bus:
+                        # If the device was already connected when connect() was called,
+                        # this BleakClient does not own the connection and must not
+                        # tear it down.
+                        if self._bus and self._owns_connection:
                             # If disconnected callback already fired, this will be a no-op
                             # since self._bus will be None and the _cleanup_all call will
                             # have already disconnected.
@@ -250,8 +259,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
                             'skipping calling "Connect" since %s is already connected',
                             self._device_path,
                         )
+                        self._owns_connection = False
                     else:
                         logger.debug("Connecting to BlueZ path %s", self._device_path)
+                        self._owns_connection = True
 
                         # Calling pair will fail if we are already paired, so
                         # in that case we just call Connect.
@@ -405,19 +416,29 @@ class BleakClientBlueZDBus(BaseBleakClient):
             self._disconnecting_event = asyncio.Event()
             try:
                 if self.is_connected:
-                    # Try to disconnect the actual device/peripheral
-                    reply = await self._bus.call(
-                        Message(
-                            destination=defs.BLUEZ_SERVICE,
-                            path=self._device_path,
-                            interface=defs.DEVICE_INTERFACE,
-                            member="Disconnect",
+                    if self._owns_connection:
+                        # Disconnect the actual device/peripheral. The manager
+                        # will fire the on_connected_changed handler which calls
+                        # _cleanup_all() and sets _disconnecting_event.
+                        reply = await self._bus.call(
+                            Message(
+                                destination=defs.BLUEZ_SERVICE,
+                                path=self._device_path,
+                                interface=defs.DEVICE_INTERFACE,
+                                member="Disconnect",
+                            )
                         )
-                    )
-                    assert_reply(reply)
+                        assert_reply(reply)
 
-                    async with async_timeout(10):
-                        await self._disconnecting_event.wait()
+                        async with async_timeout(10):
+                            await self._disconnecting_event.wait()
+                    else:
+                        # We did not initiate the connection (the device was
+                        # already connected when connect() was called), so
+                        # leave it connected. Clean up our local state since
+                        # no BlueZ "Connected"=false signal will fire.
+                        self._is_connected = False
+                        self._cleanup_all()
             finally:
                 self._disconnecting_event = None
 

--- a/tests/integration/test_client_connecting.py
+++ b/tests/integration/test_client_connecting.py
@@ -5,6 +5,7 @@ from bumble.device import Device
 
 from bleak import BleakClient
 from bleak._compat import timeout as async_timeout
+from bleak.backends import BleakBackend, get_default_backend
 from tests.integration.conftest import (
     configure_and_power_on_bumble_peripheral,
     find_ble_device,
@@ -61,6 +62,35 @@ async def test_is_connected(bumble_peripheral: Device):
     async with BleakClient(device) as client:
         assert client.is_connected is True
     assert client.is_connected is False
+
+
+@pytest.mark.skipif(
+    get_default_backend() != BleakBackend.BLUEZ_DBUS,
+    reason="reuse-existing-connection behavior is BlueZ-specific",
+)
+async def test_disconnect_does_not_disconnect_already_connected_device(
+    bumble_peripheral: Device,
+):
+    """A second BleakClient that finds the device already connected must not
+    disconnect it when closed. See https://github.com/bluez/bluez/issues/89.
+    """
+    await configure_and_power_on_bumble_peripheral(bumble_peripheral)
+
+    device = await find_ble_device(bumble_peripheral)
+
+    async with BleakClient(device) as outer_client:
+        # Nested BleakClients are not a supported usage pattern, but it
+        # is the simplest way to exercise the already-connected code path.
+        async with BleakClient(device) as inner_client:
+            # If this is false, it is a bug in Bleak. Real usage never needs
+            # to check `is_connected` after connecting because it cannot be
+            # anything but true. If connecting fails, an exception is raised
+            # before we get here.
+            assert inner_client.is_connected
+
+        assert (
+            outer_client.is_connected
+        ), "inner client disconnect should not disconnect outer client"
 
 
 async def test_disconnect_callback(bumble_peripheral: Device):


### PR DESCRIPTION
## Summary                                                                                                                                                                                 
   
When a `BleakClient` is constructed for a device that is already connected (e.g. connected by another process), `connect()` already correctly skips the BlueZ `Connect` call. However, `disconnect()` would still tear down the connection, since BlueZ does not do reference counting for connection requests.

This adds an `_owns_connection` flag to `BleakClientBlueZDBus` so that `disconnect()` only calls BlueZ `Disconnect` when this instance actually initiated the connection. Local state (`_cleanup_all()`) is still cleared either way.

Discussed in #1966 and tracked in https://github.com/bluez/bluez/issues/89.
FYI: @dlech

## Test plan
- [ ] Manual test on Linux: outer `BleakClient` connects, inner `BleakClient` "connects" to same device, inner exits, outer is still connected, outer exits, BlueZ disconnects.