### PR TITLE
docs: document macOS Bluetooth permissions when started by launchd

### DIFF
--- a/docs/backends/macos.rst
+++ b/docs/backends/macos.rst
@@ -77,6 +77,32 @@ This is only possible via the macOS system settings. To create a nice user exper
 can catch the :class:`BleakBluetoothNotAvailableError` and guide the user to ``System Settings → Privacy & Security → 
 Bluetooth``.
 
+.. _cb-launchd:
+
+Running without a foreground application (launchd, daemons)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+macOS decides whether to show the Bluetooth permission prompt based on the
+process that is responsible for the request. A script started from a
+terminal is covered by the terminal application's permission. A process
+started by ``launchd`` (a LaunchAgent or LaunchDaemon), by cron, or by any
+other supervisor has no responsible application. The system cannot show a
+prompt in that case and Bluetooth access is denied outright: bleak raises
+:class:`BleakBluetoothNotAvailableError` with reason
+``BleakBluetoothNotAvailableReason.DENIED_BY_USER``, even though the same
+interpreter works fine when run from a terminal, and nothing appears in the
+*Bluetooth* privacy list because there was never an application to list.
+
+To give the system something it can grant, run the interpreter from a
+minimal application bundle. The bundle needs an ``Info.plist`` with a
+stable ``CFBundleIdentifier`` and the ``NSBluetoothAlwaysUsageDescription``
+key, and the executable must live inside ``Contents/MacOS``. An ad hoc
+signature is sufficient (``codesign --sign - --force --deep MyService.app``).
+Start the bundled executable from the LaunchAgent instead of the bare
+interpreter. The first launch in a logged-in session shows the normal prompt
+and the grant persists. Because the grant is tied to the code signature and
+path, rebuilding or moving the bundle may prompt again.
+
 .. _cb-notification-discriminator:
 
 Notifications

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -173,6 +173,11 @@ It is not a problem with Bleak. It is a problem with your application. The appli
 It is also possible to manually add the app to the list of Bluetooth apps in
 the *Privacy* settings in the macOS *System Preferences*.
 
+If the program is started by ``launchd`` or another supervisor rather than
+from a terminal, there is no application for macOS to prompt for, and
+Bluetooth is denied without any entry in the privacy list. See
+:ref:`cb-launchd` for how to run such a process from an application bundle.
+
 .. image:: images/macos-privacy-bluetooth.png
 
 If the app is already in the list but the checkbox for Bluetooth is disabled,


### PR DESCRIPTION
## What

Adds a subsection to the CoreBluetooth backend permissions docs (`docs/backends/macos.rst`) and a pointer in the troubleshooting guide covering the case where a bleak program is started by `launchd` (LaunchAgent or LaunchDaemon) or another supervisor instead of from a terminal.

## Why

On macOS the Bluetooth permission prompt is attributed to the responsible application. A script run from a terminal is covered by the terminal's grant, but a process started by launchd has no responsible application, so the system cannot prompt and denies access outright. bleak then raises `BleakBluetoothNotAvailableError` with `BleakBluetoothNotAvailableReason.DENIED_BY_USER`, and nothing shows up in the Bluetooth privacy list because there was never an application to list. The existing docs cover bundled apps (briefcase) and the crash case, but not this one, and it is a common way to run a BLE service on a Mac.

Verified on macOS 26.6.1 with the current bleak release:

- the same interpreter scans normally from a terminal and is denied as a gui domain LaunchAgent;
- placed inside a minimal `.app` bundle with `CFBundleIdentifier` and `NSBluetoothAlwaysUsageDescription`, ad hoc signed, the same LaunchAgent scans normally.

## Checklist

- Docs only, no code changes.
- Built with `sphinx-build -W` (warnings as errors), no warnings.
- No changelog entry, matching the other docs-only commits on `develop`. Happy to add one if preferred.
