### PR TITLE
Add BLE pairing agent (Windows + Linux)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 -----
 * Added ``BleakAdapter`` class with ``get_connected_devices()`` to retrieve BLE devices that are already connected to the system without scanning.
+* Added BLE pairing agent support for Windows and Linux. ``BleakClient`` accepts a ``pairing_callbacks`` argument (and ``pair()`` a ``callbacks`` argument) taking a ``bleak.agent.PairingCallbacks`` to take part in the Numeric Comparison and Passkey Entry pairing ceremonies.
+* Added ``bleak.agent`` module with ``PairingCallbacks``, ``ConfirmPasskey``, ``RequestPasskey``, ``DisplayPasskey``, and ``IOCapability``.
 
 Fixed
 -----
@@ -100,7 +102,6 @@ Changed
 * Use ``"AcquireNotify"`` rather than ``"StartNotify"`` for Linux backend on supported characteristics
 * Allow multiple calls to ``disconnect()`` on Windows to align behavior over all backends.
 * Raise new ``BleakBluetoothNotAvailableError`` when Bluetooth is not supported, turned off or permission is denied.
-* Added ``pairing_callbacks`` parameter to ``BleakClient()`` constructor to support the different pairing methods.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -100,6 +100,7 @@ Changed
 * Use ``"AcquireNotify"`` rather than ``"StartNotify"`` for Linux backend on supported characteristics
 * Allow multiple calls to ``disconnect()`` on Windows to align behavior over all backends.
 * Raise new ``BleakBluetoothNotAvailableError`` when Bluetooth is not supported, turned off or permission is denied.
+* Added ``pairing_callbacks`` parameter to ``BleakClient()`` constructor to support the different pairing methods.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -16,6 +16,7 @@ from warnings import warn
 
 from bleak._compat import Never, Self, Unpack, assert_never
 from bleak._compat import timeout as async_timeout
+from bleak.agent import BaseBleakAgentCallbacks
 from bleak.args import SizedBuffer
 from bleak.args.bluez import (
     BlueZAdapterArgs,
@@ -557,6 +558,13 @@ class BleakClient:
             Callback that will be scheduled in the event loop when the client is
             disconnected. The callable must take one argument, which will be
             this client object.
+        pairing_callbacks:
+            Optional callbacks used in the pairing process (e.g. displaying,
+            confirming, requesting pin). If provided here instead of to the
+            :meth:`pair` method as ``callbacks`` parameter, device will be
+            implicitly paired during connection establishment. This is useful
+            for devices sending Slave Security Request immediately after
+            connection, requiring pairing before GATT service discovery.
         services:
             Optional list of services to filter. If provided, only these services
             will be resolved. This may or may not reduce the time needed to
@@ -622,6 +630,7 @@ class BleakClient:
         address_or_ble_device: Union[BLEDevice, str],
         disconnected_callback: Optional[Callable[[BleakClient], None]] = None,
         services: Optional[Iterable[str]] = None,
+        pairing_callbacks: Optional[BaseBleakAgentCallbacks] = None,
         *,
         timeout: float = 30,
         pair: bool = False,
@@ -658,6 +667,7 @@ class BleakClient:
             services=(
                 None if services is None else set(map(normalize_uuid_str, services))
             ),
+            pairing_callbacks=pairing_callbacks,
             timeout=timeout,
             bluez=bluez,
             winrt=winrt,

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -16,7 +16,7 @@ from warnings import warn
 
 from bleak._compat import Never, Self, Unpack, assert_never
 from bleak._compat import timeout as async_timeout
-from bleak.agent import BaseBleakAgentCallbacks
+from bleak.agent import PairingCallbacks
 from bleak.args import SizedBuffer
 from bleak.args.bluez import (
     BlueZAdapterArgs,
@@ -630,7 +630,7 @@ class BleakClient:
         address_or_ble_device: Union[BLEDevice, str],
         disconnected_callback: Optional[Callable[[BleakClient], None]] = None,
         services: Optional[Iterable[str]] = None,
-        pairing_callbacks: Optional[BaseBleakAgentCallbacks] = None,
+        pairing_callbacks: Optional[PairingCallbacks] = None,
         *,
         timeout: float = 30,
         pair: bool = False,

--- a/bleak/agent.py
+++ b/bleak/agent.py
@@ -1,0 +1,27 @@
+import abc
+
+from .backends.device import BLEDevice
+
+
+class BaseBleakAgentCallbacks(abc.ABC):
+    @abc.abstractmethod
+    async def request_passkey(self, device: BLEDevice) -> str:
+        """
+        Implementers should ask the user the passkey displayed on the device.
+
+        Returns:
+            Passkey provided by the user
+        """
+
+    @abc.abstractmethod
+    async def confirm_passkey(self, device: BLEDevice, passkey: str) -> bool:
+        """
+        Implementers should display the passkey code to the user and prompt the
+        user to validate the passkey code and confirm or reject the pairing request.
+
+        Args:
+            pin: The passkey to be confirmed.
+
+        Returns:
+            ``True`` to accept the pairing request or ``False`` to reject it.
+        """

--- a/bleak/agent.py
+++ b/bleak/agent.py
@@ -1,27 +1,130 @@
-import abc
+"""
+Pairing agent
+-------------
 
-from .backends.device import BLEDevice
+Types for participating in the BLE pairing ceremony.
+
+A :class:`PairingCallbacks` is a collection of optional asynchronous handlers,
+one per ceremony that the application is able to take part in. Which handlers
+are provided determines the input/output capability that Bleak advertises to
+the peer, and therefore which `Security Manager`_ pairing method is negotiated:
+
+============================================  =====================  =======================
+Provided callbacks                            Capability             Ceremony
+============================================  =====================  =======================
+(none)                                        ``NoInputNoOutput``    Just Works
+``confirm``                                   ``DisplayYesNo``       Numeric Comparison
+``request_passkey``                           ``KeyboardOnly``       Passkey Entry (input)
+``display_passkey``                           ``DisplayOnly``        Passkey Entry (output)
+``request_passkey`` + ``display_passkey``     ``KeyboardDisplay``    Passkey Entry (either)
+============================================  =====================  =======================
+
+.. _Security Manager: https://www.bluetooth.com/specifications/specs/core-specification/
+"""
+
+from collections.abc import Awaitable, Callable
+from enum import Enum, auto
+from typing import Final, NamedTuple, TypeAlias
+
+from bleak.backends.device import BLEDevice
+
+MAX_PASSKEY: Final = 999999
+"""The largest valid BLE passkey; passkeys are six decimal digits (000000-999999)."""
 
 
-class BaseBleakAgentCallbacks(abc.ABC):
-    @abc.abstractmethod
-    async def request_passkey(self, device: BLEDevice) -> str:
-        """
-        Implementers should ask the user the passkey displayed on the device.
+class ConfirmPasskey(NamedTuple):
+    """Request to confirm that the passkey shown by both devices matches.
 
-        Returns:
-            Passkey provided by the user
-        """
+    Delivered to :attr:`PairingCallbacks.confirm` during the Numeric Comparison
+    ceremony. The callback returns ``True`` to accept the pairing or ``False``
+    to reject it.
+    """
 
-    @abc.abstractmethod
-    async def confirm_passkey(self, device: BLEDevice, passkey: str) -> bool:
-        """
-        Implementers should display the passkey code to the user and prompt the
-        user to validate the passkey code and confirm or reject the pairing request.
+    device: BLEDevice
+    passkey: int
 
-        Args:
-            pin: The passkey to be confirmed.
 
-        Returns:
-            ``True`` to accept the pairing request or ``False`` to reject it.
-        """
+class RequestPasskey(NamedTuple):
+    """Request to enter the passkey displayed by the peer device.
+
+    Delivered to :attr:`PairingCallbacks.request_passkey` during the Passkey
+    Entry ceremony when the local device is the input. The callback returns the
+    passkey as an integer in the range ``0``..``999999``, or ``None`` to reject
+    the pairing.
+    """
+
+    device: BLEDevice
+
+
+class DisplayPasskey(NamedTuple):
+    """Request to display a passkey for the user to enter on the peer device.
+
+    Delivered to :attr:`PairingCallbacks.display_passkey` during the Passkey
+    Entry ceremony when the local device is the output. The peer completes the
+    ceremony when the user enters this passkey there.
+    """
+
+    device: BLEDevice
+    passkey: int
+
+
+PairingRequest: TypeAlias = ConfirmPasskey | RequestPasskey | DisplayPasskey
+"""A request the peer raises during pairing, handled by a :class:`PairingCallbacks`."""
+
+
+ConfirmCallback: TypeAlias = Callable[[ConfirmPasskey], Awaitable[bool]]
+RequestPasskeyCallback: TypeAlias = Callable[[RequestPasskey], Awaitable[int | None]]
+DisplayPasskeyCallback: TypeAlias = Callable[[DisplayPasskey], Awaitable[None]]
+
+
+class PairingCallbacks(NamedTuple):
+    """Application-provided handlers for the BLE pairing ceremony.
+
+    Each field is an asynchronous callback invoked when the peer initiates the
+    corresponding ceremony. A field left as ``None`` means the application
+    cannot take part in that ceremony; the set of provided callbacks determines
+    the advertised :class:`IOCapability` (see :func:`io_capability`). With no
+    callbacks the Just Works ceremony is used and accepted automatically.
+    """
+
+    confirm: ConfirmCallback | None = None
+    request_passkey: RequestPasskeyCallback | None = None
+    display_passkey: DisplayPasskeyCallback | None = None
+
+
+class IOCapability(Enum):
+    """The input/output capability advertised to the peer during pairing.
+
+    These mirror the Bluetooth Security Manager IO capabilities and the names
+    used by the BlueZ agent API.
+    """
+
+    NO_INPUT_NO_OUTPUT = auto()
+    """No way to display a six-digit value and no way to enter one or answer yes/no."""
+
+    DISPLAY_YES_NO = auto()
+    """Can display a six-digit value and has two buttons the user can map to yes and no."""
+
+    KEYBOARD_ONLY = auto()
+    """Can enter the digits 0-9 and answer yes/no, but cannot display a value."""
+
+    DISPLAY_ONLY = auto()
+    """Can display a six-digit value but has no input to enter one or answer yes/no."""
+
+    KEYBOARD_DISPLAY = auto()
+    """Can both display a six-digit value and enter one; LE only."""
+
+
+def io_capability(callbacks: PairingCallbacks) -> IOCapability:
+    """Derive the advertised :class:`IOCapability` from the provided callbacks."""
+    can_input = callbacks.request_passkey is not None
+    can_display = callbacks.display_passkey is not None
+    if can_input and can_display:
+        return IOCapability.KEYBOARD_DISPLAY
+    if can_input:
+        return IOCapability.KEYBOARD_ONLY
+    if can_display:
+        return IOCapability.DISPLAY_ONLY
+    if callbacks.confirm is not None:
+        return IOCapability.DISPLAY_YES_NO
+    return IOCapability.NO_INPUT_NO_OUTPUT

--- a/bleak/backends/bluezdbus/agent.py
+++ b/bleak/backends/bluezdbus/agent.py
@@ -1,0 +1,210 @@
+"""
+Agent
+-----
+
+This module contains types associated with the BlueZ D-Bus `agent api
+<https://github.com/bluez/bluez/blob/master/doc/agent-api.txt>`.
+"""
+
+import asyncio
+import contextlib
+import logging
+import os
+from typing import Set, no_type_check
+
+from dbus_fast import DBusError, Message
+from dbus_fast.aio import MessageBus
+from dbus_fast.service import ServiceInterface, method
+from dbus_fast.signature import Variant
+
+from bleak.agent import BaseBleakAgentCallbacks
+from bleak.backends.bluezdbus import defs
+from bleak.backends.bluezdbus.manager import get_global_bluez_manager
+from bleak.backends.bluezdbus.utils import assert_reply
+from bleak.backends.device import BLEDevice
+
+logger = logging.getLogger(__name__)
+
+
+class Agent(ServiceInterface):
+    """
+    Implementation of the org.bluez.Agent1 D-Bus interface.
+    """
+
+    def __init__(self, callbacks: BaseBleakAgentCallbacks):
+        """
+        Args:
+        """
+        super().__init__(defs.AGENT_INTERFACE)
+        self._callbacks = callbacks
+        self._tasks: Set[asyncio.Task] = set()
+
+    @staticmethod
+    async def _create_ble_device(device_path: str) -> BLEDevice:
+        manager = await get_global_bluez_manager()
+        return BLEDevice(
+            manager.get_device_address(device_path),
+            manager.get_device_name(device_path),
+            {"path": device_path},
+        )
+
+    @method()
+    def Release(self):  # noqa: N802
+        logger.debug("Release")
+
+    # REVISIT: mypy is broke, so we have to add redundant @no_type_check
+    # https://github.com/python/mypy/issues/6583
+
+    @method()
+    @no_type_check
+    async def RequestPinCode(self, device: "o") -> "s":  # noqa: F821 N802
+        logger.debug("RequestPinCode %s", device)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def DisplayPinCode(self, device: "o", pincode: "s"):  # noqa: F821 N802
+        logger.debug("DisplayPinCode %s %s", device, pincode)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def RequestPasskey(self, device: "o") -> "u":  # noqa: F821 N802
+        logger.debug("RequestPasskey %s", device)
+
+        ble_device = await self._create_ble_device(device)
+
+        task = asyncio.create_task(self._callbacks.request_passkey(ble_device))
+        self._tasks.add(task)
+
+        try:
+            key = await task
+        except asyncio.CancelledError:
+            raise DBusError("org.bluez.Error.Canceled", "task canceled")
+        finally:
+            self._tasks.remove(task)
+
+        if not key:
+            raise DBusError("org.bluez.Error.Rejected", "user rejected")
+
+        try:
+            passkey = int(key)
+        except ValueError:
+            raise DBusError("org.bluez.Error.Rejected", "invalid passkey")
+
+        return passkey
+
+    @method()
+    @no_type_check
+    async def DisplayPasskey(  # noqa: N802
+        self, device: "o", passkey: "u", entered: "q"  # noqa: F821
+    ):
+        passkey = f"{passkey:06}"
+        logger.debug("DisplayPasskey %s %s %d", device, passkey, entered)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def RequestConfirmation(self, device: "o", passkey: "u"):  # noqa: F821 N802
+        passkey = f"{passkey:06}"
+        logger.debug("RequestConfirmation %s %s", device, passkey)
+
+        ble_device = await self._create_ble_device(device)
+
+        task = asyncio.create_task(self._callbacks.confirm_passkey(ble_device, passkey))
+        self._tasks.add(task)
+
+        try:
+            result = await task
+        except asyncio.CancelledError:
+            raise DBusError("org.bluez.Error.Canceled", "task canceled")
+        finally:
+            self._tasks.remove(task)
+
+        if not result:
+            raise DBusError("org.bluez.Error.Rejected", "user rejected")
+        else:
+            manager = await get_global_bluez_manager()
+            # Set device as trusted.
+            reply = await manager._bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path=device,
+                    interface=defs.PROPERTIES_INTERFACE,
+                    member="Set",
+                    signature="ssv",
+                    body=[defs.DEVICE_INTERFACE, "Trusted", Variant("b", True)],
+                )
+            )
+            assert reply
+            assert_reply(reply)
+
+    @method()
+    @no_type_check
+    async def RequestAuthorization(self, device: "o"):  # noqa: F821 N802
+        logger.debug("RequestAuthorization %s", device)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    async def AuthorizeService(self, device: "o", uuid: "s"):  # noqa: F821 N802
+        logger.debug("AuthorizeService %s", device, uuid)
+        raise NotImplementedError
+
+    @method()
+    @no_type_check
+    def Cancel(self):  # noqa: F821 N802
+        logger.debug("Cancel")
+        for t in self._tasks:
+            t.cancel()
+
+
+@contextlib.asynccontextmanager
+async def bluez_agent(bus: MessageBus, callbacks: BaseBleakAgentCallbacks):
+    agent = Agent(callbacks)
+
+    # REVISIT: implement passing capability if needed
+    # "DisplayOnly", "DisplayYesNo", "KeyboardOnly", "NoInputNoOutput", "KeyboardDisplay"
+    # Note: If an empty string is used, BlueZ will fall back to "KeyboardDisplay".
+    capability = ""
+
+    # this should be a unique path to allow multiple python interpreters
+    # running bleak and multiple agents at the same time
+    agent_path = f"/org/bleak/agent/{os.getpid()}/{id(agent)}"
+
+    bus.export(agent_path, agent)
+
+    try:
+        reply = await bus.call(
+            Message(
+                destination=defs.BLUEZ_SERVICE,
+                path="/org/bluez",
+                interface=defs.AGENT_MANAGER_INTERFACE,
+                member="RegisterAgent",
+                signature="os",
+                body=[agent_path, capability],
+            )
+        )
+
+        assert reply
+        assert_reply(reply)
+
+        try:
+            yield
+        finally:
+            reply = await bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path="/org/bluez",
+                    interface=defs.AGENT_MANAGER_INTERFACE,
+                    member="UnregisterAgent",
+                    signature="o",
+                    body=[agent_path],
+                )
+            )
+
+            assert reply
+            assert_reply(reply)
+
+    finally:
+        bus.unexport(agent_path, agent)

--- a/bleak/backends/bluezdbus/agent.py
+++ b/bleak/backends/bluezdbus/agent.py
@@ -2,22 +2,45 @@
 Agent
 -----
 
-This module contains types associated with the BlueZ D-Bus `agent api
-<https://github.com/bluez/bluez/blob/master/doc/agent-api.txt>`.
+Implements the BlueZ ``org.bluez.Agent1`` D-Bus interface and binds it to a
+:class:`~bleak.agent.PairingCallbacks`. See the BlueZ `agent API
+<https://github.com/bluez/bluez/blob/master/doc/agent-api.txt>`_.
+
+The D-Bus methods carry their wire signatures as string annotations (``"o"``,
+``"u"``, ...) which dbus-fast parses but static type checkers cannot, so each
+such method is a thin ``@no_type_check`` shim delegating to a fully typed
+helper.
 """
 
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    if sys.platform != "linux":
+        assert False, "This backend is only available on Linux"
+
 import asyncio
-import contextlib
 import logging
 import os
-from typing import Set, no_type_check
+from collections.abc import AsyncGenerator
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import TypeAlias, no_type_check
 
 from dbus_fast import DBusError, Message
 from dbus_fast.aio import MessageBus
-from dbus_fast.service import ServiceInterface, method
-from dbus_fast.signature import Variant
+from dbus_fast.service import ServiceInterface
+from dbus_fast.service import method as dbus_method
 
-from bleak.agent import BaseBleakAgentCallbacks
+from bleak._compat import assert_never
+from bleak.agent import (
+    MAX_PASSKEY,
+    ConfirmPasskey,
+    DisplayPasskey,
+    IOCapability,
+    PairingCallbacks,
+    RequestPasskey,
+    io_capability,
+)
 from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.manager import get_global_bluez_manager
 from bleak.backends.bluezdbus.utils import assert_reply
@@ -25,22 +48,36 @@ from bleak.backends.device import BLEDevice
 
 logger = logging.getLogger(__name__)
 
+_PendingTask: TypeAlias = asyncio.Task[bool] | asyncio.Task[int | None]
+
+
+def _capability_name(capability: IOCapability) -> str:
+    """Map an :class:`IOCapability` to the BlueZ agent capability string."""
+    match capability:
+        case IOCapability.NO_INPUT_NO_OUTPUT:
+            return "NoInputNoOutput"
+        case IOCapability.DISPLAY_YES_NO:
+            return "DisplayYesNo"
+        case IOCapability.KEYBOARD_ONLY:
+            return "KeyboardOnly"
+        case IOCapability.DISPLAY_ONLY:
+            return "DisplayOnly"
+        case IOCapability.KEYBOARD_DISPLAY:
+            return "KeyboardDisplay"
+        case _:
+            assert_never(capability)
+
 
 class Agent(ServiceInterface):
-    """
-    Implementation of the org.bluez.Agent1 D-Bus interface.
-    """
+    """The ``org.bluez.Agent1`` interface backed by a :class:`PairingCallbacks`."""
 
-    def __init__(self, callbacks: BaseBleakAgentCallbacks):
-        """
-        Args:
-        """
+    def __init__(self, callbacks: PairingCallbacks) -> None:
         super().__init__(defs.AGENT_INTERFACE)
         self._callbacks = callbacks
-        self._tasks: Set[asyncio.Task] = set()
+        self._pending: _PendingTask | None = None
 
     @staticmethod
-    async def _create_ble_device(device_path: str) -> BLEDevice:
+    async def _ble_device(device_path: str) -> BLEDevice:
         manager = await get_global_bluez_manager()
         return BLEDevice(
             manager.get_device_address(device_path),
@@ -48,163 +85,155 @@ class Agent(ServiceInterface):
             {"path": device_path},
         )
 
-    @method()
-    def Release(self):  # noqa: N802
-        logger.debug("Release")
+    async def _run(self, task: _PendingTask) -> bool | int | None:
+        """Await a callback *task*, mapping cancellation to a D-Bus error.
 
-    # REVISIT: mypy is broke, so we have to add redundant @no_type_check
-    # https://github.com/python/mypy/issues/6583
-
-    @method()
-    @no_type_check
-    async def RequestPinCode(self, device: "o") -> "s":  # noqa: F821 N802
-        logger.debug("RequestPinCode %s", device)
-        raise NotImplementedError
-
-    @method()
-    @no_type_check
-    async def DisplayPinCode(self, device: "o", pincode: "s"):  # noqa: F821 N802
-        logger.debug("DisplayPinCode %s %s", device, pincode)
-        raise NotImplementedError
-
-    @method()
-    @no_type_check
-    async def RequestPasskey(self, device: "o") -> "u":  # noqa: F821 N802
-        logger.debug("RequestPasskey %s", device)
-
-        ble_device = await self._create_ble_device(device)
-
-        task = asyncio.create_task(self._callbacks.request_passkey(ble_device))
-        self._tasks.add(task)
-
+        The task is held so a concurrent :meth:`Cancel` can abort the in-flight
+        callback without disturbing dbus-fast's own dispatch task.
+        """
+        self._pending = task
         try:
-            key = await task
+            return await task
         except asyncio.CancelledError:
-            raise DBusError("org.bluez.Error.Canceled", "task canceled")
+            raise DBusError("org.bluez.Error.Canceled", "pairing canceled")
         finally:
-            self._tasks.remove(task)
+            self._pending = None
 
-        if not key:
-            raise DBusError("org.bluez.Error.Rejected", "user rejected")
+    async def _confirm(self, device_path: str, passkey: int) -> None:
+        if (confirm := self._callbacks.confirm) is None:
+            raise DBusError(
+                "org.bluez.Error.Rejected", "numeric comparison not supported"
+            )
+        device = await self._ble_device(device_path)
+        if not await self._run(
+            asyncio.ensure_future(confirm(ConfirmPasskey(device, passkey)))
+        ):
+            raise DBusError("org.bluez.Error.Rejected", "pairing rejected")
 
-        try:
-            passkey = int(key)
-        except ValueError:
-            raise DBusError("org.bluez.Error.Rejected", "invalid passkey")
-
+    async def _request_passkey(self, device_path: str) -> int:
+        if (request := self._callbacks.request_passkey) is None:
+            raise DBusError("org.bluez.Error.Rejected", "passkey entry not supported")
+        device = await self._ble_device(device_path)
+        passkey = await self._run(
+            asyncio.ensure_future(request(RequestPasskey(device)))
+        )
+        if passkey is None:
+            raise DBusError("org.bluez.Error.Rejected", "pairing rejected")
+        if not 0 <= passkey <= MAX_PASSKEY:
+            raise DBusError(
+                "org.bluez.Error.Rejected", f"passkey {passkey} out of range"
+            )
         return passkey
 
-    @method()
+    async def _display(self, device_path: str, passkey: int) -> None:
+        if (display := self._callbacks.display_passkey) is None:
+            return
+        device = await self._ble_device(device_path)
+        await display(DisplayPasskey(device, passkey))
+
+    @dbus_method()
+    def Release(self) -> None:  # noqa: N802
+        logger.debug("pairing agent released")
+
+    @dbus_method()
     @no_type_check
-    async def DisplayPasskey(  # noqa: N802
-        self, device: "o", passkey: "u", entered: "q"  # noqa: F821
-    ):
-        passkey = f"{passkey:06}"
-        logger.debug("DisplayPasskey %s %s %d", device, passkey, entered)
-        raise NotImplementedError
-
-    @method()
-    @no_type_check
-    async def RequestConfirmation(self, device: "o", passkey: "u"):  # noqa: F821 N802
-        passkey = f"{passkey:06}"
-        logger.debug("RequestConfirmation %s %s", device, passkey)
-
-        ble_device = await self._create_ble_device(device)
-
-        task = asyncio.create_task(self._callbacks.confirm_passkey(ble_device, passkey))
-        self._tasks.add(task)
-
-        try:
-            result = await task
-        except asyncio.CancelledError:
-            raise DBusError("org.bluez.Error.Canceled", "task canceled")
-        finally:
-            self._tasks.remove(task)
-
-        if not result:
-            raise DBusError("org.bluez.Error.Rejected", "user rejected")
-        else:
-            manager = await get_global_bluez_manager()
-            # Set device as trusted.
-            reply = await manager._bus.call(
-                Message(
-                    destination=defs.BLUEZ_SERVICE,
-                    path=device,
-                    interface=defs.PROPERTIES_INTERFACE,
-                    member="Set",
-                    signature="ssv",
-                    body=[defs.DEVICE_INTERFACE, "Trusted", Variant("b", True)],
-                )
-            )
-            assert reply
-            assert_reply(reply)
-
-    @method()
-    @no_type_check
-    async def RequestAuthorization(self, device: "o"):  # noqa: F821 N802
-        logger.debug("RequestAuthorization %s", device)
-        raise NotImplementedError
-
-    @method()
-    @no_type_check
-    async def AuthorizeService(self, device: "o", uuid: "s"):  # noqa: F821 N802
-        logger.debug("AuthorizeService %s", device, uuid)
-        raise NotImplementedError
-
-    @method()
-    @no_type_check
-    def Cancel(self):  # noqa: F821 N802
-        logger.debug("Cancel")
-        for t in self._tasks:
-            t.cancel()
-
-
-@contextlib.asynccontextmanager
-async def bluez_agent(bus: MessageBus, callbacks: BaseBleakAgentCallbacks):
-    agent = Agent(callbacks)
-
-    # REVISIT: implement passing capability if needed
-    # "DisplayOnly", "DisplayYesNo", "KeyboardOnly", "NoInputNoOutput", "KeyboardDisplay"
-    # Note: If an empty string is used, BlueZ will fall back to "KeyboardDisplay".
-    capability = ""
-
-    # this should be a unique path to allow multiple python interpreters
-    # running bleak and multiple agents at the same time
-    agent_path = f"/org/bleak/agent/{os.getpid()}/{id(agent)}"
-
-    bus.export(agent_path, agent)
-
-    try:
-        reply = await bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path="/org/bluez",
-                interface=defs.AGENT_MANAGER_INTERFACE,
-                member="RegisterAgent",
-                signature="os",
-                body=[agent_path, capability],
-            )
+    async def RequestPinCode(self, device: "o") -> "s":  # noqa: F821 N802
+        raise DBusError(
+            "org.bluez.Error.Rejected", "legacy PIN code pairing not supported"
         )
 
-        assert reply
-        assert_reply(reply)
+    @dbus_method()
+    @no_type_check
+    async def DisplayPinCode(self, device: "o", pincode: "s"):  # noqa: F821 N802
+        raise DBusError(
+            "org.bluez.Error.Rejected", "legacy PIN code pairing not supported"
+        )
 
-        try:
-            yield
-        finally:
-            reply = await bus.call(
-                Message(
-                    destination=defs.BLUEZ_SERVICE,
-                    path="/org/bluez",
-                    interface=defs.AGENT_MANAGER_INTERFACE,
-                    member="UnregisterAgent",
-                    signature="o",
-                    body=[agent_path],
-                )
-            )
+    @dbus_method()
+    @no_type_check
+    async def RequestPasskey(self, device: "o") -> "u":  # noqa: F821 N802
+        return await self._request_passkey(device)
 
-            assert reply
-            assert_reply(reply)
+    @dbus_method()
+    @no_type_check
+    async def DisplayPasskey(
+        self, device: "o", passkey: "u", entered: "q"  # noqa: F821
+    ):  # noqa: N802
+        await self._display(device, passkey)
 
-    finally:
-        bus.unexport(agent_path, agent)
+    @dbus_method()
+    @no_type_check
+    async def RequestConfirmation(self, device: "o", passkey: "u"):  # noqa: F821 N802
+        await self._confirm(device, passkey)
+
+    @dbus_method()
+    @no_type_check
+    async def RequestAuthorization(self, device: "o"):  # noqa: F821 N802
+        logger.debug("authorizing just works pairing for %s", device)
+
+    @dbus_method()
+    @no_type_check
+    async def AuthorizeService(self, device: "o", uuid: "s"):  # noqa: F821 N802
+        raise DBusError(
+            "org.bluez.Error.Rejected", "service authorization not supported"
+        )
+
+    @dbus_method()
+    def Cancel(self) -> None:  # noqa: N802
+        logger.debug("pairing canceled by peer")
+        if self._pending is not None:
+            self._pending.cancel()
+
+
+async def _register_agent(bus: MessageBus, agent_path: str, capability: str) -> None:
+    reply = await bus.call(
+        Message(
+            destination=defs.BLUEZ_SERVICE,
+            path="/org/bluez",
+            interface=defs.AGENT_MANAGER_INTERFACE,
+            member="RegisterAgent",
+            signature="os",
+            body=[agent_path, capability],
+        )
+    )
+    assert reply is not None
+    assert_reply(reply)
+
+
+async def _unregister_agent(bus: MessageBus, agent_path: str) -> None:
+    reply = await bus.call(
+        Message(
+            destination=defs.BLUEZ_SERVICE,
+            path="/org/bluez",
+            interface=defs.AGENT_MANAGER_INTERFACE,
+            member="UnregisterAgent",
+            signature="o",
+            body=[agent_path],
+        )
+    )
+    assert reply is not None
+    assert_reply(reply)
+
+
+@asynccontextmanager
+async def bluez_agent(
+    bus: MessageBus, callbacks: PairingCallbacks | None = None
+) -> AsyncGenerator[None]:
+    """Register a pairing :class:`Agent` for the duration of the context.
+
+    The advertised capability is derived from *callbacks* via
+    :func:`~bleak.agent.io_capability`. Omitting *callbacks* (or passing
+    ``None``) registers a Just Works agent. A unique object path keeps multiple
+    Bleak agents (and interpreters) from colliding.
+    """
+    callbacks = callbacks if callbacks is not None else PairingCallbacks()
+    agent = Agent(callbacks)
+    agent_path = f"/org/bleak/agent/{os.getpid()}/{id(agent)}"
+    capability = _capability_name(io_capability(callbacks))
+
+    async with AsyncExitStack() as stack:
+        bus.export(agent_path, agent)
+        stack.callback(bus.unexport, agent_path, agent)
+        await _register_agent(bus, agent_path, capability)
+        stack.push_async_callback(_unregister_agent, bus, agent_path)
+        yield

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -28,8 +28,10 @@ from dbus_fast.signature import Variant
 from bleak import BleakScanner
 from bleak._compat import override
 from bleak._compat import timeout as async_timeout
+from bleak.agent import BaseBleakAgentCallbacks
 from bleak.args import SizedBuffer
 from bleak.backends.bluezdbus import defs
+from bleak.backends.bluezdbus.agent import bluez_agent
 from bleak.backends.bluezdbus.manager import get_global_bluez_manager
 from bleak.backends.bluezdbus.scanner import BleakScannerBlueZDBus
 from bleak.backends.bluezdbus.utils import (
@@ -85,8 +87,14 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         self._requested_services = services
 
-        # D-Bus message bus
+        # Each client needs it's own D-Bus connection to avoid a quirk where
+        # BlueZ automatically enables notifications on reconnection (before
+        # we can add a handler for them) and also ensures that the pairing
+        # agent will only handle handle requests for this specific connection.
+        # The MessageBus is created on-demand during connect() to ensure a fresh
+        # connection for each connect/disconnect cycle.
         self._bus: Optional[MessageBus] = None
+
         # tracks device watcher subscription
         self._remove_device_watcher: Optional[Callable[[], None]] = None
         # private backing for is_connected property
@@ -102,6 +110,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         # used to override mtu_size property
         self._mtu_size: Optional[int] = None
+
+        self._pairing_callbacks: Optional[BaseBleakAgentCallbacks] = kwargs.get(
+            "pairing_callbacks"
+        )
 
     # Connectivity methods
 
@@ -257,7 +269,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                         # Calling pair will fail if we are already paired, so
                         # in that case we just call Connect.
                         if pair and not manager.is_paired(self._device_path):
-                            reply = await self._pair()
+                            reply = await self._pair(self._pairing_callbacks)
 
                             # For resolvable private addresses, the address will
                             # change after pairing, so we need to update that.
@@ -369,6 +381,10 @@ class BleakClientBlueZDBus(BaseBleakClient):
         """
         logger.debug("_cleanup_all(%s)", self._device_path)
 
+        # Reset all stored services.
+        self.services = None
+        self._services_resolved = False
+
         if self._remove_device_watcher:
             self._remove_device_watcher()
             self._remove_device_watcher = None
@@ -430,7 +446,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # "PropertiesChanged" signal handler and that it completed successfully
         assert self.services is None
 
-    async def _pair(self) -> Message:
+    async def _pair(self, callbacks) -> Message:
         """
         Pair with the peripheral and return the D-Bus reply.
 
@@ -440,32 +456,34 @@ class BleakClientBlueZDBus(BaseBleakClient):
         assert self._bus is not None
         assert self._device_path is not None
 
-        # REVIST: This leaves "Trusted" property set if we
-        # fail later. Probably not a big deal since we were
-        # going to trust it anyway.
-        # Trusted means device is authorized
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path=self._device_path,
-                interface=defs.PROPERTIES_INTERFACE,
-                member="Set",
-                signature="ssv",
-                body=[defs.DEVICE_INTERFACE, "Trusted", Variant("b", True)],
+        if callbacks is None:
+            # REVIST: This leaves "Trusted" property set if we
+            # fail later. Probably not a big deal since we were
+            # going to trust it anyway.
+            # Trusted means device is authorized
+            reply = await self._bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path=self._device_path,
+                    interface=defs.PROPERTIES_INTERFACE,
+                    member="Set",
+                    signature="ssv",
+                    body=[defs.DEVICE_INTERFACE, "Trusted", Variant("b", True)],
+                )
             )
-        )
-        assert_reply(reply)
+            assert_reply(reply)
 
         logger.debug("Pairing to BLE device @ %s", self.address)
-        # Pairing means device is authenticated
-        reply = await self._bus.call(
-            Message(
-                destination=defs.BLUEZ_SERVICE,
-                path=self._device_path,
-                interface=defs.DEVICE_INTERFACE,
-                member="Pair",
+        async with bluez_agent(self._bus, callbacks):
+            # Pairing means device is authenticated
+            reply = await self._bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path=self._device_path,
+                    interface=defs.DEVICE_INTERFACE,
+                    member="Pair",
+                )
             )
-        )
 
         return reply
 
@@ -482,7 +500,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             logger.debug("BLE device @ %s is already paired", self.address)
             return
 
-        reply = await self._pair()
+        reply = await self._pair(self._pairing_callbacks)
         assert_reply(reply)
 
         # For resolvable private addresses, the address will

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -28,7 +28,7 @@ from dbus_fast.signature import Variant
 from bleak import BleakScanner
 from bleak._compat import override
 from bleak._compat import timeout as async_timeout
-from bleak.agent import BaseBleakAgentCallbacks
+from bleak.agent import PairingCallbacks
 from bleak.args import SizedBuffer
 from bleak.backends.bluezdbus import defs
 from bleak.backends.bluezdbus.agent import bluez_agent
@@ -45,12 +45,38 @@ from bleak.backends.client import BaseBleakClient, NotifyCallback
 from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
-from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
+from bleak.exc import (
+    BleakDBusError,
+    BleakDeviceNotFoundError,
+    BleakError,
+    BleakPairingCancelledError,
+    BleakPairingFailedError,
+)
 
 logger = logging.getLogger(__name__)
 
 # prevent tasks from being garbage collected
 _background_tasks: set[asyncio.Task[None]] = set()
+
+
+def _assert_pairing_reply(reply: Message) -> None:
+    """Like :func:`assert_reply`, but map BlueZ authentication errors.
+
+    A canceled or failed pairing is raised as the corresponding
+    ``BleakPairing*Error`` instead of a generic D-Bus error. Unknown error
+    names fall through to :func:`assert_reply`.
+    """
+    if reply.message_type == MessageType.ERROR:
+        detail = reply.body[0] if reply.body else reply.error_name or ""
+        if reply.error_name == defs.BLUEZ_ERROR_AUTHENTICATION_CANCELED:
+            raise BleakPairingCancelledError(detail)
+        if reply.error_name in (
+            defs.BLUEZ_ERROR_AUTHENTICATION_FAILED,
+            defs.BLUEZ_ERROR_AUTHENTICATION_REJECTED,
+            defs.BLUEZ_ERROR_AUTHENTICATION_TIMEOUT,
+        ):
+            raise BleakPairingFailedError(detail)
+    assert_reply(reply)
 
 
 class BleakClientBlueZDBus(BaseBleakClient):
@@ -69,9 +95,17 @@ class BleakClientBlueZDBus(BaseBleakClient):
         services: Optional[set[str]] = None,
         *,
         bluez: BlueZClientArgs,
+        timeout: float,
+        disconnected_callback: Optional[Callable[[], None]] = None,
+        pairing_callbacks: Optional[PairingCallbacks] = None,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            timeout=timeout,
+            disconnected_callback=disconnected_callback,
+            pairing_callbacks=pairing_callbacks,
+        )
 
         self._adapter = bluez.get("adapter")
         self._device_path: Optional[str]
@@ -110,10 +144,6 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
         # used to override mtu_size property
         self._mtu_size: Optional[int] = None
-
-        self._pairing_callbacks: Optional[BaseBleakAgentCallbacks] = kwargs.get(
-            "pairing_callbacks"
-        )
 
     # Connectivity methods
 
@@ -318,7 +348,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                                     f"Device with address {self.address} was not found. It may have been removed from BlueZ when scanning stopped.",
                                 )
 
-                        assert_reply(reply)
+                        _assert_pairing_reply(reply)
 
                     self._is_connected = True
 
@@ -446,7 +476,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         # "PropertiesChanged" signal handler and that it completed successfully
         assert self.services is None
 
-    async def _pair(self, callbacks) -> Message:
+    async def _pair(self, callbacks: Optional[PairingCallbacks]) -> Message:
         """
         Pair with the peripheral and return the D-Bus reply.
 
@@ -456,12 +486,19 @@ class BleakClientBlueZDBus(BaseBleakClient):
         assert self._bus is not None
         assert self._device_path is not None
 
-        if callbacks is None:
-            # REVIST: This leaves "Trusted" property set if we
-            # fail later. Probably not a big deal since we were
-            # going to trust it anyway.
-            # Trusted means device is authorized
+        logger.debug("Pairing to BLE device @ %s", self.address)
+        async with bluez_agent(self._bus, callbacks):
             reply = await self._bus.call(
+                Message(
+                    destination=defs.BLUEZ_SERVICE,
+                    path=self._device_path,
+                    interface=defs.DEVICE_INTERFACE,
+                    member="Pair",
+                )
+            )
+
+        if reply.message_type == MessageType.METHOD_RETURN:
+            trusted = await self._bus.call(
                 Message(
                     destination=defs.BLUEZ_SERVICE,
                     path=self._device_path,
@@ -471,19 +508,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     body=[defs.DEVICE_INTERFACE, "Trusted", Variant("b", True)],
                 )
             )
-            assert_reply(reply)
-
-        logger.debug("Pairing to BLE device @ %s", self.address)
-        async with bluez_agent(self._bus, callbacks):
-            # Pairing means device is authenticated
-            reply = await self._bus.call(
-                Message(
-                    destination=defs.BLUEZ_SERVICE,
-                    path=self._device_path,
-                    interface=defs.DEVICE_INTERFACE,
-                    member="Pair",
-                )
-            )
+            assert_reply(trusted)
 
         return reply
 
@@ -501,7 +526,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             return
 
         reply = await self._pair(self._pairing_callbacks)
-        assert_reply(reply)
+        _assert_pairing_reply(reply)
 
         # For resolvable private addresses, the address will
         # change after pairing, so we need to update that.

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -11,6 +11,8 @@ BLUEZ_SERVICE = "org.bluez"
 ADAPTER_INTERFACE = "org.bluez.Adapter1"
 ADVERTISEMENT_MONITOR_INTERFACE = "org.bluez.AdvertisementMonitor1"
 ADVERTISEMENT_MONITOR_MANAGER_INTERFACE = "org.bluez.AdvertisementMonitorManager1"
+AGENT_INTERFACE = "org.bluez.Agent1"
+AGENT_MANAGER_INTERFACE = "org.bluez.AgentManager1"
 DEVICE_INTERFACE = "org.bluez.Device1"
 BATTERY_INTERFACE = "org.bluez.Battery1"
 

--- a/bleak/backends/bluezdbus/defs.py
+++ b/bleak/backends/bluezdbus/defs.py
@@ -24,6 +24,10 @@ GATT_CHARACTERISTIC_INTERFACE = "org.bluez.GattCharacteristic1"
 GATT_DESCRIPTOR_INTERFACE = "org.bluez.GattDescriptor1"
 
 # BlueZ error names
+BLUEZ_ERROR_AUTHENTICATION_CANCELED = "org.bluez.Error.AuthenticationCanceled"
+BLUEZ_ERROR_AUTHENTICATION_FAILED = "org.bluez.Error.AuthenticationFailed"
+BLUEZ_ERROR_AUTHENTICATION_REJECTED = "org.bluez.Error.AuthenticationRejected"
+BLUEZ_ERROR_AUTHENTICATION_TIMEOUT = "org.bluez.Error.AuthenticationTimeout"
 BLUEZ_ERROR_DOES_NOT_EXIST = "org.bluez.Error.DoesNotExist"
 BLUEZ_ERROR_FAILED = "org.bluez.Error.Failed"
 BLUEZ_ERROR_IMPROPERLY_CONFIGURED = "org.bluez.Error.ImproperlyConfigured"

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -6,6 +6,7 @@ import abc
 from collections.abc import Callable
 from typing import Any, Optional, Union
 
+from bleak.agent import BaseBleakAgentCallbacks
 from bleak.args import SizedBuffer
 from bleak.backends import BleakBackend, get_default_backend
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -30,6 +31,10 @@ class BaseBleakClient(abc.ABC):
         disconnected_callback (callable): Callback that will be scheduled in the
             event loop when the client is disconnected. The callable must take one
             argument, which will be this client object.
+        pairing_callbacks (BaseBleakAgentCallbacks):
+            Optional callbacks otherwise provided as ``callbacks`` parameter to the
+            :meth:`pair` method. If provided here, device will be implicitly paired
+            during connection establishment.
     """
 
     def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs: Any):
@@ -43,6 +48,9 @@ class BaseBleakClient(abc.ABC):
         self._timeout = kwargs["timeout"]
         self._disconnected_callback: Optional[Callable[[], None]] = kwargs.get(
             "disconnected_callback"
+        )
+        self._pairing_callbacks: Optional[BaseBleakAgentCallbacks] = kwargs.get(
+            "pairing_callbacks"
         )
 
     # NB: this is not marked as @abc.abstractmethod because that would break

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -4,9 +4,9 @@ Base class for backend clients.
 """
 import abc
 from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from bleak.agent import BaseBleakAgentCallbacks
+from bleak.agent import PairingCallbacks
 from bleak.args import SizedBuffer
 from bleak.backends import BleakBackend, get_default_backend
 from bleak.backends.characteristic import BleakGATTCharacteristic
@@ -31,13 +31,21 @@ class BaseBleakClient(abc.ABC):
         disconnected_callback (callable): Callback that will be scheduled in the
             event loop when the client is disconnected. The callable must take one
             argument, which will be this client object.
-        pairing_callbacks (BaseBleakAgentCallbacks):
+        pairing_callbacks (PairingCallbacks):
             Optional callbacks otherwise provided as ``callbacks`` parameter to the
             :meth:`pair` method. If provided here, device will be implicitly paired
             during connection establishment.
     """
 
-    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs: Any):
+    def __init__(
+        self,
+        address_or_ble_device: BLEDevice | str,
+        *,
+        timeout: float,
+        disconnected_callback: Callable[[], None] | None = None,
+        pairing_callbacks: Optional[PairingCallbacks] = None,
+        **kwargs: Any,
+    ) -> None:
         if isinstance(address_or_ble_device, BLEDevice):
             self.address = address_or_ble_device.address
         else:
@@ -45,13 +53,9 @@ class BaseBleakClient(abc.ABC):
 
         self.services: Optional[BleakGATTServiceCollection] = None
 
-        self._timeout = kwargs["timeout"]
-        self._disconnected_callback: Optional[Callable[[], None]] = kwargs.get(
-            "disconnected_callback"
-        )
-        self._pairing_callbacks: Optional[BaseBleakAgentCallbacks] = kwargs.get(
-            "pairing_callbacks"
-        )
+        self._timeout = timeout
+        self._disconnected_callback = disconnected_callback
+        self._pairing_callbacks = pairing_callbacks
 
     # NB: this is not marked as @abc.abstractmethod because that would break
     # 3rd-party backends. We might change this in the future to make it required.

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import Any, Optional, Union
 
 from CoreBluetooth import (
@@ -26,6 +27,7 @@ from Foundation import NSArray, NSData
 
 from bleak import BleakScanner
 from bleak._compat import override
+from bleak.agent import PairingCallbacks
 from bleak.args import SizedBuffer
 from bleak.args.corebluetooth import CBStartNotifyArgs
 from bleak.assigned_numbers import gatt_char_props_to_strs
@@ -59,19 +61,26 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self,
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
+        *,
+        timeout: float,
+        disconnected_callback: Callable[[], None] | None = None,
+        pairing_callbacks: PairingCallbacks | None = None,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            timeout=timeout,
+            disconnected_callback=disconnected_callback,
+            pairing_callbacks=pairing_callbacks,
+        )
 
         self._peripheral: Optional[CBPeripheral] = None
         self._delegate: Optional[PeripheralDelegate] = None
         self._central_manager_delegate: Optional[CentralManagerDelegate] = None
 
-        if kwargs.get("pairing_callbacks"):
-            logger.warn(
-                "Pairing is not available in Core Bluetooth.",
-                RuntimeWarning,
-                stacklevel=2,
+        if pairing_callbacks is not None:
+            logger.debug(
+                "pairing callbacks are not supported by the Core Bluetooth backend"
             )
 
         if isinstance(address_or_ble_device, BLEDevice):

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -67,6 +67,13 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self._delegate: Optional[PeripheralDelegate] = None
         self._central_manager_delegate: Optional[CentralManagerDelegate] = None
 
+        if kwargs.get("pairing_callbacks"):
+            logger.warn(
+                "Pairing is not available in Core Bluetooth.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
         if isinstance(address_or_ble_device, BLEDevice):
             (
                 self._peripheral,

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -13,12 +13,14 @@ import asyncio
 import logging
 import uuid
 import warnings
+from collections.abc import Callable
 from typing import Any, Optional, Union
 
 from android.broadcast import BroadcastReceiver
 from jnius import java_method
 
 from bleak._compat import override
+from bleak.agent import PairingCallbacks
 from bleak.assigned_numbers import gatt_char_props_to_strs
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback
@@ -46,9 +48,25 @@ class BleakClientP4Android(BaseBleakClient):
         self,
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[uuid.UUID]],
-        **kwargs,
+        *,
+        timeout: float,
+        disconnected_callback: Callable[[], None] | None = None,
+        pairing_callbacks: PairingCallbacks | None = None,
+        **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            timeout=timeout,
+            disconnected_callback=disconnected_callback,
+            pairing_callbacks=pairing_callbacks,
+        )
+
+        if pairing_callbacks is not None:
+            logger.debug(
+                "pairing callbacks are not used by the Android backend; "
+                "the system handles the pairing UI"
+            )
+
         self._requested_services = (
             set(map(defs.UUID.fromString, services)) if services else None
         )

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -58,6 +58,7 @@ from winrt.windows.storage.streams import Buffer
 from bleak import BleakScanner
 from bleak._compat import Self, assert_never, override
 from bleak._compat import timeout as async_timeout
+from bleak.agent import ConfirmPasskey, DisplayPasskey, PairingCallbacks, RequestPasskey
 from bleak.args import SizedBuffer
 from bleak.args.winrt import WinRTClientArgs as _WinRTClientArgs
 from bleak.assigned_numbers import gatt_char_props_to_strs
@@ -67,7 +68,13 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTService, BleakGATTServiceCollection
 from bleak.backends.winrt.scanner import BleakScannerWinRT, RawAdvData
-from bleak.exc import BleakDeviceNotFoundError, BleakError, BleakGATTProtocolError
+from bleak.exc import (
+    BleakDeviceNotFoundError,
+    BleakError,
+    BleakGATTProtocolError,
+    BleakPairingCancelledError,
+    BleakPairingFailedError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +141,24 @@ def _ensure_success(result: _Result, attr: Optional[str], fail_msg: str) -> Any:
     raise BleakError(f"{fail_msg}: Unexpected status code 0x{status:02X}")
 
 
+def _pairing_kinds(callbacks: PairingCallbacks | None) -> DevicePairingKinds:
+    """Derive the accepted ``DevicePairingKinds`` from the provided callbacks.
+
+    Just Works (``CONFIRM_ONLY``) is always accepted; each provided callback
+    adds the kinds it can take part in.
+    """
+    kinds = DevicePairingKinds.CONFIRM_ONLY
+    if callbacks is None:
+        return kinds
+    if callbacks.confirm is not None:
+        kinds |= DevicePairingKinds.CONFIRM_PIN_MATCH
+    if callbacks.request_passkey is not None:
+        kinds |= DevicePairingKinds.PROVIDE_PIN
+    if callbacks.display_passkey is not None:
+        kinds |= DevicePairingKinds.DISPLAY_PIN
+    return kinds
+
+
 class BleakClientWinRT(BaseBleakClient):
     """Native Windows Bleak Client.
 
@@ -150,9 +175,17 @@ class BleakClientWinRT(BaseBleakClient):
         services: Optional[set[str]] = None,
         *,
         winrt: _WinRTClientArgs,
+        timeout: float,
+        disconnected_callback: Optional[Callable[[], None]] = None,
+        pairing_callbacks: Optional[PairingCallbacks] = None,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            timeout=timeout,
+            disconnected_callback=disconnected_callback,
+            pairing_callbacks=pairing_callbacks,
+        )
 
         self._device_info: int | None
 
@@ -179,13 +212,6 @@ class BleakClientWinRT(BaseBleakClient):
         self._services_changed_token: Optional[EventRegistrationToken] = None
         self._session_status_changed_token: Optional[EventRegistrationToken] = None
         self._max_pdu_size_changed_token: Optional[EventRegistrationToken] = None
-
-        if kwargs.get("pairing_callbacks"):
-            logger.warning(
-                "Pairing is not implemented in WinRT.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
 
     def __str__(self) -> str:
         return f"{type(self).__name__} ({self.address})"
@@ -535,9 +561,19 @@ class BleakClientWinRT(BaseBleakClient):
     @override
     async def pair(
         self,
+        callbacks: Optional[PairingCallbacks] = None,
+        *,
+        protection_level: Optional[DevicePairingProtectionLevel] = None,
         **kwargs: Any,
     ) -> None:
         """Attempts to pair with the device.
+
+        Args:
+            callbacks: Optional :class:`~bleak.agent.PairingCallbacks` used to
+                take part in the pairing kinds (numeric comparison or passkey
+                entry). If omitted, the callbacks given to the
+                :class:`~bleak.BleakClient` constructor are used; with no
+                callbacks at all, Just Works pairing is accepted automatically.
 
         Keyword Args:
             protection_level (int): A ``DevicePairingProtectionLevel`` enum value:
@@ -566,17 +602,27 @@ class BleakClientWinRT(BaseBleakClient):
         if not device_information.pairing.can_pair:
             raise BleakError("Device does not support pairing")
 
-        protection_level = kwargs.get("protection_level")
-
-        # Currently only supporting Just Works solutions...
-        ceremony = DevicePairingKinds.CONFIRM_ONLY
+        callbacks = callbacks if callbacks is not None else self._pairing_callbacks
+        kinds = _pairing_kinds(callbacks)
         custom_pairing = device_information.pairing.custom
+
+        loop = asyncio.get_running_loop()
 
         def handler(
             sender: DeviceInformationCustomPairing,
             args: DevicePairingRequestedEventArgs,
-        ):
-            args.accept()
+        ) -> None:
+            deferral = args.get_deferral()
+
+            async def respond() -> None:
+                try:
+                    await self._accept_pairing(args, callbacks)
+                except Exception:
+                    logger.exception("error handling pairing request")
+                finally:
+                    deferral.complete()
+
+            asyncio.run_coroutine_threadsafe(respond(), loop)
 
         pairing_requested_token = custom_pairing.add_pairing_requested(handler)
 
@@ -588,7 +634,7 @@ class BleakClientWinRT(BaseBleakClient):
                     2,
                 )
                 pairing_result = await custom_pairing.pair_with_protection_level_async(
-                    ceremony, protection_level
+                    kinds, protection_level
                 )
             else:
                 for level in (
@@ -597,7 +643,7 @@ class BleakClientWinRT(BaseBleakClient):
                 ):
                     pairing_result = (
                         await custom_pairing.pair_with_protection_level_async(
-                            ceremony, level
+                            kinds, level
                         )
                     )
                     if (
@@ -608,20 +654,25 @@ class BleakClientWinRT(BaseBleakClient):
 
                     logger.debug("Protection level %r not met. Retrying.", level)
                 else:
-                    pairing_result = await custom_pairing.pair_async(ceremony)
+                    pairing_result = await custom_pairing.pair_async(kinds)
 
         except Exception as e:
             raise BleakError("Failure trying to pair with device!") from e
         finally:
             custom_pairing.remove_pairing_requested(pairing_requested_token)
 
-        if pairing_result.status not in (
+        status = pairing_result.status
+        if status not in (
             DevicePairingResultStatus.PAIRED,
             DevicePairingResultStatus.ALREADY_PAIRED,
         ):
-            raise BleakError(
-                f"Could not pair with device: {pairing_result.status.name}"
-            )
+            message = f"Could not pair with device: {status.name}"
+            if status in (
+                DevicePairingResultStatus.PAIRING_CANCELED,
+                DevicePairingResultStatus.REJECTED_BY_HANDLER,
+            ):
+                raise BleakPairingCancelledError(message)
+            raise BleakPairingFailedError(message)
 
         if logger.isEnabledFor(logging.DEBUG):
             # pairing_result.protection_level_used doesn't seem to return
@@ -635,6 +686,49 @@ class BleakClientWinRT(BaseBleakClient):
                 "Paired to device with protection level %s.",
                 pairing_result.protection_level_used.name,
             )
+
+    async def _accept_pairing(
+        self,
+        args: DevicePairingRequestedEventArgs,
+        callbacks: Optional[PairingCallbacks],
+    ) -> None:
+        """Respond to a WinRT pairing request by dispatching to *callbacks*.
+
+        Runs on the event loop (scheduled from the WinRT callback thread) while
+        the caller holds a deferral, so awaiting user input here is safe.
+        """
+        assert self._requester
+        device = BLEDevice(self.address, self._requester.name, self._requester)
+        logger.debug("pairing requested (kind %r)", args.pairing_kind)
+        match args.pairing_kind:
+            case DevicePairingKinds.CONFIRM_ONLY:
+                args.accept()
+            case DevicePairingKinds.CONFIRM_PIN_MATCH:
+                if (
+                    callbacks is not None
+                    and callbacks.confirm is not None
+                    and await callbacks.confirm(ConfirmPasskey(device, int(args.pin)))
+                ):
+                    args.accept()
+            case DevicePairingKinds.PROVIDE_PIN:
+                if callbacks is not None and callbacks.request_passkey is not None:
+                    passkey = await callbacks.request_passkey(RequestPasskey(device))
+                    if passkey is not None:
+                        args.accept_with_pin(f"{passkey:06d}")
+            case DevicePairingKinds.DISPLAY_PIN:
+                if callbacks is not None and callbacks.display_passkey is not None:
+                    await callbacks.display_passkey(
+                        DisplayPasskey(device, int(args.pin))
+                    )
+                    args.accept()
+            case (
+                DevicePairingKinds.NONE
+                | DevicePairingKinds.PROVIDE_PASSWORD_CREDENTIAL
+                | DevicePairingKinds.PROVIDE_ADDRESS
+            ):
+                logger.debug("unsupported pairing kind: %r", args.pairing_kind)
+            case _:
+                assert_never(args.pairing_kind)
 
     @override
     async def unpair(self) -> None:

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -180,6 +180,13 @@ class BleakClientWinRT(BaseBleakClient):
         self._session_status_changed_token: Optional[EventRegistrationToken] = None
         self._max_pdu_size_changed_token: Optional[EventRegistrationToken] = None
 
+        if kwargs.get("pairing_callbacks"):
+            logger.warning(
+                "Pairing is not implemented in WinRT.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
     def __str__(self) -> str:
         return f"{type(self).__name__} ({self.address})"
 

--- a/bleak/exc.py
+++ b/bleak/exc.py
@@ -109,6 +109,18 @@ class BleakDeviceNotFoundError(BleakError):
         self.identifier = identifier
 
 
+class BleakPairingCancelledError(BleakError):
+    """
+    Specialized exception to indicate that pairing was canceled.
+    """
+
+
+class BleakPairingFailedError(BleakError):
+    """
+    Specialized exception to indicate that pairing failed.
+    """
+
+
 class BleakDBusError(BleakError):
     """Specialized exception type for D-Bus errors."""
 

--- a/examples/pairing_agent.py
+++ b/examples/pairing_agent.py
@@ -1,0 +1,108 @@
+import argparse
+import asyncio
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.patch_stdout import patch_stdout
+
+from bleak import BaseBleakAgentCallbacks, BleakClient, BleakScanner
+from bleak.backends.device import BLEDevice
+from bleak.exc import (
+    BleakDeviceNotFoundError,
+    BleakPairingCancelledError,
+    BleakPairingFailedError,
+)
+
+
+class AgentCallbacks(BaseBleakAgentCallbacks):
+    def __init__(self) -> None:
+        self.session: PromptSession[str] = PromptSession()
+
+    async def request_passkey(self, device: BLEDevice) -> str:
+        print(f"{device.name} wants to pair.")
+        with patch_stdout():
+            response = await self.session.prompt_async("enter passkey: ")
+
+        return response
+
+    async def confirm_passkey(self, device: BLEDevice, passkey: str) -> bool:
+        print(f"{device.name} wants to pair.")
+        with patch_stdout():
+            response = await self.session.prompt_async(f"does {passkey} match (y/n)?")
+
+        return response.lower().startswith("y")
+
+
+async def main(address: str | None, name: str | None, unpair: bool, auto: bool) -> None:
+    if unpair:
+        print("unpairing...")
+        try:
+            if address:
+                await BleakClient(address).unpair()
+            elif name:
+                await BleakClient(name).unpair()
+            print("unpaired")
+        except BleakDeviceNotFoundError:
+            print("device was not paired")
+
+    print("scanning...")
+
+    if address:
+        device = await BleakScanner.find_device_by_address(address)
+        if device is None:
+            print(f"could not find device with address '{address}'")
+            return
+    elif name:
+        device = await BleakScanner.find_device_by_name(name)
+        if device is None:
+            print(f"could not find device with name '{name}'")
+            return
+    else:
+        raise ValueError("Either --name or --address must be provided")
+
+    callbacks = AgentCallbacks()
+    if auto:
+        print("connecting and pairing...")
+
+        async with BleakClient(
+            device, pair=True, pairing_callbacks=callbacks
+        ) as client:
+            print(f"connection and pairing to {client.address} successful")
+
+    else:
+        print("connecting...")
+
+        async with BleakClient(device, pairing_callbacks=callbacks) as client:
+            try:
+                print("pairing...")
+                await client.pair()
+                print("pairing successful")
+            except BleakPairingCancelledError:
+                print("paring was canceled")
+            except BleakPairingFailedError:
+                print("pairing failed (bad pin?)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("pairing_agent.py")
+
+    device_group = parser.add_mutually_exclusive_group(required=True)
+    device_group.add_argument(
+        "--name",
+        metavar="<name>",
+        help="the name of the bluetooth device to connect to",
+    )
+    device_group.add_argument(
+        "--address",
+        metavar="<address>",
+        help="the address of the bluetooth device to connect to",
+    )
+
+    parser.add_argument(
+        "--unpair", action="store_true", help="unpair first before pairing"
+    )
+    parser.add_argument(
+        "--auto", action="store_true", help="automatically pair during connect"
+    )
+    args = parser.parse_args()
+
+    asyncio.run(main(args.address, args.name, args.unpair, args.auto))

--- a/examples/pairing_agent.py
+++ b/examples/pairing_agent.py
@@ -1,85 +1,83 @@
+"""
+Pair with a BLE device using pairing callbacks.
+
+Run with ``--address <addr>`` or ``--name <name>``. Pairing happens during
+connection (``pair=True``), which is the reliable path for devices that only
+bond while connecting. Use ``--unpair`` to remove an existing bond first.
+
+Pairing callbacks are only supported on Windows and Linux. Console prompts run
+in a worker thread via :func:`asyncio.to_thread` so the event loop is not
+blocked.
+"""
+
 import argparse
 import asyncio
+import logging
 
-from prompt_toolkit import PromptSession
-from prompt_toolkit.patch_stdout import patch_stdout
+from bleak import BleakClient, BleakScanner
+from bleak.agent import ConfirmPasskey, DisplayPasskey, PairingCallbacks, RequestPasskey
+from bleak.exc import BleakDeviceNotFoundError, BleakError
 
-from bleak import BaseBleakAgentCallbacks, BleakClient, BleakScanner
-from bleak.backends.device import BLEDevice
-from bleak.exc import (
-    BleakDeviceNotFoundError,
-    BleakPairingCancelledError,
-    BleakPairingFailedError,
+
+async def confirm_passkey(request: ConfirmPasskey) -> bool:
+    answer = await asyncio.to_thread(
+        input, f"Does {request.device.name} show {request.passkey:06d}? [y/N] "
+    )
+    return answer.strip().lower().startswith("y")
+
+
+async def request_passkey(request: RequestPasskey) -> int | None:
+    answer = await asyncio.to_thread(
+        input, f"Enter the passkey shown on {request.device.name}: "
+    )
+    try:
+        return int(answer)
+    except ValueError:
+        return None
+
+
+async def display_passkey(request: DisplayPasskey) -> None:
+    print(f"Enter {request.passkey:06d} on {request.device.name}")
+
+
+CALLBACKS = PairingCallbacks(
+    confirm=confirm_passkey,
+    request_passkey=request_passkey,
+    display_passkey=display_passkey,
 )
 
 
-class AgentCallbacks(BaseBleakAgentCallbacks):
-    def __init__(self) -> None:
-        self.session: PromptSession[str] = PromptSession()
+async def main(address: str | None, name: str | None, unpair: bool) -> None:
+    target = address if address is not None else name
 
-    async def request_passkey(self, device: BLEDevice) -> str:
-        print(f"{device.name} wants to pair.")
-        with patch_stdout():
-            response = await self.session.prompt_async("enter passkey: ")
-
-        return response
-
-    async def confirm_passkey(self, device: BLEDevice, passkey: str) -> bool:
-        print(f"{device.name} wants to pair.")
-        with patch_stdout():
-            response = await self.session.prompt_async(f"does {passkey} match (y/n)?")
-
-        return response.lower().startswith("y")
-
-
-async def main(address: str | None, name: str | None, unpair: bool, auto: bool) -> None:
-    if unpair:
+    if unpair and target is not None:
         print("unpairing...")
         try:
-            if address:
-                await BleakClient(address).unpair()
-            elif name:
-                await BleakClient(name).unpair()
+            await BleakClient(target).unpair()
             print("unpaired")
         except BleakDeviceNotFoundError:
             print("device was not paired")
 
     print("scanning...")
-
-    if address:
+    if address is not None:
         device = await BleakScanner.find_device_by_address(address)
-        if device is None:
-            print(f"could not find device with address '{address}'")
-            return
-    elif name:
+    elif name is not None:
         device = await BleakScanner.find_device_by_name(name)
-        if device is None:
-            print(f"could not find device with name '{name}'")
-            return
     else:
-        raise ValueError("Either --name or --address must be provided")
+        raise ValueError("either --name or --address must be provided")
 
-    callbacks = AgentCallbacks()
-    if auto:
-        print("connecting and pairing...")
+    if device is None:
+        print("could not find device")
+        return
 
+    print("connecting and pairing...")
+    try:
         async with BleakClient(
-            device, pair=True, pairing_callbacks=callbacks
+            device, pairing_callbacks=CALLBACKS, pair=True
         ) as client:
-            print(f"connection and pairing to {client.address} successful")
-
-    else:
-        print("connecting...")
-
-        async with BleakClient(device, pairing_callbacks=callbacks) as client:
-            try:
-                print("pairing...")
-                await client.pair()
-                print("pairing successful")
-            except BleakPairingCancelledError:
-                print("paring was canceled")
-            except BleakPairingFailedError:
-                print("pairing failed (bad pin?)")
+            print(f"connected and paired to {client.address}")
+    except BleakError as e:
+        print(f"pairing failed: {e}")
 
 
 if __name__ == "__main__":
@@ -87,22 +85,17 @@ if __name__ == "__main__":
 
     device_group = parser.add_mutually_exclusive_group(required=True)
     device_group.add_argument(
-        "--name",
-        metavar="<name>",
-        help="the name of the bluetooth device to connect to",
+        "--name", metavar="<name>", help="the name of the device to connect to"
     )
     device_group.add_argument(
-        "--address",
-        metavar="<address>",
-        help="the address of the bluetooth device to connect to",
+        "--address", metavar="<address>", help="the address of the device to connect to"
     )
 
-    parser.add_argument(
-        "--unpair", action="store_true", help="unpair first before pairing"
-    )
-    parser.add_argument(
-        "--auto", action="store_true", help="automatically pair during connect"
-    )
+    parser.add_argument("--unpair", action="store_true", help="unpair before pairing")
+    parser.add_argument("--debug", action="store_true", help="enable debug logging")
     args = parser.parse_args()
 
-    asyncio.run(main(args.address, args.name, args.unpair, args.auto))
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+
+    asyncio.run(main(args.address, args.name, args.unpair))

--- a/tests/backends/bluezdbus/test_agent.py
+++ b/tests/backends/bluezdbus/test_agent.py
@@ -1,0 +1,136 @@
+"""Tests for the BlueZ pairing agent dispatch."""
+
+import sys
+
+import pytest
+
+if sys.platform != "linux":
+    pytest.skip("skipping linux-only tests", allow_module_level=True)
+    assert False  # HACK: work around pyright bug
+
+from unittest.mock import AsyncMock, MagicMock
+
+from dbus_fast import DBusError
+
+from bleak.agent import (
+    ConfirmPasskey,
+    DisplayPasskey,
+    IOCapability,
+    PairingCallbacks,
+    RequestPasskey,
+)
+from bleak.backends.bluezdbus.agent import (
+    _capability_name,  # pyright: ignore[reportPrivateUsage]
+)
+from bleak.backends.bluezdbus.agent import Agent
+
+_DEVICE_PATH = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+
+
+@pytest.fixture(autouse=True)
+def mock_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = MagicMock()
+    manager.get_device_address.return_value = "AA:BB:CC:DD:EE:FF"
+    manager.get_device_name.return_value = "Test Device"
+    monkeypatch.setattr(
+        "bleak.backends.bluezdbus.agent.get_global_bluez_manager",
+        AsyncMock(return_value=manager),
+    )
+
+
+async def _confirm(agent: Agent, passkey: int = 123456) -> None:
+    await agent._confirm(_DEVICE_PATH, passkey)  # pyright: ignore[reportPrivateUsage]
+
+
+async def _request_passkey(agent: Agent) -> int:
+    method = agent._request_passkey  # pyright: ignore[reportPrivateUsage]
+    return await method(_DEVICE_PATH)
+
+
+async def _display(agent: Agent, passkey: int = 123456) -> None:
+    await agent._display(_DEVICE_PATH, passkey)  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_confirm_accepts() -> None:
+    seen: list[int] = []
+
+    async def confirm(request: ConfirmPasskey) -> bool:
+        seen.append(request.passkey)
+        return True
+
+    await _confirm(Agent(PairingCallbacks(confirm=confirm)), 123456)
+
+    assert seen == [123456]
+
+
+async def test_confirm_rejected_raises() -> None:
+    async def confirm(request: ConfirmPasskey) -> bool:
+        return False
+
+    with pytest.raises(DBusError):
+        await _confirm(Agent(PairingCallbacks(confirm=confirm)))
+
+
+async def test_confirm_without_callback_raises() -> None:
+    with pytest.raises(DBusError):
+        await _confirm(Agent(PairingCallbacks()))
+
+
+async def test_request_passkey_returns_value() -> None:
+    async def request_passkey(request: RequestPasskey) -> int | None:
+        return 42
+
+    assert (
+        await _request_passkey(Agent(PairingCallbacks(request_passkey=request_passkey)))
+        == 42
+    )
+
+
+async def test_request_passkey_none_raises() -> None:
+    async def request_passkey(request: RequestPasskey) -> int | None:
+        return None
+
+    with pytest.raises(DBusError):
+        await _request_passkey(Agent(PairingCallbacks(request_passkey=request_passkey)))
+
+
+async def test_request_passkey_out_of_range_raises() -> None:
+    async def request_passkey(request: RequestPasskey) -> int | None:
+        return 1_000_000
+
+    with pytest.raises(DBusError):
+        await _request_passkey(Agent(PairingCallbacks(request_passkey=request_passkey)))
+
+
+async def test_request_passkey_without_callback_raises() -> None:
+    with pytest.raises(DBusError):
+        await _request_passkey(Agent(PairingCallbacks()))
+
+
+async def test_display_invokes_callback() -> None:
+    seen: list[int] = []
+
+    async def display_passkey(request: DisplayPasskey) -> None:
+        seen.append(request.passkey)
+
+    await _display(Agent(PairingCallbacks(display_passkey=display_passkey)), 654321)
+
+    assert seen == [654321]
+
+
+async def test_display_without_callback_is_noop() -> None:
+    await _display(Agent(PairingCallbacks()))
+
+
+@pytest.mark.parametrize(
+    ("capability", "name"),
+    [
+        (IOCapability.NO_INPUT_NO_OUTPUT, "NoInputNoOutput"),
+        (IOCapability.DISPLAY_YES_NO, "DisplayYesNo"),
+        (IOCapability.KEYBOARD_ONLY, "KeyboardOnly"),
+        (IOCapability.DISPLAY_ONLY, "DisplayOnly"),
+        (IOCapability.KEYBOARD_DISPLAY, "KeyboardDisplay"),
+    ],
+)
+def test_capability_name(capability: IOCapability, name: str) -> None:
+    assert _capability_name(capability) == name

--- a/tests/backends/winrt/test_pairing.py
+++ b/tests/backends/winrt/test_pairing.py
@@ -1,0 +1,194 @@
+"""Tests for WinRT pairing-kind derivation and pairing-request dispatch."""
+
+import sys
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+if sys.platform != "win32":
+    pytest.skip("skipping windows-only tests", allow_module_level=True)
+    assert False  # HACK: work around pyright bug
+
+from winrt.windows.devices.enumeration import (
+    DevicePairingKinds,
+    DevicePairingRequestedEventArgs,
+)
+
+from bleak.agent import ConfirmPasskey, DisplayPasskey, PairingCallbacks, RequestPasskey
+from bleak.backends.winrt.client import (
+    _pairing_kinds,  # pyright: ignore[reportPrivateUsage]
+)
+from bleak.backends.winrt.client import BleakClientWinRT
+
+
+async def _confirm(request: ConfirmPasskey) -> bool:
+    return True
+
+
+async def _request_passkey(request: RequestPasskey) -> int | None:
+    return 0
+
+
+async def _display_passkey(request: DisplayPasskey) -> None:
+    return None
+
+
+@pytest.mark.parametrize(
+    ("callbacks", "expected"),
+    [
+        (None, DevicePairingKinds.CONFIRM_ONLY),
+        (PairingCallbacks(), DevicePairingKinds.CONFIRM_ONLY),
+        (
+            PairingCallbacks(confirm=_confirm),
+            DevicePairingKinds.CONFIRM_ONLY | DevicePairingKinds.CONFIRM_PIN_MATCH,
+        ),
+        (
+            PairingCallbacks(request_passkey=_request_passkey),
+            DevicePairingKinds.CONFIRM_ONLY | DevicePairingKinds.PROVIDE_PIN,
+        ),
+        (
+            PairingCallbacks(display_passkey=_display_passkey),
+            DevicePairingKinds.CONFIRM_ONLY | DevicePairingKinds.DISPLAY_PIN,
+        ),
+        (
+            PairingCallbacks(
+                confirm=_confirm,
+                request_passkey=_request_passkey,
+                display_passkey=_display_passkey,
+            ),
+            DevicePairingKinds.CONFIRM_ONLY
+            | DevicePairingKinds.CONFIRM_PIN_MATCH
+            | DevicePairingKinds.PROVIDE_PIN
+            | DevicePairingKinds.DISPLAY_PIN,
+        ),
+    ],
+)
+def test_pairing_kinds(
+    callbacks: PairingCallbacks | None, expected: DevicePairingKinds
+) -> None:
+    """Each provided callback adds the pairing kind it can take part in."""
+    assert _pairing_kinds(callbacks) == expected
+
+
+def _make_client(monkeypatch: pytest.MonkeyPatch) -> BleakClientWinRT:
+    client = BleakClientWinRT("AA:BB:CC:DD:EE:FF", winrt={}, timeout=10.0)
+    requester = MagicMock()
+    requester.name = "Test Device"
+    monkeypatch.setattr(client, "_requester", requester)
+    return client
+
+
+def _make_args(kind: DevicePairingKinds, pin: str = "123456") -> MagicMock:
+    args = MagicMock(spec=DevicePairingRequestedEventArgs)
+    args.pairing_kind = kind
+    args.pin = pin
+    return args
+
+
+async def _dispatch(
+    client: BleakClientWinRT, args: MagicMock, callbacks: PairingCallbacks | None
+) -> None:
+    await client._accept_pairing(  # pyright: ignore[reportPrivateUsage]
+        cast(DevicePairingRequestedEventArgs, args), callbacks
+    )
+
+
+async def test_accept_confirm_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Just Works is accepted without any callback."""
+    client = _make_client(monkeypatch)
+    args = _make_args(DevicePairingKinds.CONFIRM_ONLY)
+
+    await _dispatch(client, args, None)
+
+    args.accept.assert_called_once_with()
+
+
+async def test_accept_numeric_comparison_confirmed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Numeric Comparison accepts when the confirm callback returns True."""
+    client = _make_client(monkeypatch)
+    seen: list[int] = []
+
+    async def confirm(request: ConfirmPasskey) -> bool:
+        seen.append(request.passkey)
+        return True
+
+    args = _make_args(DevicePairingKinds.CONFIRM_PIN_MATCH, pin="123456")
+
+    await _dispatch(client, args, PairingCallbacks(confirm=confirm))
+
+    assert seen == [123456]
+    args.accept.assert_called_once_with()
+
+
+async def test_accept_numeric_comparison_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Numeric Comparison does not accept when the confirm callback returns False."""
+    client = _make_client(monkeypatch)
+
+    async def confirm(request: ConfirmPasskey) -> bool:
+        return False
+
+    args = _make_args(DevicePairingKinds.CONFIRM_PIN_MATCH)
+
+    await _dispatch(client, args, PairingCallbacks(confirm=confirm))
+
+    args.accept.assert_not_called()
+
+
+async def test_accept_provide_pin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Passkey Entry accepts with the zero-padded passkey from the callback."""
+    client = _make_client(monkeypatch)
+
+    async def request_passkey(request: RequestPasskey) -> int | None:
+        return 42
+
+    args = _make_args(DevicePairingKinds.PROVIDE_PIN)
+
+    await _dispatch(client, args, PairingCallbacks(request_passkey=request_passkey))
+
+    args.accept_with_pin.assert_called_once_with("000042")
+
+
+async def test_accept_provide_pin_none_rejects(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returning None from the passkey callback rejects the pairing."""
+    client = _make_client(monkeypatch)
+
+    async def request_passkey(request: RequestPasskey) -> int | None:
+        return None
+
+    args = _make_args(DevicePairingKinds.PROVIDE_PIN)
+
+    await _dispatch(client, args, PairingCallbacks(request_passkey=request_passkey))
+
+    args.accept_with_pin.assert_not_called()
+
+
+async def test_accept_display_pin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Display Pin shows the passkey to the callback then accepts."""
+    client = _make_client(monkeypatch)
+    seen: list[int] = []
+
+    async def display_passkey(request: DisplayPasskey) -> None:
+        seen.append(request.passkey)
+
+    args = _make_args(DevicePairingKinds.DISPLAY_PIN, pin="654321")
+
+    await _dispatch(client, args, PairingCallbacks(display_passkey=display_passkey))
+
+    assert seen == [654321]
+    args.accept.assert_called_once_with()
+
+
+async def test_accept_unsupported_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unsupported pairing kind is neither accepted nor crashes."""
+    client = _make_client(monkeypatch)
+    args = _make_args(DevicePairingKinds.PROVIDE_PASSWORD_CREDENTIAL)
+
+    await _dispatch(client, args, None)
+
+    args.accept.assert_not_called()
+    args.accept_with_pin.assert_not_called()

--- a/tests/integration/README.rst
+++ b/tests/integration/README.rst
@@ -19,6 +19,10 @@ with a HCI-UART firmware. The firmware including instructions can be found
 the advantage over the HCI-USB firmware, that it is not automatically claimed by
 the OS, so that ``bumble`` can use it without special configurations.
 
+`Intercreate <https://intercreate.io>`_ maintains a `repository <https://github.com/intercreate/zephyr-hci>`_
+and `PyPI packages <https://pypi.org/project/zephyr-4.4.0-hci/>`_ for distribution
+of prebuilt HCI firmware. PRs to add more FW and board variants are welcome!
+
 To run the integration tests you have to pass the ``--bleak-hci-transport`` moniker of your
  ``bumble`` device. You have to specify the bumble moniker of the transport. For more
 information see the `bumble documentation <https://google.github.io/bumble/transports/serial.html>`_.
@@ -39,6 +43,15 @@ On Windows you can find the port via the Device Manager under "Ports (COM & LPT)
 And the moniker will look like this::
 
     serial:COM3
+
+If your firmware exposes an HCI-USB interface instead of UART, use the ``usb``
+transport moniker::
+
+    $ uv run pytest --bleak-hci-transport=usb:0
+
+Here ``usb:0`` selects the first USB Bluetooth controller. See the `bumble USB
+transport documentation <https://google.github.io/bumble/transports/usb.html>`_
+for selecting a specific device by ``VID:PID``.
 
 
 Virtual Bluetooth controllers

--- a/tests/integration/test_client_pairing.py
+++ b/tests/integration/test_client_pairing.py
@@ -1,19 +1,202 @@
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+
 import pytest
-from bumble.device import Device
+from bumble.device import Connection, Device
+from bumble.pairing import PairingConfig, PairingDelegate
 
 from bleak import BleakClient
+from bleak.agent import ConfirmPasskey, DisplayPasskey, PairingCallbacks, RequestPasskey
 from bleak.backends import BleakBackend, get_default_backend
 from tests.integration.conftest import (
     configure_and_power_on_bumble_peripheral,
     find_ble_device,
 )
 
+logger = logging.getLogger(__name__)
+
+_PAIRING_BACKENDS = (BleakBackend.WIN_RT, BleakBackend.BLUEZ_DBUS)
+
+pairing_supported = pytest.mark.skipif(
+    get_default_backend() not in _PAIRING_BACKENDS,
+    reason="pairing with callbacks is only implemented on WinRT and BlueZ",
+)
+
+
+@pytest.fixture
+async def pairing_peripheral(bumble_peripheral: Device) -> AsyncGenerator[Device, None]:
+    """Wrap :func:`bumble_peripheral` with the teardown a pairing test needs.
+
+    A successful pairing leaves an OS-level bond and a still-powered-on bumble
+    device. A leaked bond makes the next SMP exchange fail, so the bond is
+    removed here. Each teardown step is isolated because a single bumble
+    cleanup failure can otherwise leave the controller hung.
+    """
+    try:
+        yield bumble_peripheral
+    finally:
+        address = str(bumble_peripheral.random_address)
+        try:
+            await BleakClient(address).unpair()
+        except Exception as e:
+            logger.warning("teardown unpair of %s failed: %s", address, e)
+        try:
+            await bumble_peripheral.power_off()
+        except Exception as e:
+            logger.warning("teardown power_off failed: %s", e)
+
+
+class _JustWorksDelegate(PairingDelegate):
+    """Peripheral side of a Just Works (no MITM) pairing."""
+
+    def __init__(self) -> None:
+        super().__init__(io_capability=PairingDelegate.NO_OUTPUT_NO_INPUT)
+
+
+class _DisplayDelegate(PairingDelegate):
+    """Peripheral displays the passkey; the central enters it."""
+
+    def __init__(self, displayed: "asyncio.Future[int]") -> None:
+        super().__init__(io_capability=PairingDelegate.DISPLAY_OUTPUT_ONLY)
+        self._displayed = displayed
+
+    async def display_number(self, number: int, digits: int) -> None:
+        if not self._displayed.done():
+            self._displayed.set_result(number)
+
+
+class _KeyboardDelegate(PairingDelegate):
+    """Peripheral enters the passkey the central displays."""
+
+    def __init__(self, displayed: "asyncio.Future[int]") -> None:
+        super().__init__(io_capability=PairingDelegate.KEYBOARD_INPUT_ONLY)
+        self._displayed = displayed
+
+    async def get_number(self) -> int | None:
+        return await self._displayed
+
+
+class _CompareDelegate(PairingDelegate):
+    """Peripheral confirms a numeric comparison; records the shown passkey."""
+
+    def __init__(self, shown: "asyncio.Future[int]") -> None:
+        super().__init__(io_capability=PairingDelegate.DISPLAY_OUTPUT_AND_YES_NO_INPUT)
+        self._shown = shown
+
+    async def compare_numbers(self, number: int, digits: int) -> bool:
+        if not self._shown.done():
+            self._shown.set_result(number)
+        return True
+
+
+def _use_pairing(peripheral: Device, delegate: PairingDelegate, *, mitm: bool) -> None:
+    def factory(_connection: Connection) -> PairingConfig:
+        return PairingConfig(sc=True, mitm=mitm, bonding=True, delegate=delegate)
+
+    peripheral.pairing_config_factory = factory
+
+
+@pairing_supported
+async def test_pair_just_works(pairing_peripheral: Device) -> None:
+    """Just Works pairing succeeds with no callbacks."""
+    _use_pairing(pairing_peripheral, _JustWorksDelegate(), mitm=False)
+    await configure_and_power_on_bumble_peripheral(pairing_peripheral)
+    device = await find_ble_device(pairing_peripheral)
+
+    async with BleakClient(device, pair=True) as client:
+        assert client.is_connected
+
+
+@pairing_supported
+async def test_pair_numeric_comparison(pairing_peripheral: Device) -> None:
+    """Numeric Comparison: both sides see the same passkey and accept."""
+    loop = asyncio.get_running_loop()
+    peripheral_passkey: "asyncio.Future[int]" = loop.create_future()
+    central_passkey: "asyncio.Future[int]" = loop.create_future()
+
+    _use_pairing(pairing_peripheral, _CompareDelegate(peripheral_passkey), mitm=True)
+    await configure_and_power_on_bumble_peripheral(pairing_peripheral)
+    device = await find_ble_device(pairing_peripheral)
+
+    async def confirm(request: ConfirmPasskey) -> bool:
+        if not central_passkey.done():
+            central_passkey.set_result(request.passkey)
+        return True
+
+    async with BleakClient(
+        device, pairing_callbacks=PairingCallbacks(confirm=confirm), pair=True
+    ) as client:
+        assert client.is_connected
+
+    assert await peripheral_passkey == await central_passkey
+
+
+@pairing_supported
+async def test_pair_passkey_entry_central_inputs(pairing_peripheral: Device) -> None:
+    """Passkey Entry where the peripheral displays and the central enters."""
+    loop = asyncio.get_running_loop()
+    displayed: "asyncio.Future[int]" = loop.create_future()
+
+    _use_pairing(pairing_peripheral, _DisplayDelegate(displayed), mitm=True)
+    await configure_and_power_on_bumble_peripheral(pairing_peripheral)
+    device = await find_ble_device(pairing_peripheral)
+
+    async def request_passkey(request: RequestPasskey) -> int | None:
+        return await displayed
+
+    async with BleakClient(
+        device,
+        pairing_callbacks=PairingCallbacks(request_passkey=request_passkey),
+        pair=True,
+    ) as client:
+        assert client.is_connected
+
+
+@pairing_supported
+async def test_pair_passkey_entry_central_displays(pairing_peripheral: Device) -> None:
+    """Passkey Entry where the central displays and the peripheral enters."""
+    loop = asyncio.get_running_loop()
+    displayed: "asyncio.Future[int]" = loop.create_future()
+
+    _use_pairing(pairing_peripheral, _KeyboardDelegate(displayed), mitm=True)
+    await configure_and_power_on_bumble_peripheral(pairing_peripheral)
+    device = await find_ble_device(pairing_peripheral)
+
+    async def display_passkey(request: DisplayPasskey) -> None:
+        if not displayed.done():
+            displayed.set_result(request.passkey)
+
+    async with BleakClient(
+        device,
+        pairing_callbacks=PairingCallbacks(display_passkey=display_passkey),
+        pair=True,
+    ) as client:
+        assert client.is_connected
+
+
+@pairing_supported
+async def test_unpair(pairing_peripheral: Device) -> None:
+    """Pair then unpair a device.
+
+    Smoke test: there is no portable way to assert the OS bond was actually
+    removed, so this only verifies that ``unpair()`` completes without raising.
+    """
+    _use_pairing(pairing_peripheral, _JustWorksDelegate(), mitm=False)
+    await configure_and_power_on_bumble_peripheral(pairing_peripheral)
+    device = await find_ble_device(pairing_peripheral)
+
+    client = BleakClient(device, pair=True)
+    await client.connect()
+    await client.disconnect()
+    await client.unpair()
+
 
 @pytest.mark.skipif(
     get_default_backend() != BleakBackend.CORE_BLUETOOTH,
     reason="pairing is not possible on CoreBluetooth",
 )
-async def test_pairing_unavailable(bumble_peripheral: Device):
+async def test_pairing_unavailable(bumble_peripheral: Device) -> None:
     """Check if pairing on CoreBluetooth raises an error."""
     await configure_and_power_on_bumble_peripheral(bumble_peripheral)
 
@@ -24,6 +207,3 @@ async def test_pairing_unavailable(bumble_peripheral: Device):
         await client.pair()
     with pytest.raises(NotImplementedError):
         await client.unpair()
-
-
-# TODO: Add tests for pairing

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,58 @@
+"""Tests for :mod:`bleak.agent`."""
+
+import pytest
+
+from bleak.agent import (
+    ConfirmPasskey,
+    DisplayPasskey,
+    IOCapability,
+    PairingCallbacks,
+    RequestPasskey,
+    io_capability,
+)
+
+
+async def _confirm(request: ConfirmPasskey) -> bool:
+    return True
+
+
+async def _request_passkey(request: RequestPasskey) -> int | None:
+    return 0
+
+
+async def _display_passkey(request: DisplayPasskey) -> None:
+    return None
+
+
+@pytest.mark.parametrize(
+    ("callbacks", "expected"),
+    [
+        (PairingCallbacks(), IOCapability.NO_INPUT_NO_OUTPUT),
+        (PairingCallbacks(confirm=_confirm), IOCapability.DISPLAY_YES_NO),
+        (
+            PairingCallbacks(request_passkey=_request_passkey),
+            IOCapability.KEYBOARD_ONLY,
+        ),
+        (
+            PairingCallbacks(display_passkey=_display_passkey),
+            IOCapability.DISPLAY_ONLY,
+        ),
+        (
+            PairingCallbacks(
+                request_passkey=_request_passkey, display_passkey=_display_passkey
+            ),
+            IOCapability.KEYBOARD_DISPLAY,
+        ),
+        (
+            PairingCallbacks(
+                confirm=_confirm,
+                request_passkey=_request_passkey,
+                display_passkey=_display_passkey,
+            ),
+            IOCapability.KEYBOARD_DISPLAY,
+        ),
+    ],
+)
+def test_io_capability(callbacks: PairingCallbacks, expected: IOCapability) -> None:
+    """The advertised capability is derived from which callbacks are provided."""
+    assert io_capability(callbacks) == expected


### PR DESCRIPTION
Continues #1864 (cc @tgagneret-embedded) — this branch keeps the original pairing-callbacks commit and adds the WinRT implementation, a sum-type rework of the API, full test coverage, and review fixes. Builds on #1133 and #1100.

## What

`bleak.agent` exposes `PairingCallbacks` — optional async handlers for `ConfirmPasskey` (Numeric Comparison) and `RequestPasskey` / `DisplayPasskey` (Passkey Entry, both directions). Which callbacks are provided determines the advertised `IOCapability`, which drives the negotiated Security Manager ceremony. With no callbacks, Just Works is accepted automatically (unchanged behavior).

- **WinRT** — a deferral-bridged `PairingRequested` handler dispatches the ceremony with an exhaustive `match`.
- **BlueZ** — `org.bluez.Agent1` driven by the callbacks; the advertised capability is derived from them; the device is trusted after a successful pair.
- `timeout` / `disconnected_callback` / `pairing_callbacks` are now explicit, typed parameters on every backend (no more `kwargs.get`).
- Pairing failures raise `BleakPairingCancelledError` / `BleakPairingFailedError`.
- `examples/pairing_agent.py` demonstrates the API.

## Testing

- Unit tests: capability derivation and pairing-request dispatch (WinRT and BlueZ).
- `tests/integration/test_client_pairing.py`: bumble integration tests for all four LE Secure Connections ceremonies + unpair, runnable on Linux VHCI (no hardware) or over a USB HCI controller.
- mypy + pyright strict, flake8 / black / isort clean.
- The BlueZ `Trusted`-after-pair change addresses the review comment on #1864.

Validated on real hardware (Windows central + nRF52840 USB HCI bumble peripheral):

```
$ uv run --group test pytest tests/integration/test_client_pairing.py --bleak-hci-transport=usb:0 -v --no-cov

tests/integration/test_client_pairing.py::test_pair_just_works PASSED                        [ 16%]
tests/integration/test_client_pairing.py::test_pair_numeric_comparison PASSED                [ 33%]
tests/integration/test_client_pairing.py::test_pair_passkey_entry_central_inputs PASSED      [ 50%]
tests/integration/test_client_pairing.py::test_pair_passkey_entry_central_displays PASSED    [ 66%]
tests/integration/test_client_pairing.py::test_unpair PASSED                                 [ 83%]
tests/integration/test_client_pairing.py::test_pairing_unavailable SKIPPED (pairing is not possible on CoreBluetooth) [100%]

================================== 5 passed, 1 skipped in 24.77s ==================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1380
Closes #373 
Closes #758