### PR TITLE
bleak: Support newer uv_build versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.10.9,<0.11.0"]
+requires = ["uv_build>=0.10.9,<0.12.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
Support newer `uv_build` versions.

Fixes the following issue when building with [uv-build 0.11.21](https://pypi.org/project/uv-build/0.11.21/):

```
| DEBUG: Executing shell function do_compile
| * Getting build dependencies for wheel...
| 
| ERROR Missing dependencies:
| 	uv_build<0.11.0,>=0.10.9
| WARNING: exit code 1 from a shell command.
```