### PR TITLE
github/workflows: remove pull_request branches selection

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,6 @@ on:
     branches: [master, develop]
     paths: ["bleak/**", "tests/**", ".github/workflows/build_and_test.yml", "pyproject.toml"]
   pull_request:
-    branches: [master, develop]
     paths: ["bleak/**", "tests/**", ".github/workflows/build_and_test.yml", "pyproject.toml"]
   workflow_dispatch:
 

--- a/.github/workflows/format_and_lint.yml
+++ b/.github/workflows/format_and_lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master, develop]
   pull_request:
-    branches: [master, develop]
 
 jobs:
   format_and_lint:


### PR DESCRIPTION
GitHub imposes no limit on on actions usage by public repositories, so filtering of PRs is removed to aid developers who branch and PR to/from arbitrary branches.
