### PR TITLE
Fix EOFError from BleakClient.disconnect() on BlueZ backend

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 Fixed
 -----
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.
+* Fixed ``BleakClient.disconnect()`` on the BlueZ backend raising ``EOFError`` when BlueZ's "Disconnected" signal (delivered on the shared manager D-Bus connection) races the reply to the client's own "Disconnect" call and closes the client's D-Bus connection first.
 
 `3.0.2`_ (2026-05-02)
 =====================

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -420,24 +420,27 @@ class BleakClientBlueZDBus(BaseBleakClient):
                     async with async_timeout(10):
                         await self._disconnecting_event.wait()
             except EOFError:
-                # BlueZ's "Disconnected" PropertiesChanged signal arrives on
-                # the shared manager D-Bus connection and can race with the
-                # reply to the "Disconnect" call above. If it wins,
-                # on_connected_changed() has already run _cleanup_all(),
-                # which closes this client's own D-Bus connection out from
-                # under the pending call, so dbus-fast reports that as an
-                # EOFError here instead of a normal method reply. If cleanup
-                # already ran (self._bus is None), the device is genuinely
-                # disconnected, so this is not a real failure.
-                if self._bus is not None:
+                # An EOFError here means that the client's D-Bus connection
+                # was closed while the "Disconnect" method call above was
+                # still pending. This can happen when BlueZ's "Disconnected"
+                # PropertiesChanged signal is received on the shared manager
+                # D-Bus connection and wins the race with the reply to the
+                # method call, in which case the device is already
+                # disconnected and this is not a real failure. If the
+                # connection is still open, then the EOFError is unexpected
+                # and is re-raised.
+                if self._bus.connected:
                     raise
             finally:
                 self._disconnecting_event = None
 
-            if self._bus is not None:
+            # The D-Bus connection may have already been closed by the race
+            # condition above, in which case there is nothing left to do.
+            if self._bus.connected:
                 self._bus.disconnect()
                 await self._bus.wait_for_disconnect()
-                self._bus = None
+
+            self._bus = None
 
         # sanity check to make sure _cleanup_all() was triggered by the
         # "PropertiesChanged" signal handler and that it completed successfully

--- a/bleak/backends/bluezdbus/client.py
+++ b/bleak/backends/bluezdbus/client.py
@@ -419,12 +419,25 @@ class BleakClientBlueZDBus(BaseBleakClient):
 
                     async with async_timeout(10):
                         await self._disconnecting_event.wait()
+            except EOFError:
+                # BlueZ's "Disconnected" PropertiesChanged signal arrives on
+                # the shared manager D-Bus connection and can race with the
+                # reply to the "Disconnect" call above. If it wins,
+                # on_connected_changed() has already run _cleanup_all(),
+                # which closes this client's own D-Bus connection out from
+                # under the pending call, so dbus-fast reports that as an
+                # EOFError here instead of a normal method reply. If cleanup
+                # already ran (self._bus is None), the device is genuinely
+                # disconnected, so this is not a real failure.
+                if self._bus is not None:
+                    raise
             finally:
                 self._disconnecting_event = None
 
-            self._bus.disconnect()
-            await self._bus.wait_for_disconnect()
-            self._bus = None
+            if self._bus is not None:
+                self._bus.disconnect()
+                await self._bus.wait_for_disconnect()
+                self._bus = None
 
         # sanity check to make sure _cleanup_all() was triggered by the
         # "PropertiesChanged" signal handler and that it completed successfully

--- a/tests/backends/bluezdbus/test_client.py
+++ b/tests/backends/bluezdbus/test_client.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+"""Tests for `bleak.backends.bluezdbus.client` package."""
+
+import sys
+
+import pytest
+
+if sys.platform != "linux":
+    pytest.skip("skipping linux-only tests", allow_module_level=True)
+    assert False  # HACK: work around pyright bug
+
+from unittest.mock import AsyncMock, Mock
+
+from dbus_fast.aio import MessageBus
+from dbus_fast.constants import MessageType
+from dbus_fast.message import Message
+
+from bleak.backends.bluezdbus.client import BleakClientBlueZDBus
+from bleak.backends.service import BleakGATTServiceCollection
+
+DEVICE_PATH = "/org/bluez/hci0/dev_11_22_33_44_55_66"
+
+
+def make_connected_client() -> tuple[BleakClientBlueZDBus, Mock]:
+    """
+    Make a client that appears to be connected and give it a mocked D-Bus bus.
+
+    Returns the client and the mocked bus so that tests can make assertions
+    about how the bus was used.
+    """
+    bus = Mock(spec=MessageBus)
+    bus.wait_for_disconnect = AsyncMock()
+    client = BleakClientBlueZDBus("11:22:33:44:55:66", timeout=10.0, bluez={})
+    client._bus = bus  # pyright: ignore[reportPrivateUsage]
+    client._device_path = DEVICE_PATH  # pyright: ignore[reportPrivateUsage]
+    client._is_connected = True  # pyright: ignore[reportPrivateUsage]
+    client.services = BleakGATTServiceCollection()
+    return client, bus
+
+
+def simulate_disconnected_signal(client: BleakClientBlueZDBus, close_bus: bool) -> None:
+    """
+    Simulate receiving the BlueZ "Disconnected" signal.
+
+    This is what ``on_connected_changed()`` does, except that it optionally
+    also closes the client's own D-Bus connection, which is what happens
+    when the signal races a pending method call on that connection.
+    """
+    client._is_connected = False  # pyright: ignore[reportPrivateUsage]
+    client.services = None  # pyright: ignore[reportPrivateUsage]
+    if client._disconnecting_event is not None:  # pyright: ignore[reportPrivateUsage]
+        client._disconnecting_event.set()  # pyright: ignore[reportPrivateUsage]
+    if close_bus:
+        client._bus = None  # pyright: ignore[reportPrivateUsage]
+
+
+def method_return() -> Message:
+    """Makes a valid reply to a "Disconnect" method call."""
+    return Message(
+        message_type=MessageType.METHOD_RETURN,
+        serial=2,
+        reply_serial=1,
+    )
+
+
+async def test_disconnect_not_connected():
+    """Disconnecting a client that was never connected is a no-op."""
+    client, bus = make_connected_client()
+    client._bus = None  # pyright: ignore[reportPrivateUsage]
+
+    await client.disconnect()
+
+    bus.call.assert_not_called()
+    bus.disconnect.assert_not_called()
+
+
+async def test_disconnect():
+    """Disconnecting a connected client closes the client D-Bus connection."""
+    client, bus = make_connected_client()
+
+    # the "Disconnected" signal arrives after the reply to the "Disconnect"
+    # method call
+    orig_call = AsyncMock(return_value=method_return())
+
+    async def call_side_effect(msg: Message) -> Message:
+        reply = await orig_call(msg)
+        simulate_disconnected_signal(client, close_bus=False)
+        return reply
+
+    bus.call = AsyncMock(side_effect=call_side_effect)
+
+    await client.disconnect()
+
+    bus.disconnect.assert_called_once()
+    bus.wait_for_disconnect.assert_awaited_once()
+    assert client.is_connected is False
+    assert client._bus is None  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_disconnect_eoferror_when_disconnected():
+    """
+    An ``EOFError`` from the "Disconnect" method call is treated as success
+    if the client D-Bus connection was already closed.
+
+    BlueZ's "Disconnected" signal arrives on the shared manager D-Bus
+    connection and can race the reply to the client's own "Disconnect"
+    method call. If the signal wins, the client's D-Bus connection is
+    closed while the call is still pending, so dbus-fast fails the call
+    with ``EOFError`` instead of a method reply, even though the device
+    is disconnected.
+    """
+    client, bus = make_connected_client()
+
+    async def call_side_effect(msg: Message) -> Message:
+        assert msg.member == "Disconnect"
+        # the "Disconnected" signal arrives before the reply to this
+        # pending method call and the connection is closed
+        simulate_disconnected_signal(client, close_bus=True)
+        raise EOFError
+
+    bus.call = AsyncMock(side_effect=call_side_effect)
+
+    await client.disconnect()
+
+    # the bus was already closed, so it must not be closed a second time
+    bus.disconnect.assert_not_called()
+    bus.wait_for_disconnect.assert_not_awaited()
+    assert client.is_connected is False
+
+
+async def test_disconnect_already_disconnected():
+    """
+    Disconnecting a client whose device was already disconnected by the
+    peer only closes the client D-Bus connection.
+    """
+    client, bus = make_connected_client()
+    simulate_disconnected_signal(client, close_bus=False)
+
+    await client.disconnect()
+
+    bus.call.assert_not_called()
+    bus.disconnect.assert_called_once()
+    bus.wait_for_disconnect.assert_awaited_once()
+
+
+async def test_disconnect_eoferror_when_not_disconnected():
+    """An ``EOFError`` from an open connection is a real failure and is raised."""
+    client, bus = make_connected_client()
+    bus.call = AsyncMock(side_effect=EOFError)
+
+    with pytest.raises(EOFError):
+        await client.disconnect()
+
+    bus.disconnect.assert_not_called()

--- a/tests/backends/bluezdbus/test_client.py
+++ b/tests/backends/bluezdbus/test_client.py
@@ -29,7 +29,7 @@ def make_connected_client() -> tuple[BleakClientBlueZDBus, Mock]:
     Returns the client and the mocked bus so that tests can make assertions
     about how the bus was used.
     """
-    bus = Mock(spec=MessageBus)
+    bus = Mock(spec=MessageBus, connected=True)
     bus.wait_for_disconnect = AsyncMock()
     client = BleakClientBlueZDBus("11:22:33:44:55:66", timeout=10.0, bluez={})
     client._bus = bus  # pyright: ignore[reportPrivateUsage]
@@ -39,22 +39,6 @@ def make_connected_client() -> tuple[BleakClientBlueZDBus, Mock]:
     return client, bus
 
 
-def simulate_disconnected_signal(client: BleakClientBlueZDBus, close_bus: bool) -> None:
-    """
-    Simulate receiving the BlueZ "Disconnected" signal.
-
-    This is what ``on_connected_changed()`` does, except that it optionally
-    also closes the client's own D-Bus connection, which is what happens
-    when the signal races a pending method call on that connection.
-    """
-    client._is_connected = False  # pyright: ignore[reportPrivateUsage]
-    client.services = None  # pyright: ignore[reportPrivateUsage]
-    if client._disconnecting_event is not None:  # pyright: ignore[reportPrivateUsage]
-        client._disconnecting_event.set()  # pyright: ignore[reportPrivateUsage]
-    if close_bus:
-        client._bus = None  # pyright: ignore[reportPrivateUsage]
-
-
 def method_return() -> Message:
     """Makes a valid reply to a "Disconnect" method call."""
     return Message(
@@ -62,6 +46,26 @@ def method_return() -> Message:
         serial=2,
         reply_serial=1,
     )
+
+
+def simulate_disconnected_signal(
+    client: BleakClientBlueZDBus, bus: Mock, close_bus: bool = False
+) -> None:
+    """
+    Simulate receiving the BlueZ "Disconnected" signal.
+
+    This does what the ``on_connected_changed()`` callback does, plus it can
+    also close the client's own D-Bus connection, which is what happens when
+    the signal races a pending method call on that connection.
+    """
+    client._is_connected = False  # pyright: ignore[reportPrivateUsage]
+    client.services = None  # pyright: ignore[reportPrivateUsage]
+    if client._disconnecting_event is not None:  # pyright: ignore[reportPrivateUsage]
+        client._disconnecting_event.set()  # pyright: ignore[reportPrivateUsage]
+    if close_bus:
+        # like the D-Bus connection being closed while a method call is
+        # still pending, dbus-fast then raises EOFError for that call
+        bus.connected = False
 
 
 async def test_disconnect_not_connected():
@@ -85,7 +89,7 @@ async def test_disconnect():
 
     async def call_side_effect(msg: Message) -> Message:
         reply = await orig_call(msg)
-        simulate_disconnected_signal(client, close_bus=False)
+        simulate_disconnected_signal(client, bus, close_bus=False)
         return reply
 
     bus.call = AsyncMock(side_effect=call_side_effect)
@@ -98,7 +102,22 @@ async def test_disconnect():
     assert client._bus is None  # pyright: ignore[reportPrivateUsage]
 
 
-async def test_disconnect_eoferror_when_disconnected():
+async def test_disconnect_already_disconnected():
+    """
+    Disconnecting a client whose device was already disconnected by the
+    peer only closes the client D-Bus connection.
+    """
+    client, bus = make_connected_client()
+    simulate_disconnected_signal(client, bus, close_bus=False)
+
+    await client.disconnect()
+
+    bus.call.assert_not_called()
+    bus.disconnect.assert_called_once()
+    bus.wait_for_disconnect.assert_awaited_once()
+
+
+async def test_disconnect_eoferror_when_bus_disconnected():
     """
     An ``EOFError`` from the "Disconnect" method call is treated as success
     if the client D-Bus connection was already closed.
@@ -116,7 +135,7 @@ async def test_disconnect_eoferror_when_disconnected():
         assert msg.member == "Disconnect"
         # the "Disconnected" signal arrives before the reply to this
         # pending method call and the connection is closed
-        simulate_disconnected_signal(client, close_bus=True)
+        simulate_disconnected_signal(client, bus, close_bus=True)
         raise EOFError
 
     bus.call = AsyncMock(side_effect=call_side_effect)
@@ -127,24 +146,10 @@ async def test_disconnect_eoferror_when_disconnected():
     bus.disconnect.assert_not_called()
     bus.wait_for_disconnect.assert_not_awaited()
     assert client.is_connected is False
+    assert client._bus is None  # pyright: ignore[reportPrivateUsage]
 
 
-async def test_disconnect_already_disconnected():
-    """
-    Disconnecting a client whose device was already disconnected by the
-    peer only closes the client D-Bus connection.
-    """
-    client, bus = make_connected_client()
-    simulate_disconnected_signal(client, close_bus=False)
-
-    await client.disconnect()
-
-    bus.call.assert_not_called()
-    bus.disconnect.assert_called_once()
-    bus.wait_for_disconnect.assert_awaited_once()
-
-
-async def test_disconnect_eoferror_when_not_disconnected():
+async def test_disconnect_eoferror_when_bus_connected():
     """An ``EOFError`` from an open connection is a real failure and is raised."""
     client, bus = make_connected_client()
     bus.call = AsyncMock(side_effect=EOFError)


### PR DESCRIPTION
## Bug

Bleak's BlueZ client opens a dedicated D-Bus connection per BLE session (self._bus) and sends its own "Disconnect" method call on it from disconnect(), then awaits the reply. Separately, the shared global manager holds its own D-Bus connection that watches BlueZ's "Disconnected" PropertiesChanged signal and, on it, synchronously runs on_connected_changed() -> _cleanup_all(), which closes self._bus.

These two connections race: when BlueZ's "Disconnected" signal is delivered on the manager's connection before the reply to the client's own "Disconnect" call arrives on self._bus, _cleanup_all() closes self._bus out from under the pending call.

Reproduced consistently against a real BlueZ peripheral on a dbus-fast/BlueZ combination.

## Fix

Fix disconnect() to catch EOFError from the pending "Disconnect" call and treat it as a successful disconnect when self._bus is already None (i.e. _cleanup_all() has already run) . Also guard the follow-up self._bus.disconnect()/wait_for_disconnect() so it isn't called a second time when the race has already closed and cleared self._bus.

