### PR TITLE
tests/integration/test_client_characteristics: wait for indication data

### DIFF
--- a/tests/integration/test_client_characteristics.py
+++ b/tests/integration/test_client_characteristics.py
@@ -370,8 +370,7 @@ async def test_indicate_gatt_char(
         b"ind1",
     )
 
-    # dont wait since 'indicate_subscriber' waits for ack from client
-    data = indicated_data.get_nowait()
+    data = await asyncio.wait_for(indicated_data.get(), timeout=1)
     assert data == b"ind1"
 
     await char_test_peripheral.bumble_peripheral.indicate_subscriber(  # type: ignore  # (missing type hints in bumble)
@@ -380,8 +379,7 @@ async def test_indicate_gatt_char(
         b"ind2",
     )
 
-    # dont wait since 'indicate_subscriber' waits for ack from client
-    data = indicated_data.get_nowait()
+    data = await asyncio.wait_for(indicated_data.get(), timeout=1)
     assert data == b"ind2"
 
     await char_test_peripheral.bleak_client.stop_notify(INDICATE_CHAR_UUID)


### PR DESCRIPTION
`test_indicate_gatt_char()` occasionally fails on the `get_nowait()` calls in the BlueZ backend.

The logic in the removed comments was perhaps flawed. It is logical that `indicate_subscriber()` should not return until all Bluetooth I/O is done. However, BlueZ may not be waiting for D-Bus signals to complete before considering the indication to be done.

Waiting for data asynchronously should fix the issues. It is difficult to reproduce though, so we will have to wait and see.

Fixes: https://github.com/hbldh/bleak/issues/1980
