### PR TITLE
backends: make timeout and disconnected_callback explicit kwargs

### DIFF
--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -66,10 +66,16 @@ class BleakClientBlueZDBus(BaseBleakClient):
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
         *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
         bluez: BlueZClientArgs,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
 
         self._adapter = bluez.get("adapter")
         self._device_path: Optional[str]

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -4,7 +4,7 @@ Base class for backend clients.
 """
 import abc
 from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from bleak.args import SizedBuffer
 from bleak.backends import BleakBackend, get_default_backend
@@ -28,11 +28,18 @@ class BaseBleakClient(abc.ABC):
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call.
         disconnected_callback (callable): Callback that will be scheduled in the
-            event loop when the client is disconnected. The callable must take one
-            argument, which will be this client object.
+            event loop when the client is disconnected. The callable takes no
+            arguments.
     """
 
-    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs: Any):
+    def __init__(
+        self,
+        address_or_ble_device: BLEDevice | str,
+        *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
+        **kwargs: Any,
+    ) -> None:
         if isinstance(address_or_ble_device, BLEDevice):
             self.address = address_or_ble_device.address
         else:
@@ -40,10 +47,8 @@ class BaseBleakClient(abc.ABC):
 
         self.services: Optional[BleakGATTServiceCollection] = None
 
-        self._timeout = kwargs["timeout"]
-        self._disconnected_callback: Optional[Callable[[], None]] = kwargs.get(
-            "disconnected_callback"
-        )
+        self._timeout = timeout
+        self._disconnected_callback = disconnected_callback
 
     # NB: this is not marked as @abc.abstractmethod because that would break
     # 3rd-party backends. We might change this in the future to make it required.

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import Any, Optional, Union
 
 from CoreBluetooth import (
@@ -59,9 +60,16 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self,
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
+        *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
 
         self._peripheral: Optional[CBPeripheral] = None
         self._delegate: Optional[PeripheralDelegate] = None

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import uuid
 import warnings
+from collections.abc import Callable
 from typing import Any, Optional, Union
 
 from android.broadcast import BroadcastReceiver
@@ -46,9 +47,16 @@ class BleakClientP4Android(BaseBleakClient):
         self,
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[uuid.UUID]],
-        **kwargs,
+        *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
+        **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
         self._requested_services = (
             set(map(defs.UUID.fromString, services)) if services else None
         )

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -149,10 +149,16 @@ class BleakClientWinRT(BaseBleakClient):
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
         *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
         winrt: _WinRTClientArgs,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
 
         self._device_info: int | None
 


### PR DESCRIPTION
Split out of #1990.

## What

Makes the previously-implicit `timeout` / `disconnected_callback` contract explicit on the backend clients instead of threading them through `**kwargs`:

- `BaseBleakClient.__init__` takes `timeout` and `disconnected_callback` as explicit keyword-only parameters.
- The WinRT, BlueZ, CoreBluetooth, and p4android backends accept and forward them explicitly.
- Corrects the `disconnected_callback` docstring: the backend-level callable takes **no** arguments (signature is `Callable[[], None]`), matching how backends invoke it — the previous "must take one argument (the client)" text described the public facade, not this interface.

This makes the constructor signatures self-documenting and is the groundwork for adding `pairing_callbacks` as a sibling explicit parameter in a follow-up.

## Note for review

This also drops the `branches: [master, develop]` filter from the `pull_request:` trigger in `build_and_test.yml` and `format_and_lint.yml` so CI runs on every PR (it was needed to run CI on the stacked split PRs). If you'd rather keep that filter on upstream, I'm happy to pull those two lines back out of this PR.

## Testing

- mypy + pyright (strict) clean, native and Linux-simulated.
- No behavior change; existing connect/disconnect coverage exercises the forwarded parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
