### PR TITLE
bleak: cache BleakAdapter instances per event loop

### DIFF
--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -9,9 +9,19 @@ import logging
 import os
 import sys
 import uuid
-from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
+from collections.abc import AsyncGenerator, Awaitable, Callable, Hashable, Iterable
 from types import TracebackType
-from typing import Any, Literal, Optional, TypedDict, Union, cast, overload
+from typing import (
+    Any,
+    ClassVar,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+    cast,
+    final,
+    overload,
+)
 from warnings import warn
 
 from bleak._compat import Never, Self, Unpack, assert_never
@@ -424,6 +434,7 @@ class BleakScanner:
                 return None
 
 
+@final
 class BleakAdapter:
     """
     Interface for Bleak Bluetooth adapter operations.
@@ -437,6 +448,17 @@ class BleakAdapter:
     .. versionadded:: unreleased
     """
 
+    _instances: ClassVar[
+        dict[
+            tuple[
+                asyncio.AbstractEventLoop,
+                type[BaseBleakAdapter],
+                Hashable,
+            ],
+            "BleakAdapter",
+        ]
+    ] = {}
+
     def __init__(self, backend: BaseBleakAdapter):
         self._backend = backend
 
@@ -446,13 +468,16 @@ class BleakAdapter:
         *,
         bluez: BlueZAdapterArgs = {},
         backend: Optional[type[BaseBleakAdapter]] = None,
-    ) -> Self:
+    ) -> "BleakAdapter":
         """
         Get a Bluetooth adapter for the current platform.
 
         Currently all platforms other than Linux only allow one Bluetooth
         adapter. On Linux, the adapter can be selected via the ``bluez``
         argument with ``{"adapter": "<adapter_name>"}``.
+
+        Repeated calls from the same running event loop with the same
+        adapter selection return the same :class:`BleakAdapter` instance.
 
         Args:
             bluez:
@@ -472,7 +497,23 @@ class BleakAdapter:
             if backend is None
             else (backend, backend.__name__)
         )
-        return cls(await PlatformBleakAdapter.get(bluez=bluez))
+        loop = asyncio.get_running_loop()
+        key = (loop, PlatformBleakAdapter, PlatformBleakAdapter.cache_key(bluez=bluez))
+
+        try:
+            return cls._instances[key]
+        except KeyError:
+            pass
+
+        # Lazily clean up entries for closed loops so the cache does not
+        # accumulate over time. Mirrors the pattern in
+        # ``bleak.backends.bluezdbus.manager._global_instances``.
+        for closed_key in [k for k in cls._instances if k[0].is_closed()]:
+            del cls._instances[closed_key]
+
+        instance = cls(await PlatformBleakAdapter.get(bluez=bluez))
+        cls._instances[key] = instance
+        return instance
 
     async def get_connected_devices(
         self,

--- a/bleak/backends/adapter.py
+++ b/bleak/backends/adapter.py
@@ -1,3 +1,4 @@
+from collections.abc import Hashable
 from typing import Any
 
 from bleak._compat import Self
@@ -30,6 +31,18 @@ class BaseBleakAdapter:
             NotImplementedError: if the current backend does not support this.
         """
         raise NotImplementedError("get is not implemented for this backend")
+
+    @classmethod
+    def cache_key(cls, **kwargs: Any) -> Hashable:
+        """
+        Return a value used to differentiate cached :class:`BleakAdapter`
+        instances for this backend.
+
+        Subclasses override this to differentiate by backend-specific args
+        (e.g. the BlueZ adapter name). The default returns ``None``, which
+        means a single cache entry per (loop, backend type).
+        """
+        return None
 
     async def get_connected_devices(
         self, service_uuids: frozenset[str]

--- a/bleak/backends/bluezdbus/adapter.py
+++ b/bleak/backends/bluezdbus/adapter.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     if sys.platform != "linux":
         assert False, "This backend is only available on Linux"
 
+from collections.abc import Hashable
 from typing import Any
 
 from bleak._compat import Self, override
@@ -29,6 +30,11 @@ class BleakAdapterBlueZDBus(BaseBleakAdapter):
             f"/org/bluez/{adapter}" if adapter else manager.get_default_adapter()
         )
         return cls(adapter_path)
+
+    @classmethod
+    @override
+    def cache_key(cls, *, bluez: BlueZAdapterArgs = {}, **kwargs: Any) -> Hashable:
+        return bluez.get("adapter")
 
     @override
     async def get_connected_devices(

--- a/tests/integration/test_adapter.py
+++ b/tests/integration/test_adapter.py
@@ -73,6 +73,15 @@ async def connected_peripheral(
 
 
 @pytest.mark.asyncio(loop_scope="module")
+@pytest.mark.usefixtures("hci_transport")
+async def test_get_returns_same_instance_on_second_call() -> None:
+    """``BleakAdapter.get()`` returns the same instance on repeated calls."""
+    a = await BleakAdapter.get()
+    b = await BleakAdapter.get()
+    assert a is b
+
+
+@pytest.mark.asyncio(loop_scope="module")
 async def test_get_connected_devices_without_filters_returns_non_empty(
     connected_peripheral: ConnectedPeripheral,
 ) -> None:


### PR DESCRIPTION
`BleakAdapter.get()` now returns the same `BleakAdapter` instance on repeated calls from the same event loop with the same adapter selection. The cache is keyed by (loop, `PlatformBleakAdapter`, `adapter_path`), so different adapters selected via `bluez={"adapter": ...}` get distinct instances.

Mirrors the pattern in `bleak.backends.bluezdbus.manager._global_instances` introduced in 1be914c.
