### PR TITLE
backends/winrt: use try_call_soon_threadsafe() in event handlers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changed
 Fixed
 -----
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.
+* Fixed crash in WinRT backend if a WinRT event handler is called after the asyncio event loop is closed.
 
 `3.0.2`_ (2026-05-02)
 =====================

--- a/bleak/backends/winrt/client.py
+++ b/bleak/backends/winrt/client.py
@@ -61,6 +61,7 @@ from bleak._compat import timeout as async_timeout
 from bleak.args import SizedBuffer
 from bleak.args.winrt import WinRTClientArgs as _WinRTClientArgs
 from bleak.assigned_numbers import gatt_char_props_to_strs
+from bleak.backends._utils import try_call_soon_threadsafe
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.client import BaseBleakClient, NotifyCallback
 from bleak.backends.descriptor import BleakGATTDescriptor
@@ -249,7 +250,7 @@ class BleakClientWinRT(BaseBleakClient):
 
         def services_changed_handler(sender: BluetoothLEDevice, args: Object) -> None:
             logger.debug("%s: services changed", self.address)
-            loop.call_soon_threadsafe(handle_services_changed)
+            try_call_soon_threadsafe(loop, handle_services_changed)
 
         self._services_changed_token = self._requester.add_gatt_services_changed(
             services_changed_handler
@@ -315,7 +316,7 @@ class BleakClientWinRT(BaseBleakClient):
                 args.error,
                 args.status,
             )
-            loop.call_soon_threadsafe(handle_session_status_changed, args)
+            try_call_soon_threadsafe(loop, handle_session_status_changed, args)
 
         def max_pdu_size_changed_handler(sender: GattSession, args: Object) -> None:
             try:
@@ -1025,7 +1026,7 @@ class BleakClientWinRT(BaseBleakClient):
             sender: GattCharacteristic, args: GattValueChangedEventArgs
         ) -> None:
             value = bytearray(args.characteristic_value)
-            loop.call_soon_threadsafe(callback, value)
+            try_call_soon_threadsafe(loop, callback, value)
 
         event_handler_token = winrt_char.add_value_changed(handle_value_changed)
         self._notification_callbacks[characteristic.handle] = event_handler_token
@@ -1107,7 +1108,7 @@ class FutureLike(Generic[T]):
                 # have to get result on this thread, otherwise it may not return correct value
                 self._result = op.get_results()
 
-            self._loop.call_soon_threadsafe(call_callbacks)
+            try_call_soon_threadsafe(self._loop, call_callbacks)
 
         op.completed = call_callbacks_threadsafe
 

--- a/bleak/backends/winrt/scanner.py
+++ b/bleak/backends/winrt/scanner.py
@@ -24,6 +24,7 @@ from winrt.windows.foundation import EventRegistrationToken
 
 from bleak._compat import override
 from bleak.assigned_numbers import AdvertisementDataType
+from bleak.backends._utils import try_call_soon_threadsafe
 from bleak.backends.scanner import (
     AdvertisementData,
     AdvertisementDataCallback,
@@ -283,7 +284,7 @@ class BleakScannerWinRT(BaseBleakScanner):
             sender: BluetoothLEAdvertisementWatcher,
             args: BluetoothLEAdvertisementReceivedEventArgs,
         ) -> None:
-            event_loop.call_soon_threadsafe(self._received_handler, sender, args)
+            try_call_soon_threadsafe(event_loop, self._received_handler, sender, args)
 
         self._received_token = self.watcher.add_received(on_received)
 
@@ -291,7 +292,7 @@ class BleakScannerWinRT(BaseBleakScanner):
             sender: BluetoothLEAdvertisementWatcher,
             args: BluetoothLEAdvertisementWatcherStoppedEventArgs,
         ) -> None:
-            event_loop.call_soon_threadsafe(self._stopped_handler, sender, args)
+            try_call_soon_threadsafe(event_loop, self._stopped_handler, sender, args)
 
         self._stopped_token = self.watcher.add_stopped(on_stopped)
 


### PR DESCRIPTION
WinRT event handlers run on a thread pool thread and hand off to the asyncio loop with `call_soon_threadsafe()` without checking that the loop is still open. One landing after the loop is closed raises `RuntimeError('Event loop is closed')` on a non-Python thread where nothing can catch it, so it surfaces as an unraisable exception at shutdown (under pytest, a `PytestUnraisableExceptionWarning`). The usual trigger is disconnect at teardown: `handle_disconnect()` removes the session-status token, but a callback already in flight races the loop shutdown and loses.

Same failure #1855 fixed for CoreBluetooth, so this applies the existing `try_call_soon_threadsafe()` helper to all six cross-thread hops in `client.py` and `scanner.py`.

Related: #1278, the same traceback from 2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y2188WRhSN8xiHTeKNDmoV
