### PR TITLE
backends/bluezdbus: use dbus-fast typed annotations

### DIFF
--- a/.github/alpine-vm/alpine-vm-setup.sh
+++ b/.github/alpine-vm/alpine-vm-setup.sh
@@ -26,6 +26,19 @@ step 'Enable bluetooth and dbus services'
 rc-update add bluetooth default
 rc-update add dbus default
 
+# Enable BlueZ experimental D-Bus interfaces. The AdvertisementMonitorManager1
+# interface (used by passive scanning with or_patterns) is gated behind this
+# flag, so RegisterMonitor is unavailable without it.
+step 'Enable BlueZ experimental interfaces'
+mkdir -p /etc/bluetooth
+if [ -f /etc/bluetooth/main.conf ] && grep -qiE '^[[:space:]]*#?[[:space:]]*Experimental' /etc/bluetooth/main.conf; then
+	sed -i -E 's/^[[:space:]]*#?[[:space:]]*Experimental.*/Experimental = true/I' /etc/bluetooth/main.conf
+elif [ -f /etc/bluetooth/main.conf ] && grep -qE '^\[General\]' /etc/bluetooth/main.conf; then
+	sed -i '/^\[General\]/a Experimental = true' /etc/bluetooth/main.conf
+else
+	printf '[General]\nExperimental = true\n' >> /etc/bluetooth/main.conf
+fi
+
 # Configure vhci kernel module to load at boot
 step 'Configure VHCI kernel module for boot'
 echo "hci_vhci" >> /etc/modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Added
 -----
 * Added ``BleakAdapter`` class with ``get_connected_devices()`` to retrieve BLE devices that are already connected to the system without scanning.
 
+Changed
+-------
+* Changed minimum ``dbus-fast`` version to 4.0.0 on Linux.
+
 Fixed
 -----
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -15,11 +15,18 @@ if TYPE_CHECKING:
 
 import logging
 from collections.abc import Iterable
-from typing import Any, no_type_check
+from typing import Annotated, Any
 from warnings import warn
 
 from dbus_fast import PropertyAccess
-from dbus_fast.service import ServiceInterface, dbus_property, method
+from dbus_fast.annotations import (
+    DBusInt16,
+    DBusObjectPath,
+    DBusSignature,
+    DBusStr,
+    DBusUInt16,
+)
+from dbus_fast.service import ServiceInterface, dbus_method, dbus_property
 
 from bleak.args.bluez import OrPattern as _OrPattern
 from bleak.args.bluez import OrPatternLike as _OrPatternLike
@@ -68,64 +75,51 @@ class AdvertisementMonitor(ServiceInterface):
                 List of or patterns that will be returned by the ``Patterns`` property.
         """
         super().__init__(defs.ADVERTISEMENT_MONITOR_INTERFACE)
-        # dbus_fast marshaling requires list instead of tuple
-        self._or_patterns = [list(p) for p in or_patterns]
+        self._or_patterns = list(or_patterns)
 
-    @method()
-    def Release(self):
+    @dbus_method()
+    def Release(self) -> None:
         logger.debug("Release")
 
-    @method()
-    def Activate(self):
+    @dbus_method()
+    def Activate(self) -> None:
         logger.debug("Activate")
 
-    # REVISIT: mypy is broke, so we have to add redundant @no_type_check
-    # https://github.com/python/mypy/issues/6583
-
-    @method()
-    @no_type_check
-    def DeviceFound(self, device: "o"):  # noqa: F821
+    @dbus_method()
+    def DeviceFound(self, device: DBusObjectPath) -> None:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("DeviceFound %s", device)
 
-    @method()
-    @no_type_check
-    def DeviceLost(self, device: "o"):  # noqa: F821
+    @dbus_method()
+    def DeviceLost(self, device: DBusObjectPath) -> None:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("DeviceLost %s", device)
 
     @dbus_property(PropertyAccess.READ)
-    @no_type_check
-    def Type(self) -> "s":  # noqa: F821
+    def Type(self) -> DBusStr:
         # this is currently the only type supported in BlueZ
         return "or_patterns"
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSILowThreshold(self) -> "n":  # noqa: F821
-        ...
+    def RSSILowThreshold(self) -> DBusInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSIHighThreshold(self) -> "n":  # noqa: F821
-        ...
+    def RSSIHighThreshold(self) -> DBusInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSILowTimeout(self) -> "q":  # noqa: F821
-        ...
+    def RSSILowTimeout(self) -> DBusUInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSIHighTimeout(self) -> "q":  # noqa: F821
-        ...
+    def RSSIHighTimeout(self) -> DBusUInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSISamplingPeriod(self) -> "q":  # noqa: F821
-        ...
+    def RSSISamplingPeriod(self) -> DBusUInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ)
-    @no_type_check
-    def Patterns(self) -> "a(yyay)":  # noqa: F821
+    def Patterns(self) -> Annotated[list[_OrPatternLike], DBusSignature("a(yyay)")]:
         return self._or_patterns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "winrt-Windows.Foundation>=3.1; platform_system=='Windows'",
     "winrt-Windows.Foundation.Collections>=3.1; platform_system=='Windows'",
     "winrt-Windows.Storage.Streams>=3.1; platform_system=='Windows'",
-    "dbus-fast>=1.83.0; platform_system=='Linux'",
+    "dbus-fast>=4.0.0; platform_system=='Linux'",
 ]
 
 [project.urls]

--- a/tests/integration/test_scanner.py
+++ b/tests/integration/test_scanner.py
@@ -8,12 +8,22 @@ from bumble.core import UUID
 from bumble.device import Device
 
 from bleak import BleakScanner
+from bleak.args.bluez import OrPattern, OrPatternLike
+from bleak.assigned_numbers import AdvertisementDataType
+from bleak.backends import BleakBackend, get_default_backend
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.uuids import normalize_uuid_str
 from tests.integration.conftest import configure_and_power_on_bumble_peripheral
 
 DEFAULT_TIMEOUT = 5.0
+
+# The default bumble peripheral advertises Flags == 0x06
+# (LE General Discoverable | BR/EDR not supported), so this pattern matches it.
+_FLAGS_NAMED_TUPLE: list[OrPatternLike] = [
+    OrPattern(0, AdvertisementDataType.FLAGS, b"\x06")
+]
+_FLAGS_PLAIN_TUPLE: list[OrPatternLike] = [(0, AdvertisementDataType.FLAGS, b"\x06")]
 
 
 async def test_discover(bumble_peripheral: Device):
@@ -111,6 +121,47 @@ async def test_adv_data_simple(bumble_peripheral: Device):
 
     # The rssi can vary. So we only check for a plausible range.
     assert -127 <= found_adv_data.rssi <= 20
+
+
+@pytest.mark.skipif(
+    get_default_backend() != BleakBackend.BLUEZ_DBUS,
+    reason="passive scanning with or_patterns is only supported on BlueZ",
+)
+@pytest.mark.parametrize(
+    "or_patterns",
+    [_FLAGS_NAMED_TUPLE, _FLAGS_PLAIN_TUPLE],
+    ids=["named_tuple", "tuple"],
+)
+async def test_passive_scan_or_patterns(
+    bumble_peripheral: Device,
+    or_patterns: list[OrPatternLike],
+):
+    """Passive scanning with ``or_patterns`` discovers the device.
+
+    Exercises the ``org.bluez.AdvertisementMonitor1`` ``Patterns`` property
+    (D-Bus signature ``a(yyay)``) end to end. Both ``OrPattern`` named tuples
+    and plain tuples must marshal over D-Bus without converting each pattern to
+    a ``list`` first.
+    """
+    await configure_and_power_on_bumble_peripheral(bumble_peripheral)
+
+    found_adv_data_future: asyncio.Future[AdvertisementData] = asyncio.Future()
+
+    def detection_callback(device: BLEDevice, adv_data: AdvertisementData):
+        if device.name == bumble_peripheral.name and not found_adv_data_future.done():
+            found_adv_data_future.set_result(adv_data)
+
+    async with BleakScanner(
+        detection_callback,
+        scanning_mode="passive",
+        bluez={"or_patterns": or_patterns},
+    ):
+        found_adv_data = await asyncio.wait_for(
+            found_adv_data_future, timeout=DEFAULT_TIMEOUT
+        )
+
+    assert found_adv_data is not None
+    assert found_adv_data.local_name == bumble_peripheral.name
 
 
 async def test_adv_data_complex(bumble_peripheral: Device):

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ test = [
 requires-dist = [
     { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=3.0.0" },
     { name = "bleak-pythonista", marker = "extra == 'pythonista'", specifier = ">=0.1.1" },
-    { name = "dbus-fast", marker = "sys_platform == 'linux'", specifier = ">=1.83.0" },
+    { name = "dbus-fast", marker = "sys_platform == 'linux'", specifier = ">=4.0.0" },
     { name = "pyobjc-core", marker = "sys_platform == 'darwin'", specifier = ">=10.3" },
     { name = "pyobjc-framework-corebluetooth", marker = "sys_platform == 'darwin'", specifier = ">=10.3" },
     { name = "pyobjc-framework-libdispatch", marker = "sys_platform == 'darwin'", specifier = ">=10.3" },


### PR DESCRIPTION
Split out of #1990, addressing the review request to use dbus-fast's typed annotations instead of the string-signature shims.

## What

Migrates `AdvertisementMonitor`'s `org.bluez.AdvertisementMonitor1` interface from `@no_type_check` + string signatures to dbus-fast's typed annotations:

- Method/property signatures use the `dbus_fast.annotations` aliases — `DBusObjectPath`, `DBusStr`, `DBusInt16`, `DBusUInt16`, and `Annotated[..., DBusSignature("a(yyay)")]` — instead of the `"o"` / `"s"` / `"a(yyay)"` string shims.
- Uses the typed `@dbus_method` decorator (not `@method`), with explicit `-> None` return types on the void methods.
- Drops the `@no_type_check` workaround for [python/mypy#6583](https://github.com/python/mypy/issues/6583) and the `# noqa: F821` forward-ref shims.
- Disabled property stubs `raise NotImplementedError` instead of `...` — they are type-checked now, so an empty body would fail mypy.
- `Patterns` is typed `list[_OrPatternLike]` (the `(yyay)` struct is `(int, int, bytes)`), and the or-patterns are stored as-is via `list(or_patterns)`. The old `# dbus_fast marshaling requires list instead of tuple` conversion is removed — dbus-fast marshals tuples/`NamedTuple`s for STRUCTs just as well as lists.
- Bumps `dbus-fast>=4.0.0` on Linux (no upper cap) — 4.0 is the first release that ships the annotation aliases and `dbus_method`.

## Why

This is the prerequisite that lets the BlueZ backend (and the pairing agent built on it) be fully type-checked without per-method opt-outs.

## Testing

- mypy + pyright (strict) clean, native and Linux-simulated.
- No change to the marshaled D-Bus output; the BlueZ VHCI integration suite exercises the advertisement monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
