### PR TITLE
bleak: add the pairing_callbacks argument to BleakClient

### DIFF
--- a/.github/alpine-vm/alpine-vm-setup.sh
+++ b/.github/alpine-vm/alpine-vm-setup.sh
@@ -26,6 +26,19 @@ step 'Enable bluetooth and dbus services'
 rc-update add bluetooth default
 rc-update add dbus default
 
+# Enable BlueZ experimental D-Bus interfaces. The AdvertisementMonitorManager1
+# interface (used by passive scanning with or_patterns) is gated behind this
+# flag, so RegisterMonitor is unavailable without it.
+step 'Enable BlueZ experimental interfaces'
+mkdir -p /etc/bluetooth
+if [ -f /etc/bluetooth/main.conf ] && grep -qiE '^[[:space:]]*#?[[:space:]]*Experimental' /etc/bluetooth/main.conf; then
+	sed -i -E 's/^[[:space:]]*#?[[:space:]]*Experimental.*/Experimental = true/I' /etc/bluetooth/main.conf
+elif [ -f /etc/bluetooth/main.conf ] && grep -qE '^\[General\]' /etc/bluetooth/main.conf; then
+	sed -i '/^\[General\]/a Experimental = true' /etc/bluetooth/main.conf
+else
+	printf '[General]\nExperimental = true\n' >> /etc/bluetooth/main.conf
+fi
+
 # Configure vhci kernel module to load at boot
 step 'Configure VHCI kernel module for boot'
 echo "hci_vhci" >> /etc/modules

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Added
 -----
 * Added ``BleakAdapter`` class with ``get_connected_devices()`` to retrieve BLE devices that are already connected to the system without scanning.
 
+Changed
+-------
+* Changed minimum ``dbus-fast`` version to 4.0.0 on Linux.
+
 Fixed
 -----
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 -----
 * Added ``BleakAdapter`` class with ``get_connected_devices()`` to retrieve BLE devices that are already connected to the system without scanning.
+* Added a ``pairing_callbacks`` argument to ``BleakClient`` taking a ``bleak.pairing.PairingCallbacks`` to take part in the BLE pairing ceremony (Numeric Comparison / Passkey Entry) during connection.
 
 Changed
 -------

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -40,6 +40,7 @@ from bleak.backends.scanner import (
 )
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakCharacteristicNotFoundError, BleakError
+from bleak.pairing import PairingCallbacks
 from bleak.uuids import normalize_uuid_16, normalize_uuid_str
 
 __author__ = """Henrik Blidh"""
@@ -573,6 +574,11 @@ class BleakClient:
             In rare cases, on other platforms, it might be necessary to pair the
             device first in order to be able to even enumerate the services during
             the connection process.
+        pairing_callbacks:
+            Callbacks used during pairing (numeric comparison / passkey entry);
+            see :data:`~bleak.pairing.PairingCallbacks`. They apply whether the
+            device is paired during connection (``pair=True``) or by a later
+            :meth:`pair` call. Backends that do not support pairing ignore them.
         bluez:
             Dictionary of BlueZ/Linux platform-specific options.
         winrt:
@@ -615,6 +621,9 @@ class BleakClient:
 
     .. versionchanged:: 3.0
         Added ``bluez`` parameter.
+
+    .. versionchanged:: unreleased
+        Added ``pairing_callbacks`` parameter.
     """
 
     def __init__(
@@ -625,6 +634,7 @@ class BleakClient:
         *,
         timeout: float = 30,
         pair: bool = False,
+        pairing_callbacks: PairingCallbacks | None = None,
         bluez: BlueZClientArgs = {},
         winrt: WinRTClientArgs = {},
         backend: Optional[type[BaseBleakClient]] = None,
@@ -658,6 +668,7 @@ class BleakClient:
             services=(
                 None if services is None else set(map(normalize_uuid_str, services))
             ),
+            pairing_callbacks=pairing_callbacks,
             timeout=timeout,
             bluez=bluez,
             winrt=winrt,

--- a/bleak/_compat.py
+++ b/bleak/_compat.py
@@ -13,6 +13,7 @@ if sys.version_info < (3, 11):
     from typing_extensions import TypeVarTuple as TypeVarTuple
     from typing_extensions import Unpack as Unpack
     from typing_extensions import assert_never as assert_never
+    from typing_extensions import assert_type as assert_type
 else:
     from asyncio import timeout as timeout  # noqa: F401
     from typing import Never as Never  # noqa: F401
@@ -20,6 +21,7 @@ else:
     from typing import TypeVarTuple as TypeVarTuple  # noqa: F401
     from typing import Unpack as Unpack  # noqa: F401
     from typing import assert_never as assert_never  # noqa: F401
+    from typing import assert_type as assert_type  # noqa: F401
 
 if sys.version_info < (3, 12):
     from typing_extensions import override as override

--- a/bleak/backends/bluezdbus/advertisement_monitor.py
+++ b/bleak/backends/bluezdbus/advertisement_monitor.py
@@ -15,11 +15,18 @@ if TYPE_CHECKING:
 
 import logging
 from collections.abc import Iterable
-from typing import Any, no_type_check
+from typing import Annotated, Any
 from warnings import warn
 
 from dbus_fast import PropertyAccess
-from dbus_fast.service import ServiceInterface, dbus_property, method
+from dbus_fast.annotations import (
+    DBusInt16,
+    DBusObjectPath,
+    DBusSignature,
+    DBusStr,
+    DBusUInt16,
+)
+from dbus_fast.service import ServiceInterface, dbus_method, dbus_property
 
 from bleak.args.bluez import OrPattern as _OrPattern
 from bleak.args.bluez import OrPatternLike as _OrPatternLike
@@ -68,64 +75,51 @@ class AdvertisementMonitor(ServiceInterface):
                 List of or patterns that will be returned by the ``Patterns`` property.
         """
         super().__init__(defs.ADVERTISEMENT_MONITOR_INTERFACE)
-        # dbus_fast marshaling requires list instead of tuple
-        self._or_patterns = [list(p) for p in or_patterns]
+        self._or_patterns = list(or_patterns)
 
-    @method()
-    def Release(self):
+    @dbus_method()
+    def Release(self) -> None:
         logger.debug("Release")
 
-    @method()
-    def Activate(self):
+    @dbus_method()
+    def Activate(self) -> None:
         logger.debug("Activate")
 
-    # REVISIT: mypy is broke, so we have to add redundant @no_type_check
-    # https://github.com/python/mypy/issues/6583
-
-    @method()
-    @no_type_check
-    def DeviceFound(self, device: "o"):  # noqa: F821
+    @dbus_method()
+    def DeviceFound(self, device: DBusObjectPath) -> None:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("DeviceFound %s", device)
 
-    @method()
-    @no_type_check
-    def DeviceLost(self, device: "o"):  # noqa: F821
+    @dbus_method()
+    def DeviceLost(self, device: DBusObjectPath) -> None:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("DeviceLost %s", device)
 
     @dbus_property(PropertyAccess.READ)
-    @no_type_check
-    def Type(self) -> "s":  # noqa: F821
+    def Type(self) -> DBusStr:
         # this is currently the only type supported in BlueZ
         return "or_patterns"
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSILowThreshold(self) -> "n":  # noqa: F821
-        ...
+    def RSSILowThreshold(self) -> DBusInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSIHighThreshold(self) -> "n":  # noqa: F821
-        ...
+    def RSSIHighThreshold(self) -> DBusInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSILowTimeout(self) -> "q":  # noqa: F821
-        ...
+    def RSSILowTimeout(self) -> DBusUInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSIHighTimeout(self) -> "q":  # noqa: F821
-        ...
+    def RSSIHighTimeout(self) -> DBusUInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ, disabled=True)
-    @no_type_check
-    def RSSISamplingPeriod(self) -> "q":  # noqa: F821
-        ...
+    def RSSISamplingPeriod(self) -> DBusUInt16:
+        raise NotImplementedError
 
     @dbus_property(PropertyAccess.READ)
-    @no_type_check
-    def Patterns(self) -> "a(yyay)":  # noqa: F821
+    def Patterns(self) -> Annotated[list[_OrPatternLike], DBusSignature("a(yyay)")]:
         return self._or_patterns

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -44,6 +44,7 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakDBusError, BleakDeviceNotFoundError, BleakError
+from bleak.pairing import PairingCallbacks
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
         *,
         disconnected_callback: Callable[[], None] | None,
         timeout: float,
+        pairing_callbacks: PairingCallbacks | None = None,
         bluez: BlueZClientArgs,
         **kwargs: Any,
     ):
@@ -75,6 +77,7 @@ class BleakClientBlueZDBus(BaseBleakClient):
             address_or_ble_device,
             disconnected_callback=disconnected_callback,
             timeout=timeout,
+            pairing_callbacks=pairing_callbacks,
         )
 
         self._adapter = bluez.get("adapter")

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -66,10 +66,16 @@ class BleakClientBlueZDBus(BaseBleakClient):
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
         *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
         bluez: BlueZClientArgs,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
 
         self._adapter = bluez.get("adapter")
         self._device_path: Optional[str]

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -13,6 +13,7 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTServiceCollection
 from bleak.exc import BleakError
+from bleak.pairing import PairingCallbacks
 
 NotifyCallback = Callable[[bytearray], None]
 
@@ -30,6 +31,11 @@ class BaseBleakClient(abc.ABC):
         disconnected_callback (callable): Callback that will be scheduled in the
             event loop when the client is disconnected. The callable takes no
             arguments.
+        pairing_callbacks (PairingCallbacks | None): Object implementing one or
+            more pairing-capability protocols (see
+            :data:`~bleak.pairing.PairingCallbacks`); used by backends that pair
+            during connection (BlueZ and WinRT) and ignored by others. ``None``
+            (the default) means no callbacks, which selects Just Works.
     """
 
     def __init__(
@@ -38,6 +44,7 @@ class BaseBleakClient(abc.ABC):
         *,
         disconnected_callback: Callable[[], None] | None,
         timeout: float,
+        pairing_callbacks: PairingCallbacks | None = None,
         **kwargs: Any,
     ) -> None:
         if isinstance(address_or_ble_device, BLEDevice):
@@ -49,6 +56,7 @@ class BaseBleakClient(abc.ABC):
 
         self._timeout = timeout
         self._disconnected_callback = disconnected_callback
+        self._pairing_callbacks = pairing_callbacks
 
     # NB: this is not marked as @abc.abstractmethod because that would break
     # 3rd-party backends. We might change this in the future to make it required.

--- a/bleak/backends/client.py
+++ b/bleak/backends/client.py
@@ -4,7 +4,7 @@ Base class for backend clients.
 """
 import abc
 from collections.abc import Callable
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from bleak.args import SizedBuffer
 from bleak.backends import BleakBackend, get_default_backend
@@ -28,11 +28,18 @@ class BaseBleakClient(abc.ABC):
     Keyword Args:
         timeout (float): Timeout for required ``discover`` call.
         disconnected_callback (callable): Callback that will be scheduled in the
-            event loop when the client is disconnected. The callable must take one
-            argument, which will be this client object.
+            event loop when the client is disconnected. The callable takes no
+            arguments.
     """
 
-    def __init__(self, address_or_ble_device: Union[BLEDevice, str], **kwargs: Any):
+    def __init__(
+        self,
+        address_or_ble_device: BLEDevice | str,
+        *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
+        **kwargs: Any,
+    ) -> None:
         if isinstance(address_or_ble_device, BLEDevice):
             self.address = address_or_ble_device.address
         else:
@@ -40,10 +47,8 @@ class BaseBleakClient(abc.ABC):
 
         self.services: Optional[BleakGATTServiceCollection] = None
 
-        self._timeout = kwargs["timeout"]
-        self._disconnected_callback: Optional[Callable[[], None]] = kwargs.get(
-            "disconnected_callback"
-        )
+        self._timeout = timeout
+        self._disconnected_callback = disconnected_callback
 
     # NB: this is not marked as @abc.abstractmethod because that would break
     # 3rd-party backends. We might change this in the future to make it required.

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 import asyncio
 import logging
+from collections.abc import Callable
 from typing import Any, Optional, Union
 
 from CoreBluetooth import (
@@ -59,9 +60,16 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         self,
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
+        *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
 
         self._peripheral: Optional[CBPeripheral] = None
         self._delegate: Optional[PeripheralDelegate] = None

--- a/bleak/backends/corebluetooth/client.py
+++ b/bleak/backends/corebluetooth/client.py
@@ -44,6 +44,7 @@ from bleak.backends.descriptor import BleakGATTDescriptor
 from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTService, BleakGATTServiceCollection
 from bleak.exc import BleakDeviceNotFoundError, BleakError
+from bleak.pairing import PairingCallbacks
 
 logger = logging.getLogger(__name__)
 
@@ -63,13 +64,20 @@ class BleakClientCoreBluetooth(BaseBleakClient):
         *,
         disconnected_callback: Callable[[], None] | None,
         timeout: float,
+        pairing_callbacks: PairingCallbacks | None = None,
         **kwargs: Any,
     ):
         super().__init__(
             address_or_ble_device,
             disconnected_callback=disconnected_callback,
             timeout=timeout,
+            pairing_callbacks=pairing_callbacks,
         )
+
+        if pairing_callbacks is not None:
+            logger.debug(
+                "pairing callbacks are not supported by the Core Bluetooth backend"
+            )
 
         self._peripheral: Optional[CBPeripheral] = None
         self._delegate: Optional[PeripheralDelegate] = None

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -28,6 +28,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.p4android import defs, utils
 from bleak.backends.service import BleakGATTService, BleakGATTServiceCollection
 from bleak.exc import BleakError
+from bleak.pairing import PairingCallbacks
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +51,22 @@ class BleakClientP4Android(BaseBleakClient):
         *,
         disconnected_callback: Callable[[], None] | None,
         timeout: float,
+        pairing_callbacks: PairingCallbacks | None = None,
         **kwargs: Any,
     ):
         super().__init__(
             address_or_ble_device,
             disconnected_callback=disconnected_callback,
             timeout=timeout,
+            pairing_callbacks=pairing_callbacks,
         )
+
+        if pairing_callbacks is not None:
+            logger.debug(
+                "pairing callbacks are not used by the Android backend; "
+                "the system handles the pairing UI"
+            )
+
         self._requested_services = (
             set(map(defs.UUID.fromString, services)) if services else None
         )

--- a/bleak/backends/p4android/client.py
+++ b/bleak/backends/p4android/client.py
@@ -13,6 +13,7 @@ import asyncio
 import logging
 import uuid
 import warnings
+from collections.abc import Callable
 from typing import Any, Optional, Union
 
 from android.broadcast import BroadcastReceiver
@@ -46,9 +47,16 @@ class BleakClientP4Android(BaseBleakClient):
         self,
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[uuid.UUID]],
-        **kwargs,
+        *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
+        **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
         self._requested_services = (
             set(map(defs.UUID.fromString, services)) if services else None
         )

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -149,10 +149,16 @@ class BleakClientWinRT(BaseBleakClient):
         address_or_ble_device: Union[BLEDevice, str],
         services: Optional[set[str]] = None,
         *,
+        disconnected_callback: Callable[[], None] | None,
+        timeout: float,
         winrt: _WinRTClientArgs,
         **kwargs: Any,
     ):
-        super().__init__(address_or_ble_device, **kwargs)
+        super().__init__(
+            address_or_ble_device,
+            disconnected_callback=disconnected_callback,
+            timeout=timeout,
+        )
 
         self._device_info: int | None
 

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -68,6 +68,7 @@ from bleak.backends.device import BLEDevice
 from bleak.backends.service import BleakGATTService, BleakGATTServiceCollection
 from bleak.backends.winrt.scanner import BleakScannerWinRT, RawAdvData
 from bleak.exc import BleakDeviceNotFoundError, BleakError, BleakGATTProtocolError
+from bleak.pairing import PairingCallbacks
 
 logger = logging.getLogger(__name__)
 
@@ -151,6 +152,7 @@ class BleakClientWinRT(BaseBleakClient):
         *,
         disconnected_callback: Callable[[], None] | None,
         timeout: float,
+        pairing_callbacks: PairingCallbacks | None = None,
         winrt: _WinRTClientArgs,
         **kwargs: Any,
     ):
@@ -158,6 +160,7 @@ class BleakClientWinRT(BaseBleakClient):
             address_or_ble_device,
             disconnected_callback=disconnected_callback,
             timeout=timeout,
+            pairing_callbacks=pairing_callbacks,
         )
 
         self._device_info: int | None

--- a/bleak/pairing.py
+++ b/bleak/pairing.py
@@ -1,0 +1,153 @@
+"""
+Pairing
+-------
+
+Types for participating in the BLE pairing ceremony.
+
+An application takes part in pairing by supplying an object that implements one or
+more of the capability protocols in this module -- :class:`SupportsConfirm`,
+:class:`SupportsRequestPasskey`, and :class:`SupportsDisplayPasskey`. Only the
+methods for the ceremonies the application can perform are implemented; the
+*absence* of a method means the application cannot take part in that ceremony.
+Which methods are present determines the input/output capability that Bleak
+advertises to the peer, and therefore which `Security Manager`_ pairing method is
+negotiated:
+
+============================================  =====================  =======================
+Implemented methods                           Capability             Ceremony
+============================================  =====================  =======================
+(none)                                        ``NoInputNoOutput``    Just Works
+``confirm``                                   ``DisplayYesNo``       Numeric Comparison
+``request_passkey``                           ``KeyboardOnly``       Passkey Entry (input)
+``display_passkey``                           ``DisplayOnly``        Passkey Entry (output)
+``request_passkey`` + ``display_passkey``     ``KeyboardDisplay``    Passkey Entry (either)
+============================================  =====================  =======================
+
+A ``confirm`` method also implies a display, since Numeric Comparison shows the
+value being compared, so combining it with another method upgrades the advertised
+capability (e.g. ``confirm`` + ``display_passkey`` is ``DisplayYesNo``, while
+``confirm`` + ``request_passkey`` is ``KeyboardDisplay``).
+
+There are two equivalent ways to supply an implementation:
+
+* any object -- a :class:`~typing.NamedTuple` is a natural fit -- that structurally
+  implements the chosen methods, or
+* a subclass of the matching protocols -- :class:`SupportsConfirm`,
+  :class:`SupportsRequestPasskey`, :class:`SupportsDisplayPasskey`. Their methods are
+  abstract, so the type checker *and* the interpreter require you to implement every
+  capability you inherit (merely inheriting is not enough); state may be carried on
+  ``self``, and the protocols may be combined freely by multiple inheritance.
+
+Because detection is structural (see :func:`io_capability`), implement *only* the
+methods for the ceremonies you support and omit the rest; a method that is present
+but does not work (for example, one that always raises) still advertises the
+capability, which is almost never what you want.
+
+The IO capabilities and their mapping to a pairing method follow the `Security
+Manager`_ specification: Bluetooth Core Specification v5.4, Vol 3, Part H, Section
+2.3.2 (IO capabilities) and Section 2.3.5.1 (mapping of IO capabilities to the key
+generation method).
+
+.. _Security Manager: https://www.bluetooth.com/specifications/specs/core-specification/
+"""
+
+from abc import abstractmethod
+from enum import Enum, auto
+from typing import Final, Protocol, TypeAlias, runtime_checkable
+
+from bleak.backends.device import BLEDevice
+
+MAX_PASSKEY: Final = 999999
+"""The largest valid BLE passkey; passkeys are six decimal digits (000000-999999)."""
+
+
+@runtime_checkable
+class SupportsConfirm(Protocol):
+    """Capability to take part in Numeric Comparison (``DisplayYesNo``)."""
+
+    @abstractmethod
+    async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+        """Numeric Comparison: receive *device* and the *passkey* shown on both
+        devices; return ``True`` to accept the pairing or ``False`` to reject it."""
+
+
+@runtime_checkable
+class SupportsRequestPasskey(Protocol):
+    """Capability to enter a passkey for Passkey Entry (``KeyboardOnly``)."""
+
+    @abstractmethod
+    async def request_passkey(self, device: BLEDevice) -> int | None:
+        """Passkey Entry (input): return the passkey the peer is displaying -- an
+        integer from ``0`` to :data:`MAX_PASSKEY` -- or ``None`` to reject the
+        pairing. ``0`` (``000000``) is itself a valid passkey, so rejection is
+        signalled only by ``None``, never by a falsy return value."""
+
+
+@runtime_checkable
+class SupportsDisplayPasskey(Protocol):
+    """Capability to display a passkey for Passkey Entry (``DisplayOnly``)."""
+
+    @abstractmethod
+    async def display_passkey(self, device: BLEDevice, passkey: int) -> None:
+        """Passkey Entry (output): display the given *passkey* for the user to enter
+        on the peer device."""
+
+
+PairingCallbacks: TypeAlias = (
+    SupportsConfirm | SupportsRequestPasskey | SupportsDisplayPasskey
+)
+"""An object implementing one or more pairing capabilities.
+
+This is the type backends accept (as ``PairingCallbacks | None``, where ``None``
+means no callbacks and selects Just Works). Satisfy it with any object -- a
+:class:`~typing.NamedTuple` is a natural fit -- that defines the chosen methods, or
+by subclassing :class:`SupportsConfirm`, :class:`SupportsRequestPasskey`, and/or
+:class:`SupportsDisplayPasskey`.
+"""
+
+
+class IOCapability(Enum):
+    """The input/output capability advertised to the peer during pairing.
+
+    These are the five IO capabilities defined by the Bluetooth Core
+    Specification (Vol 3, Part H, Section 2.3.2), named in Pythonic form (BlueZ,
+    for example, spells them ``NoInputNoOutput``, ``DisplayYesNo``, and so on).
+    """
+
+    NO_INPUT_NO_OUTPUT = auto()
+    """No way to display a six-digit value and no way to enter one or answer yes/no."""
+
+    DISPLAY_YES_NO = auto()
+    """Can display a six-digit value and has two buttons the user can map to yes and no."""
+
+    KEYBOARD_ONLY = auto()
+    """Can enter the digits 0-9 and answer yes/no, but cannot display a value."""
+
+    DISPLAY_ONLY = auto()
+    """Can display a six-digit value but has no input to enter one or answer yes/no."""
+
+    KEYBOARD_DISPLAY = auto()
+    """Can both display a six-digit value and enter one; LE only."""
+
+
+def io_capability(callbacks: PairingCallbacks | None) -> IOCapability:
+    """Derive the advertised :class:`IOCapability` from *callbacks*.
+
+    Detection is structural: each capability is present when *callbacks* implements
+    the corresponding method. ``None`` (no callbacks) maps to ``NoInputNoOutput``,
+    which selects the Just Works ceremony on backends that support pairing. A
+    ``confirm`` method implies a display, since Numeric Comparison shows the value
+    being confirmed.
+    """
+    can_input = isinstance(callbacks, SupportsRequestPasskey)
+    can_confirm = isinstance(callbacks, SupportsConfirm)
+    can_display = isinstance(callbacks, SupportsDisplayPasskey) or can_confirm
+    if can_input and can_display:
+        return IOCapability.KEYBOARD_DISPLAY
+    if can_input:
+        return IOCapability.KEYBOARD_ONLY
+    if can_confirm:
+        return IOCapability.DISPLAY_YES_NO
+    if can_display:
+        return IOCapability.DISPLAY_ONLY
+    return IOCapability.NO_INPUT_NO_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "winrt-Windows.Foundation>=3.1; platform_system=='Windows'",
     "winrt-Windows.Foundation.Collections>=3.1; platform_system=='Windows'",
     "winrt-Windows.Storage.Streams>=3.1; platform_system=='Windows'",
-    "dbus-fast>=1.83.0; platform_system=='Linux'",
+    "dbus-fast>=4.0.0; platform_system=='Linux'",
 ]
 
 [project.urls]

--- a/tests/integration/test_client_pairing.py
+++ b/tests/integration/test_client_pairing.py
@@ -10,10 +10,26 @@ from tests.integration.conftest import (
 
 
 @pytest.mark.skipif(
+    get_default_backend() == BleakBackend.CORE_BLUETOOTH,
+    reason="unpair is not available on CoreBluetooth",
+)
+async def test_unpair_unpaired_device(bumble_peripheral: Device) -> None:
+    """unpair() after a connect/disconnect of a never-paired device does not raise."""
+    await configure_and_power_on_bumble_peripheral(bumble_peripheral)
+
+    device = await find_ble_device(bumble_peripheral)
+
+    client = BleakClient(device)
+    await client.connect()
+    await client.disconnect()
+    await client.unpair()
+
+
+@pytest.mark.skipif(
     get_default_backend() != BleakBackend.CORE_BLUETOOTH,
     reason="pairing is not possible on CoreBluetooth",
 )
-async def test_pairing_unavailable(bumble_peripheral: Device):
+async def test_pairing_unavailable(bumble_peripheral: Device) -> None:
     """Check if pairing on CoreBluetooth raises an error."""
     await configure_and_power_on_bumble_peripheral(bumble_peripheral)
 
@@ -24,6 +40,3 @@ async def test_pairing_unavailable(bumble_peripheral: Device):
         await client.pair()
     with pytest.raises(NotImplementedError):
         await client.unpair()
-
-
-# TODO: Add tests for pairing

--- a/tests/integration/test_scanner.py
+++ b/tests/integration/test_scanner.py
@@ -8,12 +8,22 @@ from bumble.core import UUID
 from bumble.device import Device
 
 from bleak import BleakScanner
+from bleak.args.bluez import OrPattern, OrPatternLike
+from bleak.assigned_numbers import AdvertisementDataType
+from bleak.backends import BleakBackend, get_default_backend
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
 from bleak.uuids import normalize_uuid_str
 from tests.integration.conftest import configure_and_power_on_bumble_peripheral
 
 DEFAULT_TIMEOUT = 5.0
+
+# The default bumble peripheral advertises Flags == 0x06
+# (LE General Discoverable | BR/EDR not supported), so this pattern matches it.
+_FLAGS_NAMED_TUPLE: list[OrPatternLike] = [
+    OrPattern(0, AdvertisementDataType.FLAGS, b"\x06")
+]
+_FLAGS_PLAIN_TUPLE: list[OrPatternLike] = [(0, AdvertisementDataType.FLAGS, b"\x06")]
 
 
 async def test_discover(bumble_peripheral: Device):
@@ -111,6 +121,47 @@ async def test_adv_data_simple(bumble_peripheral: Device):
 
     # The rssi can vary. So we only check for a plausible range.
     assert -127 <= found_adv_data.rssi <= 20
+
+
+@pytest.mark.skipif(
+    get_default_backend() != BleakBackend.BLUEZ_DBUS,
+    reason="passive scanning with or_patterns is only supported on BlueZ",
+)
+@pytest.mark.parametrize(
+    "or_patterns",
+    [_FLAGS_NAMED_TUPLE, _FLAGS_PLAIN_TUPLE],
+    ids=["named_tuple", "tuple"],
+)
+async def test_passive_scan_or_patterns(
+    bumble_peripheral: Device,
+    or_patterns: list[OrPatternLike],
+):
+    """Passive scanning with ``or_patterns`` discovers the device.
+
+    Exercises the ``org.bluez.AdvertisementMonitor1`` ``Patterns`` property
+    (D-Bus signature ``a(yyay)``) end to end. Both ``OrPattern`` named tuples
+    and plain tuples must marshal over D-Bus without converting each pattern to
+    a ``list`` first.
+    """
+    await configure_and_power_on_bumble_peripheral(bumble_peripheral)
+
+    found_adv_data_future: asyncio.Future[AdvertisementData] = asyncio.Future()
+
+    def detection_callback(device: BLEDevice, adv_data: AdvertisementData):
+        if device.name == bumble_peripheral.name and not found_adv_data_future.done():
+            found_adv_data_future.set_result(adv_data)
+
+    async with BleakScanner(
+        detection_callback,
+        scanning_mode="passive",
+        bluez={"or_patterns": or_patterns},
+    ):
+        found_adv_data = await asyncio.wait_for(
+            found_adv_data_future, timeout=DEFAULT_TIMEOUT
+        )
+
+    assert found_adv_data is not None
+    assert found_adv_data.local_name == bumble_peripheral.name
 
 
 async def test_adv_data_complex(bumble_peripheral: Device):

--- a/tests/test_client_pairing_callbacks.py
+++ b/tests/test_client_pairing_callbacks.py
@@ -1,0 +1,40 @@
+"""Tests for the :class:`~bleak.BleakClient` ``pairing_callbacks`` argument."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from bleak import BleakClient
+from bleak.backends.device import BLEDevice
+
+ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+class _Confirmer:
+    """A minimal object satisfying :class:`~bleak.pairing.SupportsConfirm`."""
+
+    async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+        return True
+
+
+def _fake_backend() -> MagicMock:
+    backend = MagicMock()
+    backend.__name__ = "FakeBackend"
+    return backend
+
+
+def _client(backend: MagicMock, **kwargs: Any) -> None:
+    """Construct a ``BleakClient`` whose backend class is the given mock."""
+    BleakClient(ADDRESS, backend=backend, **kwargs)  # type: ignore[arg-type]
+
+
+def test_pairing_callbacks_forwarded_to_backend() -> None:
+    backend = _fake_backend()
+    callbacks = _Confirmer()
+    _client(backend, pairing_callbacks=callbacks, pair=True)
+    assert backend.call_args.kwargs["pairing_callbacks"] is callbacks
+
+
+def test_default_pairing_callbacks_forwarded_to_backend() -> None:
+    backend = _fake_backend()
+    _client(backend)
+    assert backend.call_args.kwargs["pairing_callbacks"] is None

--- a/tests/test_pairing.py
+++ b/tests/test_pairing.py
@@ -1,0 +1,292 @@
+"""Tests for :mod:`bleak.pairing`.
+
+Coverage is split across the ways an application may supply pairing callbacks --
+subclassing the capability protocols and defining a plain (structurally typed)
+object such as a :class:`~typing.NamedTuple` -- and across both the runtime
+behaviour of :func:`~bleak.pairing.io_capability` and the static typing of the
+protocols.
+"""
+
+from typing import NamedTuple, TypeAlias
+
+import pytest
+
+from bleak._compat import assert_never, assert_type
+from bleak.backends.device import BLEDevice
+from bleak.pairing import (
+    IOCapability,
+    PairingCallbacks,
+    SupportsConfirm,
+    SupportsDisplayPasskey,
+    SupportsRequestPasskey,
+    io_capability,
+)
+
+DEVICE = BLEDevice("AA:BB:CC:DD:EE:FF", None, None)
+
+
+class _Confirm(SupportsConfirm):
+    async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+        return True
+
+
+class _Request(SupportsRequestPasskey):
+    async def request_passkey(self, device: BLEDevice) -> int | None:
+        return 0
+
+
+class _Display(SupportsDisplayPasskey):
+    async def display_passkey(self, device: BLEDevice, passkey: int) -> None:
+        return None
+
+
+class _ConfirmRequest(_Confirm, _Request):
+    pass
+
+
+class _ConfirmDisplay(_Confirm, _Display):
+    pass
+
+
+class _RequestDisplay(_Request, _Display):
+    pass
+
+
+class _All(_Confirm, _Request, _Display):
+    pass
+
+
+class TupleConfirm(NamedTuple):
+    async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+        return True
+
+
+class TupleRequestDisplay(NamedTuple):
+    passkey: int
+
+    async def request_passkey(self, device: BLEDevice) -> int | None:
+        return self.passkey
+
+    async def display_passkey(self, device: BLEDevice, passkey: int) -> None:
+        return None
+
+
+class _DuckConfirm:
+    async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+        return True
+
+
+class _DuckRequest:
+    async def request_passkey(self, device: BLEDevice) -> int | None:
+        return 0
+
+
+class _DuckDisplay:
+    async def display_passkey(self, device: BLEDevice, passkey: int) -> None:
+        return None
+
+
+class _DuckConfirmRequest(_DuckConfirm, _DuckRequest):
+    pass
+
+
+class _DuckConfirmDisplay(_DuckConfirm, _DuckDisplay):
+    pass
+
+
+class _DuckRequestDisplay(_DuckRequest, _DuckDisplay):
+    pass
+
+
+class _DuckAll(_DuckConfirm, _DuckRequest, _DuckDisplay):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("callbacks", "expected"),
+    [
+        (None, IOCapability.NO_INPUT_NO_OUTPUT),
+        (_Confirm(), IOCapability.DISPLAY_YES_NO),
+        (_Request(), IOCapability.KEYBOARD_ONLY),
+        (_Display(), IOCapability.DISPLAY_ONLY),
+        (_ConfirmRequest(), IOCapability.KEYBOARD_DISPLAY),
+        (_ConfirmDisplay(), IOCapability.DISPLAY_YES_NO),
+        (_RequestDisplay(), IOCapability.KEYBOARD_DISPLAY),
+        (_All(), IOCapability.KEYBOARD_DISPLAY),
+    ],
+)
+def test_io_capability(
+    callbacks: PairingCallbacks | None, expected: IOCapability
+) -> None:
+    """Every combination of implemented methods maps to the documented capability."""
+    assert io_capability(callbacks) is expected
+
+
+@pytest.mark.parametrize(
+    ("callbacks", "expected"),
+    [
+        (TupleConfirm(), IOCapability.DISPLAY_YES_NO),
+        (TupleRequestDisplay(passkey=0), IOCapability.KEYBOARD_DISPLAY),
+    ],
+)
+def test_io_capability_namedtuple(
+    callbacks: PairingCallbacks, expected: IOCapability
+) -> None:
+    """A user-supplied NamedTuple is detected the same way as a protocol subclass."""
+    assert io_capability(callbacks) is expected
+
+
+@pytest.mark.parametrize(
+    ("callbacks", "expected"),
+    [
+        (_DuckConfirm(), IOCapability.DISPLAY_YES_NO),
+        (_DuckRequest(), IOCapability.KEYBOARD_ONLY),
+        (_DuckDisplay(), IOCapability.DISPLAY_ONLY),
+        (_DuckConfirmRequest(), IOCapability.KEYBOARD_DISPLAY),
+        (_DuckConfirmDisplay(), IOCapability.DISPLAY_YES_NO),
+        (_DuckRequestDisplay(), IOCapability.KEYBOARD_DISPLAY),
+        (_DuckAll(), IOCapability.KEYBOARD_DISPLAY),
+    ],
+)
+def test_io_capability_structural(
+    callbacks: PairingCallbacks, expected: IOCapability
+) -> None:
+    """A plain object that matches the protocols only structurally (it does not
+    subclass them) is detected across every non-empty combination -- a protocol
+    subclass can satisfy isinstance nominally and skip this purely structural path."""
+    assert io_capability(callbacks) is expected
+
+
+def test_isinstance_reflects_implemented_methods() -> None:
+    """The runtime-checkable protocols match on the presence of their method."""
+    assert isinstance(_Confirm(), SupportsConfirm)
+    assert not isinstance(_Confirm(), SupportsRequestPasskey)
+    assert not isinstance(_Confirm(), SupportsDisplayPasskey)
+
+    assert isinstance(_RequestDisplay(), SupportsRequestPasskey)
+    assert isinstance(_RequestDisplay(), SupportsDisplayPasskey)
+    assert not isinstance(_RequestDisplay(), SupportsConfirm)
+
+
+def test_present_but_broken_method_still_advertises() -> None:
+    """The runtime-checkable protocols match on method *presence*, not on whether
+    the method actually works -- so a present-but-broken handler still advertises
+    the capability. This is why io_capability cannot validate behaviour and the
+    docs tell implementers to omit unsupported ceremonies rather than stub them."""
+
+    class BrokenConfirm:
+        async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+            raise RuntimeError("confirm is not really implemented")
+
+    agent = BrokenConfirm()
+    assert isinstance(agent, SupportsConfirm)
+    assert io_capability(agent) is IOCapability.DISPLAY_YES_NO
+
+
+class _IncompleteConfirm(SupportsConfirm):
+    pass
+
+
+class _IncompleteRequest(SupportsRequestPasskey):
+    pass
+
+
+class _IncompleteDisplay(SupportsDisplayPasskey):
+    pass
+
+
+_IncompleteSubclass: TypeAlias = (
+    type[_IncompleteConfirm] | type[_IncompleteRequest] | type[_IncompleteDisplay]
+)
+
+
+@pytest.mark.parametrize(
+    "incomplete", [_IncompleteConfirm, _IncompleteRequest, _IncompleteDisplay]
+)
+def test_protocol_subclass_without_override_cannot_instantiate(
+    incomplete: _IncompleteSubclass,
+) -> None:
+    """Inheriting a capability protocol but not implementing its method is an error
+    at instantiation -- the protocol methods are abstract -- so a user who merely
+    inherits cannot end up with a silently broken handler."""
+    with pytest.raises(TypeError):
+        incomplete()  # type: ignore[abstract]
+
+
+async def test_callbacks_are_invocable() -> None:
+    """The implemented methods are awaitable with the documented signatures."""
+    agent = _All()
+    assert await agent.confirm(DEVICE, 123456) is True
+    assert await agent.request_passkey(DEVICE) == 0
+    await agent.display_passkey(DEVICE, 123456)
+
+
+async def test_namedtuple_implementation_with_state() -> None:
+    """A user can implement the callbacks as a NamedTuple that carries state: it is
+    detected by :func:`io_capability`, and its method behaves per that state."""
+
+    class MyPairing(NamedTuple):
+        accepted_passkey: int
+
+        async def confirm(self, device: BLEDevice, passkey: int) -> bool:
+            return passkey == self.accepted_passkey
+
+    callbacks = MyPairing(accepted_passkey=123456)
+    assert io_capability(callbacks) is IOCapability.DISPLAY_YES_NO
+    assert await callbacks.confirm(DEVICE, 123456) is True
+    assert await callbacks.confirm(DEVICE, 999999) is False
+
+
+def _opaque() -> object:
+    """Return a value statically typed as ``object`` so the ``isinstance`` narrowing
+    in :func:`test_static_typing` is a real check rather than a tautology on an
+    already-known type."""
+    return _Confirm()
+
+
+def test_static_typing() -> None:
+    """Static guarantees: the return type, and protocol narrowing via isinstance."""
+    assert_type(io_capability(None), IOCapability)
+
+    candidate = _opaque()
+    if isinstance(candidate, SupportsConfirm):
+        assert_type(candidate, SupportsConfirm)
+
+
+def test_static_assignability() -> None:
+    """Both supply mechanisms satisfy ``PairingCallbacks`` statically: every element
+    of this list is type-checked against the annotation."""
+    accepted: list[PairingCallbacks | None] = [
+        None,
+        _All(),
+        TupleConfirm(),
+        TupleRequestDisplay(passkey=0),
+    ]
+    assert len(accepted) == 4
+
+
+def _capability_name(capability: IOCapability) -> str:
+    match capability:
+        case IOCapability.NO_INPUT_NO_OUTPUT:
+            return "NoInputNoOutput"
+        case IOCapability.DISPLAY_ONLY:
+            return "DisplayOnly"
+        case IOCapability.DISPLAY_YES_NO:
+            return "DisplayYesNo"
+        case IOCapability.KEYBOARD_ONLY:
+            return "KeyboardOnly"
+        case IOCapability.KEYBOARD_DISPLAY:
+            return "KeyboardDisplay"
+        case _ as unreachable:
+            assert_never(unreachable)
+
+
+def test_capability_name() -> None:
+    """Each member maps to its specific name. (``assert_never`` in
+    :func:`_capability_name` separately proves *static* exhaustiveness, so adding a
+    member without a case is a type error.)"""
+    assert _capability_name(IOCapability.NO_INPUT_NO_OUTPUT) == "NoInputNoOutput"
+    assert _capability_name(IOCapability.DISPLAY_ONLY) == "DisplayOnly"
+    assert _capability_name(IOCapability.DISPLAY_YES_NO) == "DisplayYesNo"
+    assert _capability_name(IOCapability.KEYBOARD_ONLY) == "KeyboardOnly"
+    assert _capability_name(IOCapability.KEYBOARD_DISPLAY) == "KeyboardDisplay"

--- a/uv.lock
+++ b/uv.lock
@@ -322,7 +322,7 @@ test = [
 requires-dist = [
     { name = "async-timeout", marker = "python_full_version < '3.11'", specifier = ">=3.0.0" },
     { name = "bleak-pythonista", marker = "extra == 'pythonista'", specifier = ">=0.1.1" },
-    { name = "dbus-fast", marker = "sys_platform == 'linux'", specifier = ">=1.83.0" },
+    { name = "dbus-fast", marker = "sys_platform == 'linux'", specifier = ">=4.0.0" },
     { name = "pyobjc-core", marker = "sys_platform == 'darwin'", specifier = ">=10.3" },
     { name = "pyobjc-framework-corebluetooth", marker = "sys_platform == 'darwin'", specifier = ">=10.3" },
     { name = "pyobjc-framework-libdispatch", marker = "sys_platform == 'darwin'", specifier = ">=10.3" },


### PR DESCRIPTION
> [!WARNING]
> **LLM Disclosure**
>
> Authored by claude-opus-4-8[1m] on behalf of @JPHutchins — surfacing the completed, tested LE Secure Connections pairing implementation as a reviewable stack awaiting maintainer feedback.

**Part of the LE Secure Connections pairing feature (BlueZ + WinRT).** Full stack, in dependency order:
foundation — #1991 (dbus typed annotations) · #1992 (pairing API) · #1993 (existing-behavior tests) · #1994 (explicit kwargs) — then
`pairing-callbacks-plumbing` → `pairing-client-arg` → `pairing-bluez` → `pairing-winrt` → `pairing-example`.

### This PR
Add the public `pairing_callbacks` argument to `BleakClient`, forwarded to the backend (+ a fake-backend forwarding test).

**Clean per-change diff:** JPHutchins/bleak#9

### Why the diff looks large
A cross-fork PR can only target `develop`, so this also carries the foundation commits (cherry-picked onto the fork's `pairing-foundation` base for clear provenance) plus any earlier stack commits. Those fall away as #1991–#1994 land on `develop`. **Review the isolated change via the fork link above.**

### Status
Complete; CI green. Awaiting maintainer feedback.
