### PR TITLE
bleak: add return_adv parameter to BleakScanner.find_device_by_* methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 -----
 * Added ``BleakAdapter`` class with ``get_connected_devices()`` to retrieve BLE devices that are already connected to the system without scanning.
+* Added ``return_adv`` parameter to ``BleakScanner.find_device_by_address()``, ``BleakScanner.find_device_by_name()`` and ``BleakScanner.find_device_by_filter()``. Fixes #1277.
 
 Fixed
 -----

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -341,57 +341,148 @@ class BleakScanner:
         """
         return {d[0].address: d for d in self._backend.seen_devices.values()}
 
+    @overload
     @classmethod
     async def find_device_by_address(
-        cls, device_identifier: str, timeout: float = 10.0, **kwargs: Unpack[ExtraArgs]
-    ) -> Optional[BLEDevice]:
+        cls,
+        device_identifier: str,
+        timeout: float = 10.0,
+        *,
+        return_adv: Literal[False] = False,
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[BLEDevice]: ...
+
+    @overload
+    @classmethod
+    async def find_device_by_address(
+        cls,
+        device_identifier: str,
+        timeout: float = 10.0,
+        *,
+        return_adv: Literal[True],
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[tuple[BLEDevice, AdvertisementData]]: ...
+
+    @classmethod
+    async def find_device_by_address(
+        cls,
+        device_identifier: str,
+        timeout: float = 10.0,
+        *,
+        return_adv: bool = False,
+        **kwargs: Unpack[ExtraArgs],
+    ):
         """Obtain a ``BLEDevice`` for a BLE server specified by Bluetooth address or (macOS) UUID address.
 
         Args:
             device_identifier: The Bluetooth/UUID address of the Bluetooth peripheral sought.
             timeout: Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
+            return_adv: If ``True``, the return value will also include advertising data.
             **kwargs: additional args passed to the :class:`BleakScanner` constructor.
 
         Returns:
-            The ``BLEDevice`` sought or ``None`` if not detected.
+            The ``BLEDevice`` sought (paired with its most recently received
+            :class:`AdvertisementData` if ``return_adv`` is ``True``) or
+            ``None`` if not detected.
 
+        .. versionchanged:: unreleased
+            Added ``return_adv`` parameter.
         """
         device_identifier = device_identifier.lower()
-        return await cls.find_device_by_filter(
+        return await cls._find_device_by_filter(
             lambda d, ad: d.address.lower() == device_identifier,
-            timeout=timeout,
+            timeout,
+            return_adv,
             **kwargs,
         )
 
+    @overload
     @classmethod
     async def find_device_by_name(
-        cls, name: str, timeout: float = 10.0, **kwargs: Unpack[ExtraArgs]
-    ) -> Optional[BLEDevice]:
+        cls,
+        name: str,
+        timeout: float = 10.0,
+        *,
+        return_adv: Literal[False] = False,
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[BLEDevice]: ...
+
+    @overload
+    @classmethod
+    async def find_device_by_name(
+        cls,
+        name: str,
+        timeout: float = 10.0,
+        *,
+        return_adv: Literal[True],
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[tuple[BLEDevice, AdvertisementData]]: ...
+
+    @classmethod
+    async def find_device_by_name(
+        cls,
+        name: str,
+        timeout: float = 10.0,
+        *,
+        return_adv: bool = False,
+        **kwargs: Unpack[ExtraArgs],
+    ):
         """Obtain a ``BLEDevice`` for a BLE server specified by the local name in the advertising data.
 
         Args:
             name: The name sought.
             timeout: Optional timeout to wait for detection of specified peripheral before giving up. Defaults to 10.0 seconds.
+            return_adv: If ``True``, the return value will also include advertising data.
             **kwargs: additional args passed to the :class:`BleakScanner` constructor.
 
         Returns:
-            The ``BLEDevice`` sought or ``None`` if not detected.
+            The ``BLEDevice`` sought (paired with its most recently received
+            :class:`AdvertisementData` if ``return_adv`` is ``True``) or
+            ``None`` if not detected.
 
         .. versionadded:: 0.20
+
+        .. versionchanged:: unreleased
+            Added ``return_adv`` parameter.
         """
-        return await cls.find_device_by_filter(
+        return await cls._find_device_by_filter(
             lambda d, ad: ad.local_name == name,
-            timeout=timeout,
+            timeout,
+            return_adv,
             **kwargs,
         )
+
+    @overload
+    @classmethod
+    async def find_device_by_filter(
+        cls,
+        filterfunc: AdvertisementDataFilter,
+        timeout: float = 10.0,
+        *,
+        return_adv: Literal[False] = False,
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[BLEDevice]: ...
+
+    @overload
+    @classmethod
+    async def find_device_by_filter(
+        cls,
+        filterfunc: AdvertisementDataFilter,
+        timeout: float = 10.0,
+        *,
+        return_adv: Literal[True],
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[tuple[BLEDevice, AdvertisementData]]: ...
 
     @classmethod
     async def find_device_by_filter(
         cls,
         filterfunc: AdvertisementDataFilter,
         timeout: float = 10.0,
+        *,
+        return_adv: bool = False,
         **kwargs: Unpack[ExtraArgs],
-    ) -> Optional[BLEDevice]:
+    ):
         """Obtain a ``BLEDevice`` for a BLE server that matches a given filter function.
 
         This can be used to find a BLE server by other identifying information than its address,
@@ -404,21 +495,42 @@ class BleakScanner:
             timeout:
                 Optional timeout to wait for detection of specified peripheral
                 before giving up. Defaults to 10.0 seconds.
+            return_adv:
+                If ``True``, the return value will also include advertising data.
             **kwargs:
                 Additional arguments to be passed to the :class:`BleakScanner`
                 constructor.
 
         Returns:
-            The :class:`BLEDevice` sought or ``None`` if not detected before
+            The :class:`BLEDevice` sought (paired with the
+            :class:`AdvertisementData` that matched the filter if
+            ``return_adv`` is ``True``) or ``None`` if not detected before
             the timeout.
 
+        .. versionchanged:: unreleased
+            Added ``return_adv`` parameter.
         """
+        return await cls._find_device_by_filter(
+            filterfunc,
+            timeout,
+            return_adv,
+            **kwargs,
+        )
+
+    @classmethod
+    async def _find_device_by_filter(
+        cls,
+        filterfunc: AdvertisementDataFilter,
+        timeout: float,
+        return_adv: bool,
+        **kwargs: Unpack[ExtraArgs],
+    ) -> Optional[Union[BLEDevice, tuple[BLEDevice, AdvertisementData]]]:
         async with cls(**kwargs) as scanner:
             try:
                 async with async_timeout(timeout):
                     async for bd, ad in scanner.advertisement_data():
                         if filterfunc(bd, ad):
-                            return bd
+                            return (bd, ad) if return_adv else bd
                     assert_never(cast(Never, "advertisement_data() should never stop"))
             except asyncio.TimeoutError:
                 return None

--- a/tests/integration/test_scanner.py
+++ b/tests/integration/test_scanner.py
@@ -45,6 +45,31 @@ async def test_find_by_address(bumble_peripheral: Device):
     assert device is not None
 
 
+async def test_find_by_filter(bumble_peripheral: Device):
+    """Scanner is finding the device by a custom filter function."""
+    await configure_and_power_on_bumble_peripheral(bumble_peripheral)
+
+    device = await BleakScanner.find_device_by_filter(
+        lambda d, ad: ad.local_name == bumble_peripheral.name
+    )
+    assert device is not None
+    assert isinstance(device, BLEDevice)
+
+
+async def test_find_by_name_return_adv(bumble_peripheral: Device):
+    """Scanner returns the advertisement data when finding a device with return_adv=True."""
+    await configure_and_power_on_bumble_peripheral(bumble_peripheral)
+
+    result = await BleakScanner.find_device_by_name(
+        bumble_peripheral.name, return_adv=True
+    )
+    assert result is not None
+    device, adv = result
+    assert isinstance(device, BLEDevice)
+    assert isinstance(adv, AdvertisementData)
+    assert adv.local_name == bumble_peripheral.name
+
+
 @pytest.mark.parametrize("service_uuid_available", [True, False])
 async def test_discover_filter_by_service_uuid(
     bumble_peripheral: Device,


### PR DESCRIPTION
Fixes #1277.

Adds a `return_adv=` keyword argument to `BleakScanner.find_device_by_address()`, `find_device_by_name()` and `find_device_by_filter()`, mirroring the existing parameter of `BleakScanner.discover()`, so callers can get the matching advertisement data without using the deprecated `BLEDevice.metadata`.

Implementation notes:
- Same `@overload` pattern as `discover()`: `Literal[False]`/`Literal[True]` overloads narrow the return type to `Optional[BLEDevice]` or `Optional[tuple[BLEDevice, AdvertisementData]]`.
- The three public methods delegate to a new private `_find_device_by_filter()` that takes a plain `bool`, so the `by_address`/`by_name` implementations don't have to branch to satisfy overload resolution.
- For `find_device_by_filter()` the returned advertisement is the one that matched the filter; for the other two it is the most recently received one at match time.
- Added an integration test (`test_find_by_name_return_adv`) to `tests/integration/test_scanner.py` and a changelog entry.

`poe lint`, `poe typecheck` (mypy + pyright) and the unit tests pass locally. Also verified on real hardware on macOS (BlueNRG-based peripheral): `return_adv=True` returns the `(BLEDevice, AdvertisementData)` tuple with plausible RSSI, and the default call still returns a bare `BLEDevice`, for both `find_device_by_filter()` and `find_device_by_address()`.