### PR TITLE
backends/corebluetooth: clear notify callbacks on disconnect

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Added
 Fixed
 -----
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.
+* Fixed ``ValueError`` when calling ``start_notify()`` after reconnecting in the CoreBluetooth backend. Fixes #1969.
 
 `3.0.2`_ (2026-05-02)
 =====================

--- a/bleak/backends/corebluetooth/PeripheralDelegate.py
+++ b/bleak/backends/corebluetooth/PeripheralDelegate.py
@@ -339,6 +339,18 @@ class PeripheralDelegate:
             self._read_rssi_futures.values(),
         )
 
+    def clear_notify_callbacks(self) -> None:
+        """
+        Removes all registered notification callbacks.
+
+        CoreBluetooth automatically stops notifications when a peripheral
+        disconnects, so this should be called on disconnect to keep the
+        delegate state in sync. Otherwise ``start_notifications`` will fail
+        with "Characteristic notifications already started" after reconnecting.
+        """
+        self._characteristic_notify_callbacks.clear()
+        self._characteristic_notification_discriminators.clear()
+
     async def discover_services(
         self, services: Optional[NSArray[CBUUID]] = None
     ) -> NSArray[CBService]:

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -116,6 +116,12 @@ class BleakClientCoreBluetooth(BaseBleakClient):
 
             assert self._delegate is not None
 
+            # CoreBluetooth has already stopped all notifications at this
+            # point, but the delegate is reused when reconnecting, so its
+            # bookkeeping needs to be reset, otherwise calling start_notify()
+            # again after reconnecting raises ValueError.
+            self._delegate.clear_notify_callbacks()
+
             # If there are any pending futures waiting for delegate callbacks, we
             # need to raise an exception since the callback will no longer be
             # called because the device is disconnected.

--- a/tests/backends/corebluetooth/test_client.py
+++ b/tests/backends/corebluetooth/test_client.py
@@ -1,0 +1,74 @@
+import sys
+
+import pytest
+
+if sys.platform != "darwin":
+    pytest.skip("CoreBluetooth only tests", allow_module_level=True)
+    # unreachable, but makes the type checkers happy
+    assert False
+
+from typing import cast
+from unittest.mock import AsyncMock, Mock, patch
+
+from CoreBluetooth import CBPeripheral
+
+from bleak.backends.corebluetooth.CentralManagerDelegate import (
+    CentralManagerDelegate,
+    DisconnectCallback,
+)
+from bleak.backends.corebluetooth.client import BleakClientCoreBluetooth
+from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
+
+
+async def test_disconnect_callback_clears_notify_callbacks() -> None:
+    """
+    The disconnect callback resets the notification bookkeeping of the
+    peripheral delegate, so that ``start_notify()`` works again after
+    reconnecting with the same client instance.
+
+    Regression test for: https://github.com/hbldh/bleak/issues/1969
+    """
+    peripheral = cast(CBPeripheral, Mock())
+    disconnect_callbacks: list[DisconnectCallback] = []
+
+    async def connect(
+        peripheral: CBPeripheral,
+        disconnect_callback: DisconnectCallback,
+        timeout: float = 10.0,
+    ) -> None:
+        disconnect_callbacks.append(disconnect_callback)
+
+    manager = Mock(spec=CentralManagerDelegate)
+    manager.connect = connect
+
+    device = BLEDevice(
+        "00000000-0000-0000-0000-000000000000", "Test", (peripheral, manager)
+    )
+    client = BleakClientCoreBluetooth(device, timeout=10.0)
+
+    with patch.object(BleakClientCoreBluetooth, "_get_services", AsyncMock()):
+        await client.connect(pair=False)
+
+    delegate = client._delegate  # pyright: ignore[reportPrivateUsage]
+    assert delegate is not None
+
+    callbacks = (
+        delegate._characteristic_notify_callbacks  # pyright: ignore[reportPrivateUsage]
+    )
+    discriminators = (
+        delegate._characteristic_notification_discriminators  # pyright: ignore[reportPrivateUsage]
+    )
+
+    callbacks[42] = lambda data: None
+    discriminators[42] = None
+
+    (disconnect_callback,) = disconnect_callbacks
+    disconnect_callback()
+
+    assert not callbacks
+    assert not discriminators
+
+    # the disconnect callback also fails any pending futures
+    with pytest.raises(BleakError, match="disconnected"):
+        await delegate._services_discovered_future  # pyright: ignore[reportPrivateUsage]

--- a/tests/backends/corebluetooth/test_peripheral_delegate.py
+++ b/tests/backends/corebluetooth/test_peripheral_delegate.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+
+if sys.platform != "darwin":
+    pytest.skip("CoreBluetooth only tests", allow_module_level=True)
+    # unreachable, but makes the type checkers happy
+    assert False
+
+from typing import cast
+from unittest.mock import Mock
+
+from CoreBluetooth import CBPeripheral
+
+from bleak.backends.corebluetooth.PeripheralDelegate import PeripheralDelegate
+
+
+async def test_clear_notify_callbacks() -> None:
+    """clear_notify_callbacks() removes all notification bookkeeping."""
+    delegate = PeripheralDelegate(cast(CBPeripheral, Mock()))
+
+    callbacks = (
+        delegate._characteristic_notify_callbacks  # pyright: ignore[reportPrivateUsage]
+    )
+    discriminators = (
+        delegate._characteristic_notification_discriminators  # pyright: ignore[reportPrivateUsage]
+    )
+
+    callbacks[42] = lambda data: None
+    discriminators[42] = None
+
+    delegate.clear_notify_callbacks()
+
+    assert not callbacks
+    assert not discriminators

--- a/tests/integration/test_issue_1969.py
+++ b/tests/integration/test_issue_1969.py
@@ -1,0 +1,61 @@
+import pytest
+from bumble.att import Attribute
+from bumble.device import Device
+from bumble.gatt import Characteristic, Service
+
+from bleak import BleakClient
+from bleak.backends import BleakBackend, get_default_backend
+from bleak.backends.characteristic import BleakGATTCharacteristic
+from tests.integration.conftest import (
+    configure_and_power_on_bumble_peripheral,
+    find_ble_device,
+)
+
+TEST_SERVICE_UUID = "08a67ad7-22ca-4e06-89a0-c6cfe0c76471"
+TEST_CHARACTERISTIC_UUID = "797f54d7-83d1-49c7-9992-0d0b136117dd"
+
+
+@pytest.mark.skipif(
+    get_default_backend() != BleakBackend.CORE_BLUETOOTH,
+    reason="issue present in Core Bluetooth backend only",
+)
+async def test_start_notify_after_reconnect(bumble_peripheral: Device) -> None:
+    """
+    Ensure notifications can be started again after disconnecting and reconnecting.
+
+    The Core Bluetooth backend reuses its peripheral delegate when the same
+    client instance reconnects, so the notification bookkeeping has to be
+    cleared on disconnect, otherwise start_notify() raises
+    ``ValueError("Characteristic notifications already started")``.
+
+    Regression test for: https://github.com/hbldh/bleak/issues/1969
+    """
+
+    test_characteristic = Characteristic[bytes](
+        TEST_CHARACTERISTIC_UUID,
+        Characteristic.Properties.NOTIFY,
+        Attribute.Permissions(0),
+    )
+
+    await configure_and_power_on_bumble_peripheral(
+        bumble_peripheral, services=[Service(TEST_SERVICE_UUID, [test_characteristic])]
+    )
+
+    device = await find_ble_device(bumble_peripheral)
+
+    def notify_callback(
+        characteristic: BleakGATTCharacteristic, data: bytearray
+    ) -> None:
+        pass
+
+    client = BleakClient(device, services=[TEST_SERVICE_UUID])
+
+    async with client:
+        await client.start_notify(TEST_CHARACTERISTIC_UUID, notify_callback)
+
+    await bumble_peripheral.start_advertising()
+
+    # Reusing the same client instance keeps the backend state from the first
+    # connection, which is what triggered the issue.
+    async with client:
+        await client.start_notify(TEST_CHARACTERISTIC_UUID, notify_callback)


### PR DESCRIPTION
Fixes #1969.

On macOS, calling `start_notify()` after disconnecting and reconnecting with the same `BleakClient` raises `ValueError("Characteristic notifications already started")`.

CoreBluetooth stops notifications at the OS level on disconnect, but the `PeripheralDelegate` is reused on reconnect (`BleakClientCoreBluetooth.connect()` only creates a new one when `self._delegate is None`), so the stale entries in `_characteristic_notify_callbacks` / `_characteristic_notification_discriminators` survive the disconnect and trip the guard in `start_notifications()`. This matches the root cause analysis in the issue comments.

Changes:
- Add `PeripheralDelegate.clear_notify_callbacks()` and call it from the client's `disconnect_callback`, alongside the existing future cleanup.
- Add `tests/integration/test_issue_1969.py` (connect → `start_notify` → disconnect → reconnect with the same client → `start_notify`), following the existing bumble-based `test_issue_*` pattern. It is CoreBluetooth-only via `skipif`, since BlueZ tracks notification state at the D-Bus level and is unaffected.
- Changelog entry under Unreleased.

`poe lint`, `poe typecheck` and the unit tests pass locally on macOS. 


Verified on real hardware (macOS, Apple Silicon, BlueNRG-based peripheral): on develop the second start_notify() after reconnecting with the same client instance raises ValueError("Characteristic notifications already started"); with this branch the same connect → notify → disconnect → reconnect → notify sequence succeeds.
