### PR TITLE
backends/bluezdbus: handle D-Bus connection loss

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,8 @@ Changed
 Fixed
 -----
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.
+* Fixed BlueZ backend not detecting loss of the D-Bus connection, which left clients reporting connected forever and disconnect callbacks never firing.
+* Fixed ``disconnect()`` raising ``EOFError`` and leaking the D-Bus connection in BlueZ backend when the message bus died.
 
 `3.0.2`_ (2026-05-02)
 =====================

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -419,12 +419,45 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
                     async with async_timeout(10):
                         await self._disconnecting_event.wait()
+            except (EOFError, OSError) as e:
+                # The D-Bus connection is dead, so the "PropertiesChanged"
+                # signal will never arrive; clean up here so the client does
+                # not report connected forever.
+                logger.debug(
+                    "D-Bus connection lost while disconnecting (%s): %r",
+                    self._device_path,
+                    e,
+                )
+                self._is_connected = False
+                self._cleanup_all()
+                # Wake any concurrent disconnect() call waiting on the event.
+                self._disconnecting_event.set()
             finally:
                 self._disconnecting_event = None
 
-            self._bus.disconnect()
-            await self._bus.wait_for_disconnect()
-            self._bus = None
+            try:
+                self._bus.disconnect()
+                # On a bus that died abnormally, wait_for_disconnect()
+                # re-raises the original socket error.
+                await self._bus.wait_for_disconnect()
+            except (EOFError, OSError) as e:
+                # Expected when the bus is already dead
+                logger.debug(
+                    "error disconnecting from bus (%s): %r", self._device_path, e
+                )
+            except Exception as e:
+                # Deliberately not re-raised: wait_for_disconnect() replays
+                # whatever error killed the reader when the bus died, which
+                # can be any type and was already handled at that time, and
+                # a raise here would leave callers unable to release a dead
+                # connection.
+                logger.warning(
+                    "unexpected error disconnecting from bus (%s): %r",
+                    self._device_path,
+                    e,
+                )
+            finally:
+                self._bus = None
 
         # sanity check to make sure _cleanup_all() was triggered by the
         # "PropertiesChanged" signal handler and that it completed successfully

--- a/bleak/backends/bluezdbus/manager.py
+++ b/bleak/backends/bluezdbus/manager.py
@@ -18,7 +18,7 @@ import contextlib
 import logging
 import os
 from collections import defaultdict
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Coroutine, Iterator
 from functools import partial
 from typing import Any, NamedTuple, Optional, cast
 
@@ -159,6 +159,17 @@ _ADVERTISING_DATA_PROPERTIES = {
 }
 
 
+def _fire_callback(callback: Callable[..., None], *args: Any) -> None:
+    """
+    Calls a callback, isolating exceptions so they do not stop the
+    remaining callbacks or propagate into the D-Bus message reader.
+    """
+    try:
+        callback(*args)
+    except Exception:
+        logger.exception("error in callback")
+
+
 def get_max_write_without_response_size(char_props: GattCharacteristic1) -> int:
     # "MTU" property was added in BlueZ 5.62, otherwise fall
     # back to minimum MTU according to Bluetooth spec.
@@ -175,6 +186,7 @@ class BlueZManager:
     def __init__(self) -> None:
         self._bus: Optional[MessageBus] = None
         self._bus_lock = asyncio.Lock()
+        self._bus_watcher_task: Optional[asyncio.Task[None]] = None
 
         # dict of object path: dict of interface name: dict of property name: property value
         self._properties: dict[str, dict[str, dict[str, Any]]] = {}
@@ -199,6 +211,25 @@ class BlueZManager:
         self._device_watchers: dict[str, set[DeviceWatcher]] = {}
         self._condition_callbacks: dict[str, set[DeviceConditionCallback]] = {}
         self._services_cache: dict[str, BleakGATTServiceCollection] = {}
+
+    def _reset_cached_state(self) -> None:
+        """Clears all state cached from the message bus."""
+        self._properties.clear()
+        self._service_map.clear()
+        self._characteristic_map.clear()
+        self._descriptor_map.clear()
+        self._services_cache.clear()
+        self._adapters.clear()
+
+    def _iter_device_props(self) -> Iterator[tuple[str, Device1]]:
+        """
+        Yields the D-Bus object path and device properties for each
+        device in BlueZ.
+        """
+        for path, interfaces in self._properties.items():
+            props = cast(Device1 | None, interfaces.get(defs.DEVICE_INTERFACE))
+            if props is not None:
+                yield path, props
 
     def _check_adapter(self, adapter_path: str) -> None:
         """
@@ -309,12 +340,9 @@ class BlueZManager:
                 )
                 assert_reply(reply)
 
-                # dictionaries are cleared in case AddInterfaces was received first
+                # state is cleared in case AddInterfaces was received first
                 # or there was a bus reset and we are reconnecting
-                self._properties.clear()
-                self._service_map.clear()
-                self._characteristic_map.clear()
-                self._descriptor_map.clear()
+                self._reset_cached_state()
 
                 for path, interfaces in reply.body[0].items():
                     props = unpack_variants(interfaces)
@@ -366,6 +394,89 @@ class BlueZManager:
 
             # Everything is setup, so save the bus
             self._bus = bus
+
+            # Watch for the bus dying (e.g. D-Bus daemon restart or a broken
+            # socket) so cached state is invalidated and device watchers are
+            # notified instead of reporting stale "Connected" state forever.
+            if self._bus_watcher_task is not None:
+                self._bus_watcher_task.cancel()
+            self._bus_watcher_task = asyncio.create_task(
+                self._monitor_bus_disconnect(bus)
+            )
+
+    async def _monitor_bus_disconnect(self, bus: MessageBus) -> None:
+        """
+        Waits for the message bus to disconnect and resets the manager state.
+        """
+        exc: Optional[Exception] = None
+        try:
+            await bus.wait_for_disconnect()
+        except Exception as e:
+            exc = e
+
+        try:
+            async with self._bus_lock:
+                if bus is not self._bus:
+                    # A newer bus was set up by async_init(); the state for
+                    # this bus was already discarded.
+                    return
+
+                logger.warning(
+                    "D-Bus connection to BlueZ was lost (%r); "
+                    "resetting state and notifying watchers",
+                    exc,
+                )
+                self._handle_bus_disconnect()
+        except Exception:
+            # This is a fire and forget task, so log instead of surfacing
+            # the error as a destroyed pending task at garbage collection.
+            logger.exception("error handling bus disconnect")
+
+    def _handle_bus_disconnect(self) -> None:
+        """
+        Resets cached state after the message bus disconnected.
+
+        This must remain fully synchronous, it is called while holding
+        the bus lock.
+        """
+        device_paths: list[str] = []
+        connected_paths: list[str] = []
+        for path, props in self._iter_device_props():
+            device_paths.append(path)
+            if props.get("Connected"):
+                connected_paths.append(path)
+
+        # Clear the cached state first so callbacks observe the updated
+        # state, the same ordering _parse_msg uses.
+        self._reset_cached_state()
+
+        # The devices did not necessarily disconnect, but without the bus
+        # there is no way to know, and reporting them disconnected makes
+        # clients clean up and reconnect, which rebuilds the bus.
+        for path in connected_paths:
+            if callbacks := self._condition_callbacks.get(path):
+                for item in callbacks.copy():
+                    if item.property_name == "Connected":
+                        _fire_callback(item.callback, False)
+
+            self._notify_connected_changed(path, False)
+
+        # Report all devices as removed so pending service discovery waits
+        # finish and scanners drop their seen devices.
+        removed_callbacks = self._device_removed_callbacks.copy()
+        for path in device_paths:
+            for callback, adapter_path in removed_callbacks:
+                if path.startswith(adapter_path):
+                    _fire_callback(callback, path)
+
+    def _notify_connected_changed(self, device_path: str, connected: bool) -> None:
+        """
+        Notifies device watchers that the "Connected" property changed.
+        """
+        if watchers := self._device_watchers.get(device_path):
+            # callbacks may remove the watcher, hence the copy
+            for watcher in watchers.copy():
+                _fire_callback(watcher.on_connected_changed, connected)
 
     def get_default_adapter(self) -> str:
         """
@@ -859,12 +970,7 @@ class BlueZManager:
         """
         result: list[tuple[str, Device1]] = []
 
-        for path, interfaces in self._properties.items():
-            props = cast(Device1 | None, interfaces.get(defs.DEVICE_INTERFACE))
-
-            if props is None:
-                continue
-
+        for path, props in self._iter_device_props():
             if props["Adapter"] != adapter_path:
                 continue
 
@@ -1198,12 +1304,9 @@ class BlueZManager:
 
                     # handle device connection change watchers
                     if "Connected" in changed:
-                        new_connected = self_interface["Connected"]
-                        watchers = self._device_watchers.get(device_path)
-                        if watchers:
-                            # callbacks may remove the watcher, hence the copy
-                            for watcher in watchers.copy():
-                                watcher.on_connected_changed(new_connected)
+                        self._notify_connected_changed(
+                            device_path, self_interface["Connected"]
+                        )
 
                 elif interface == defs.GATT_CHARACTERISTIC_INTERFACE:
                     # handle characteristic value change watchers
@@ -1257,6 +1360,14 @@ async def get_global_bluez_manager() -> BlueZManager:
         ]
         for closed_loop in closed_loops:
             manager = _global_instances.pop(closed_loop)
+            # The watcher task can never run again since its loop is
+            # closed; cancel best effort to avoid a destroyed pending
+            # task warning. Cancelling can raise RuntimeError since it
+            # schedules the wakeup on the closed loop.
+            task = manager._bus_watcher_task  # pyright: ignore[reportPrivateUsage]
+            if task is not None:
+                with contextlib.suppress(RuntimeError):
+                    task.cancel()
             if manager._bus is not None:  # pyright: ignore[reportPrivateUsage]
                 manager._bus._finalize(None)  # pyright: ignore[reportPrivateUsage]
 

--- a/tests/backends/bluezdbus/test_manager.py
+++ b/tests/backends/bluezdbus/test_manager.py
@@ -1,0 +1,483 @@
+"""Tests for the BlueZ D-Bus manager handling the message bus disconnecting."""
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    if sys.platform != "linux":
+        assert False, "This backend is only available on Linux"
+
+import asyncio
+import contextlib
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+if sys.platform != "linux":
+    pytest.skip("skipping linux-only tests", allow_module_level=True)
+
+from dbus_fast.constants import MessageType
+from dbus_fast.message import Message
+from dbus_fast.signature import Variant
+
+from bleak.backends.bluezdbus import defs
+from bleak.backends.bluezdbus import manager as manager_module
+from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
+from bleak.backends.bluezdbus.manager import BlueZManager
+from bleak.exc import BleakError
+
+ADAPTER_PATH = "/org/bluez/hci0"
+DEVICE_PATH = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF"
+SERVICE_PATH = "/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF/service0001"
+SECOND_ADAPTER_PATH = "/org/bluez/hci1"
+SECOND_DEVICE_PATH = "/org/bluez/hci1/dev_AA_BB_CC_DD_EE_00"
+HR_SERVICE_UUID = "0000180d-0000-1000-8000-00805f9b34fb"
+UNRELATED_SERVICE_UUID = "0000ffff-0000-1000-8000-00805f9b34fb"
+
+
+def build_managed_objects(
+    services_resolved: bool = True,
+    include_second_adapter: bool = False,
+) -> dict[str, dict[str, dict[str, Variant]]]:
+    managed_objects = {
+        ADAPTER_PATH: {
+            defs.ADAPTER_INTERFACE: {"Powered": Variant("b", True)},
+        },
+        DEVICE_PATH: {
+            defs.DEVICE_INTERFACE: {
+                "Connected": Variant("b", True),
+                "ServicesResolved": Variant("b", services_resolved),
+                "Adapter": Variant("o", ADAPTER_PATH),
+                "Address": Variant("s", "AA:BB:CC:DD:EE:FF"),
+                "UUIDs": Variant("as", [HR_SERVICE_UUID]),
+            },
+        },
+        SERVICE_PATH: {
+            defs.GATT_SERVICE_INTERFACE: {
+                "Device": Variant("o", DEVICE_PATH),
+                "UUID": Variant("s", HR_SERVICE_UUID),
+            },
+        },
+    }
+    if include_second_adapter:
+        managed_objects[SECOND_ADAPTER_PATH] = {
+            defs.ADAPTER_INTERFACE: {"Powered": Variant("b", True)},
+        }
+        managed_objects[SECOND_DEVICE_PATH] = {
+            defs.DEVICE_INTERFACE: {
+                "Connected": Variant("b", False),
+                "ServicesResolved": Variant("b", False),
+                "Adapter": Variant("o", SECOND_ADAPTER_PATH),
+                "Address": Variant("s", "AA:BB:CC:DD:EE:00"),
+            },
+        }
+    return managed_objects
+
+
+class FakeMessageBus:
+    """A stand-in for the dbus_fast MessageBus with a controllable lifetime."""
+
+    def __init__(self, managed_objects: dict[str, Any]) -> None:
+        self._managed_objects = managed_objects
+        self.connected = False
+        self.handler: Optional[Callable[[Message], None]] = None
+        self._disconnect_future: asyncio.Future[None] = (
+            asyncio.get_running_loop().create_future()
+        )
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    def add_message_handler(self, handler: Callable[[Message], None]) -> None:
+        self.handler = handler
+
+    async def call(self, msg: Message) -> Message:
+        if not self.connected:
+            raise EOFError
+        return Message(
+            message_type=MessageType.METHOD_RETURN,
+            reply_serial=1,
+            body=[self._managed_objects] if msg.member == "GetManagedObjects" else [],
+        )
+
+    def disconnect(self) -> None:
+        self.connected = False
+        if not self._disconnect_future.done():
+            self._disconnect_future.set_result(None)
+
+    async def wait_for_disconnect(self) -> None:
+        return await self._disconnect_future
+
+    def die(self, exc: Optional[Exception] = None) -> None:
+        """Simulate the socket dying abnormally."""
+        self.connected = False
+        if not self._disconnect_future.done():
+            self._disconnect_future.set_exception(
+                exc or EOFError("dbus daemon went away")
+            )
+
+    def _finalize(self, err: Optional[Exception]) -> None:
+        """Release resources like the real MessageBus does."""
+        self.connected = False
+
+
+class FakeMessageBusFactory:
+    """Creates FakeMessageBus instances and records them."""
+
+    def __init__(self, managed_objects: dict[str, Any]) -> None:
+        self.managed_objects = managed_objects
+        self.instances: list[FakeMessageBus] = []
+
+    def __call__(self, *args: Any, **kwargs: Any) -> FakeMessageBus:
+        bus = FakeMessageBus(self.managed_objects)
+        self.instances.append(bus)
+        return bus
+
+
+def noop_characteristic_value_changed(char_path: str, value: bytes) -> None:
+    pass
+
+
+def get_watcher_task(manager: BlueZManager) -> "asyncio.Task[None]":
+    task = manager._bus_watcher_task  # pyright: ignore[reportPrivateUsage]
+    assert task is not None
+    return task
+
+
+MakeManager = Callable[..., Awaitable[tuple[BlueZManager, FakeMessageBusFactory]]]
+
+
+@pytest.fixture
+async def make_manager(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[MakeManager]:
+    """Create initialized managers and reap their watcher tasks at teardown."""
+    managers: list[BlueZManager] = []
+
+    async def _make(
+        managed_objects: Optional[dict[str, Any]] = None,
+    ) -> tuple[BlueZManager, FakeMessageBusFactory]:
+        factory = FakeMessageBusFactory(managed_objects or build_managed_objects())
+        monkeypatch.setattr(manager_module, "MessageBus", factory)
+        manager = BlueZManager()
+        await manager.async_init()
+        managers.append(manager)
+        return manager, factory
+
+    yield _make
+
+    for manager in managers:
+        task = manager._bus_watcher_task  # pyright: ignore[reportPrivateUsage]
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+async def test_bus_death_resets_state_and_notifies_watchers(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager()
+    bus = factory.instances[0]
+
+    connected_changes: list[bool] = []
+    manager.add_device_watcher(
+        DEVICE_PATH, connected_changes.append, noop_characteristic_value_changed
+    )
+
+    assert manager.is_connected(DEVICE_PATH) is True
+
+    bus.die()
+    await get_watcher_task(manager)
+
+    assert connected_changes == [False]
+    assert manager._properties == {}  # pyright: ignore[reportPrivateUsage]
+    assert manager._services_cache == {}  # pyright: ignore[reportPrivateUsage]
+    assert manager.is_connected(DEVICE_PATH) is False
+
+
+async def test_bus_death_unblocks_pending_service_discovery(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager(
+        build_managed_objects(services_resolved=False)
+    )
+    bus = factory.instances[0]
+
+    discovery_task = asyncio.create_task(
+        manager._wait_for_services_discovery(  # pyright: ignore[reportPrivateUsage]
+            DEVICE_PATH
+        )
+    )
+    await asyncio.sleep(0)
+    assert not discovery_task.done()
+
+    bus.die()
+    await get_watcher_task(manager)
+
+    with pytest.raises(BleakError, match="device disconnected"):
+        await discovery_task
+
+
+async def test_async_init_recovers_after_bus_death(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager()
+    bus = factory.instances[0]
+
+    bus.die()
+    dead_watcher_task = get_watcher_task(manager)
+    await dead_watcher_task
+    assert manager._properties == {}  # pyright: ignore[reportPrivateUsage]
+
+    await manager.async_init()
+
+    assert len(factory.instances) == 2
+    assert manager._bus is factory.instances[1]  # pyright: ignore[reportPrivateUsage]
+    assert DEVICE_PATH in manager._properties  # pyright: ignore[reportPrivateUsage]
+    assert manager.is_connected(DEVICE_PATH) is True
+    assert get_watcher_task(manager) is not dead_watcher_task
+
+
+async def test_reinit_does_not_notify_watchers(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager()
+    bus = factory.instances[0]
+
+    connected_changes: list[bool] = []
+    manager.add_device_watcher(
+        DEVICE_PATH, connected_changes.append, noop_characteristic_value_changed
+    )
+
+    # The bus is no longer connected but the socket has not errored yet;
+    # async_init replaces it and disconnects it without firing watchers.
+    bus.connected = False
+    superseded_watcher_task = get_watcher_task(manager)
+    await manager.async_init()
+    with contextlib.suppress(asyncio.CancelledError):
+        await superseded_watcher_task
+
+    assert manager._bus is factory.instances[1]  # pyright: ignore[reportPrivateUsage]
+    assert connected_changes == []
+    assert manager.is_connected(DEVICE_PATH) is True
+
+
+async def test_bus_death_callback_exception_does_not_stop_notifications(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager(
+        build_managed_objects(include_second_adapter=True)
+    )
+    bus = factory.instances[0]
+
+    def raising_connected_changed(connected: bool) -> None:
+        raise RuntimeError("bad callback")
+
+    connected_changes: list[bool] = []
+    manager.add_device_watcher(
+        DEVICE_PATH, raising_connected_changed, noop_characteristic_value_changed
+    )
+    manager.add_device_watcher(
+        DEVICE_PATH, connected_changes.append, noop_characteristic_value_changed
+    )
+
+    removed_paths: list[str] = []
+    manager._device_removed_callbacks.append(  # pyright: ignore[reportPrivateUsage]
+        manager_module.DeviceRemovedCallbackAndState(removed_paths.append, ADAPTER_PATH)
+    )
+
+    bus.die()
+    await get_watcher_task(manager)
+
+    # The raising watcher does not prevent the other notifications, and
+    # the device on the other adapter does not match the removed callback
+    assert connected_changes == [False]
+    assert removed_paths == [DEVICE_PATH]
+    assert manager.is_connected(DEVICE_PATH) is False
+
+
+async def test_watcher_ignores_superseded_bus(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager()
+    bus = factory.instances[0]
+    watcher_task = get_watcher_task(manager)
+
+    # Simulate async_init having replaced the bus without the watcher
+    # task being cancelled yet
+    manager._bus = FakeMessageBus({})  # type: ignore[assignment] # pyright: ignore[reportPrivateUsage]
+    bus.die()
+    await watcher_task
+
+    assert manager.is_connected(DEVICE_PATH) is True
+
+
+async def test_global_manager_cleans_up_closed_loops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed_loop = asyncio.new_event_loop()
+    closed_loop.close()
+    stale_manager = MagicMock()
+    never_started_loop = asyncio.new_event_loop()
+    never_started_loop.close()
+    never_started_manager = MagicMock()
+    never_started_manager._bus_watcher_task = None
+    never_started_manager._bus = None
+    instances = manager_module._global_instances  # pyright: ignore[reportPrivateUsage]
+    instances[closed_loop] = stale_manager
+    instances[never_started_loop] = never_started_manager
+
+    factory = FakeMessageBusFactory(build_managed_objects())
+    monkeypatch.setattr(manager_module, "MessageBus", factory)
+    manager: Optional[BlueZManager] = None
+    try:
+        manager = await manager_module.get_global_bluez_manager()
+
+        assert closed_loop not in instances
+        assert never_started_loop not in instances
+        stale_manager._bus_watcher_task.cancel.assert_called_once_with()
+        stale_manager._bus._finalize.assert_called_once_with(None)
+    finally:
+        instances.pop(asyncio.get_running_loop(), None)
+        if manager is not None:
+            task = get_watcher_task(manager)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+async def test_parse_msg_connected_change_notifies_watchers(
+    make_manager: MakeManager,
+) -> None:
+    manager, factory = await make_manager()
+    bus = factory.instances[0]
+
+    connected_changes: list[bool] = []
+    manager.add_device_watcher(
+        DEVICE_PATH, connected_changes.append, noop_characteristic_value_changed
+    )
+    disconnected_wait_task = asyncio.create_task(
+        manager._wait_condition(  # pyright: ignore[reportPrivateUsage]
+            DEVICE_PATH, "Connected", False
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert bus.handler is not None
+    bus.handler(
+        Message(
+            message_type=MessageType.SIGNAL,
+            path=DEVICE_PATH,
+            interface=defs.PROPERTIES_INTERFACE,
+            member="PropertiesChanged",
+            signature="sa{sv}as",
+            body=[defs.DEVICE_INTERFACE, {"Connected": Variant("b", False)}, []],
+        )
+    )
+
+    assert connected_changes == [False]
+    assert manager.is_connected(DEVICE_PATH) is False
+    await asyncio.wait_for(disconnected_wait_task, timeout=1)
+
+
+async def test_get_connected_devices(make_manager: MakeManager) -> None:
+    manager, _ = await make_manager(build_managed_objects(include_second_adapter=True))
+
+    matches = manager.get_connected_devices(ADAPTER_PATH, frozenset({HR_SERVICE_UUID}))
+    assert [path for path, _ in matches] == [DEVICE_PATH]
+
+    no_matches = manager.get_connected_devices(
+        ADAPTER_PATH, frozenset({UNRELATED_SERVICE_UUID})
+    )
+    assert no_matches == []
+
+
+async def test_watcher_logs_unexpected_handler_error(
+    make_manager: MakeManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, factory = await make_manager()
+    bus = factory.instances[0]
+
+    def raising_handler() -> None:
+        raise RuntimeError("unexpected handler failure")
+
+    monkeypatch.setattr(manager, "_handle_bus_disconnect", raising_handler)
+    bus.die()
+
+    # The watcher task logs the error instead of raising it
+    await get_watcher_task(manager)
+
+
+async def test_global_manager_cleans_up_closed_loop_with_real_watcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A watcher task left on a closed loop must not break the accessor."""
+    factory = FakeMessageBusFactory(build_managed_objects())
+    monkeypatch.setattr(manager_module, "MessageBus", factory)
+
+    def init_manager_on_own_loop() -> tuple[BlueZManager, asyncio.AbstractEventLoop]:
+        own_loop = asyncio.new_event_loop()
+        stale_manager = BlueZManager()
+        own_loop.run_until_complete(stale_manager.async_init())
+        own_loop.close()
+        return stale_manager, own_loop
+
+    loop = asyncio.get_running_loop()
+    stale_manager, closed_loop = await loop.run_in_executor(
+        None, init_manager_on_own_loop
+    )
+    assert not get_watcher_task(stale_manager).done()
+    instances = manager_module._global_instances  # pyright: ignore[reportPrivateUsage]
+    instances[closed_loop] = stale_manager
+
+    manager: Optional[BlueZManager] = None
+    try:
+        # Must not raise even though the stale watcher task can only be
+        # cancelled through its closed loop
+        manager = await manager_module.get_global_bluez_manager()
+
+        assert closed_loop not in instances
+    finally:
+        instances.pop(loop, None)
+        if manager is not None:
+            task = get_watcher_task(manager)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+class ExplodingFakeMessageBus(FakeMessageBus):
+    """A bus whose teardown raises an unexpected error."""
+
+    def disconnect(self) -> None:
+        raise RuntimeError("unexpected teardown failure")
+
+
+async def test_client_disconnect_with_unexpected_teardown_error() -> None:
+    client = BleakClientBlueZDBus("AA:BB:CC:DD:EE:FF", bluez={}, timeout=10)
+    client._device_path = DEVICE_PATH  # pyright: ignore[reportPrivateUsage]
+    client._bus = ExplodingFakeMessageBus({})  # type: ignore[assignment] # pyright: ignore[reportPrivateUsage]
+
+    await client.disconnect()
+
+    assert client._bus is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_client_disconnect_with_dead_bus() -> None:
+    client = BleakClientBlueZDBus("AA:BB:CC:DD:EE:FF", bluez={}, timeout=10)
+    client._device_path = DEVICE_PATH  # pyright: ignore[reportPrivateUsage]
+
+    dead_bus = FakeMessageBus({})
+    dead_bus.die()
+    client._bus = dead_bus  # type: ignore[assignment] # pyright: ignore[reportPrivateUsage]
+    client._is_connected = True  # pyright: ignore[reportPrivateUsage]
+
+    await client.disconnect()
+
+    assert client._bus is None  # pyright: ignore[reportPrivateUsage]
+    assert client.is_connected is False
+    assert client.services is None


### PR DESCRIPTION
The BlueZ manager never noticed its message bus dying, for example when a D-Bus daemon or proxy restarts. Cached properties kept reporting devices as connected, device watchers never fired, and clients reported connected forever with no disconnect callback, so consumers never reconnected. This is the stall reported in Jc2k/aiohomekit#534.

async_init now arms a watcher on the bus via wait_for_disconnect. When the bus dies the manager clears its cached state, fires Connected condition callbacks and device watchers with False, and reports devices removed so pending service discovery unblocks; the next async_init rebuilds the bus exactly as before. If async_init observes the dead bus before the watcher task runs, it waits for the watcher to finish before replacing the bus, so the notification is delivered exactly once whichever side sees the loss first. BleakClientBlueZDBus.disconnect also tolerates a dead bus now, running the same teardown as a disconnect signal so the disconnected callback fires once and the bus is always released, while still raising the documented timeout if the device does not disconnect.

Devices are reported disconnected even when only a proxy in front of bluetoothd restarted and the BLE link is still up, since without the bus there is no way to tell. This makes clients clean up and reconnect, and connect() already skips the Connect call when the manager sees the device is still connected, so the reconnect is cheap in that case.

Per the guidelines: CHANGELOG.rst is updated, new unit tests cover the state reset, watcher notification, discovery unblock, recovery, reinit race, closed loop cleanup and client disconnect paths, and the branch is a single squashed commit. One known limitation, scanner sessions are not restored automatically after a bus loss, matching existing behavior.
