### PR TITLE
Keep deprecated adapter arguments from mutating BlueZ defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Changed
 
 Fixed
 -----
+* Fixed deprecated ``adapter`` keyword argument mutating shared defaults and caller-provided ``bluez`` arguments in ``BleakScanner`` and ``BleakClient``. Fixes #2028.
 * Fixed handling empty notification payloads in BlueZ backend when using "AcquireNotify". Fixes #1982.
 
 `3.0.2`_ (2026-05-02)

--- a/bleak/__init__.py
+++ b/bleak/__init__.py
@@ -139,8 +139,7 @@ class BleakScanner:
                 stacklevel=2,
             )
 
-            if "adapter" not in bluez:
-                bluez["adapter"] = adapter_kwarg
+            bluez = {"adapter": adapter_kwarg, **bluez}
 
         self._backend = PlatformBleakScanner(
             detection_callback,
@@ -645,8 +644,7 @@ class BleakClient:
                 stacklevel=2,
             )
 
-            if "adapter" not in bluez:
-                bluez["adapter"] = adapter_kwarg
+            bluez = {"adapter": adapter_kwarg, **bluez}
 
         self._backend = PlatformBleakClient(
             address_or_ble_device,

--- a/tests/test_adapter_deprecation.py
+++ b/tests/test_adapter_deprecation.py
@@ -1,6 +1,65 @@
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import Mock
+
 import pytest
 
 from bleak import BleakClient, BleakScanner
+
+
+@pytest.fixture(params=["scanner", "client"])
+def backend_bluez_args(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> Callable[..., dict[str, Any]]:
+    backend = Mock()
+    monkeypatch.setattr(
+        f"bleak.get_platform_{request.param}_backend_type",
+        lambda: (backend, "test"),
+    )
+
+    def create(**kwargs: Any) -> dict[str, Any]:
+        if request.param == "scanner":
+            BleakScanner(**kwargs)
+        else:
+            BleakClient("00:11:22:33:44:55", **kwargs)
+        return backend.call_args.kwargs["bluez"]
+
+    return create
+
+
+def test_adapter_kwarg_does_not_change_defaults(
+    backend_bluez_args: Callable[..., dict[str, Any]],
+):
+    with pytest.deprecated_call(match="the 'adapter' keyword argument is deprecated"):
+        first = backend_bluez_args(adapter="hci1")
+    with pytest.deprecated_call(match="the 'adapter' keyword argument is deprecated"):
+        second = backend_bluez_args(adapter="hci2")
+
+    assert first == {"adapter": "hci1"}
+    assert second == {"adapter": "hci2"}
+    assert backend_bluez_args() == {}
+
+
+def test_adapter_kwarg_does_not_change_caller_bluez_args(
+    backend_bluez_args: Callable[..., dict[str, Any]],
+):
+    bluez: dict[str, str] = {}
+    with pytest.deprecated_call(match="the 'adapter' keyword argument is deprecated"):
+        actual = backend_bluez_args(adapter="hci1", bluez=bluez)
+
+    assert actual == {"adapter": "hci1"}
+    assert bluez == {}
+
+
+def test_explicit_bluez_adapter_takes_precedence(
+    backend_bluez_args: Callable[..., dict[str, Any]],
+):
+    bluez = {"adapter": "hci2"}
+    with pytest.deprecated_call(match="the 'adapter' keyword argument is deprecated"):
+        actual = backend_bluez_args(adapter="hci1", bluez=bluez)
+
+    assert actual == {"adapter": "hci2"}
+    assert bluez == {"adapter": "hci2"}
 
 
 async def test_adapter_kwarg_deprecated_in_scanner():


### PR DESCRIPTION
Fixes #2028.

The deprecated `adapter=` shim currently writes into the shared `bluez={}` default in both `BleakScanner` and `BleakClient`. After one instance requests `hci1`, later instances can inherit that adapter or ignore a new `adapter=` value. The same assignment also changes a caller-provided BlueZ dictionary.

Build a new dictionary when applying the deprecated argument, following the approach endorsed in #2028. An explicit `bluez["adapter"]` retains precedence. Add parameterized regression tests for both constructors and the required changelog entry. The tests replace backend constructors, so they do not need Bluetooth hardware or an event loop.

Validation:

- Before the fix: four mutation regression cases failed; two precedence cases passed.
- The six new cases pass on Windows CPython 3.10 and 3.14 with pytest 8.4.2 and warnings treated as errors.
- Complete adapter-deprecation test file on Python 3.12: 8 passed.
- Full Windows Python 3.12 suite: 19 passed, 103 skipped (hardware-dependent integration and other-platform tests).
- isort, Black, flake8, mypy (92 source files), Pyright, Sphinx with warnings treated as errors, and sdist/wheel builds passed.

The remaining full Python-version and OS matrix, including Linux BlueZ integration with real or virtual controllers, still needs CI. The tests here verify argument isolation before backend construction and do not exercise Bluetooth hardware.

AI assistance: OpenAI Codex helped investigate the issue, implement the maintainer-endorsed approach, write regression tests, run checks, and prepare this description.

### CI coverage follow-up

All 20 build/test jobs and the format/lint check passed. Codecov reports 100% coverage for the two modified coverable lines; `bleak/__init__.py` coverage increased from 80.64% to 81.39%.

The project check reports 52.95% against a 53.00% baseline. Its entire decrease comes from unchanged `bleak/backends/bluezdbus/manager.py`: line 1115 changed from fully to partially covered, and lines 1116–1117 changed from covered to uncovered. These lines handle an adapter `InterfacesRemoved` signal; the baseline Python 3.10 BlueZ integration run covered this cleanup path, while the current run did not. No coverage threshold or unrelated tests were changed.

The branch already includes current `develop`. Codecov's one-commit-behind warning refers to its coverage baseline: the intervening commit only changes `.readthedocs.yml` and does not trigger the build/test workflow. [Full Codecov comparison](https://app.codecov.io/gh/hbldh/bleak/pull/2029).
